### PR TITLE
issue #97 - add iterateAssignees() to RtRepoITCase.java

### DIFF
--- a/src/test/java/com/jcabi/github/RtRepoITCase.java
+++ b/src/test/java/com/jcabi/github/RtRepoITCase.java
@@ -39,8 +39,6 @@ import org.junit.Test;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
- * @todo #16 Add test iterateAssignees() to check that
- *  assignees actually fetched.
  *  See http://developer.github.com/v3/issues/assignees/
  */
 public final class RtRepoITCase {
@@ -72,15 +70,15 @@ public final class RtRepoITCase {
     }
 
     /**
-     * RtRepo can fetch assignees
+     * RtRepo can fetch assignees.
      * @throws Exception If some problem inside
      */
     @Test
     public void iterateAssignees() throws Exception {
         final Repo repo = RtRepoITCase.repo();
         MatcherAssert.assertThat(
-          repo.assignees().iterate(),
-          Matchers.not(Matchers.emptyIterable())
+            repo.assignees().iterate(),
+            Matchers.not(Matchers.emptyIterable())
         );
     }
 


### PR DESCRIPTION
re-based into separate branches, argh -- would've been nice to know this up-front
NOTE: you'll need to take branch 100 to get a clean -Pqulice for 97 and 99
