### PR TITLE
Issue #262 RtRepos is able to remove a repository

### DIFF
--- a/src/main/java/com/jcabi/github/Repos.java
+++ b/src/main/java/com/jcabi/github/Repos.java
@@ -74,4 +74,12 @@ public interface Repos {
     Repo get(@NotNull(message = "coordinates can't be NULL")
         Coordinates coords);
 
+    /**
+     * Remove repository by name.
+     * @param coords Repository name in "user/repo" format
+     * @throws IOException If there is any I/O problem
+     * @see <a href="http://developer.github.com/v3/repos/#delete-a-repository">Delete a Repository</a>
+     */
+    void remove(@NotNull(message = "coordinates can't be NULL")
+        Coordinates coords) throws IOException;
 }

--- a/src/main/java/com/jcabi/github/RtRepos.java
+++ b/src/main/java/com/jcabi/github/RtRepos.java
@@ -111,4 +111,15 @@ final class RtRepos implements Repos {
         final Coordinates name) {
         return new RtRepo(this.ghub, this.entry, name);
     }
+
+    @Override
+    public void remove(
+        @NotNull(message = "coordinates can't be NULL")
+        final Coordinates coords) throws IOException {
+        this.request.method(Request.DELETE)
+            .uri().path(coords.toString()).back()
+            .fetch()
+            .as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_NO_CONTENT);
+    }
 }

--- a/src/main/java/com/jcabi/github/mock/MkRepos.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepos.java
@@ -38,6 +38,7 @@ import com.jcabi.github.Repos;
 import com.jcabi.log.Logger;
 import java.io.IOException;
 import javax.json.JsonObject;
+import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.xembly.Directives;
@@ -49,6 +50,7 @@ import org.xembly.Directives;
  * @version $Id$
  * @since 0.5
  * @checkstyle MultipleStringLiterals (500 lines)
+ * @todo #262 Implement method MkRepos.remove() to remove particular repository.
  */
 @Immutable
 @Loggable(Loggable.DEBUG)
@@ -116,6 +118,13 @@ final class MkRepos implements Repos {
             throw new IllegalStateException(ex);
         }
         return new MkRepo(this.storage, this.self, coords);
+    }
+
+    @Override
+    public void remove(
+        @NotNull(message = "coordinates can't be NULL")
+        final Coordinates coords) {
+        throw new UnsupportedOperationException("MkRepos#remove");
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtReposTest.java
+++ b/src/test/java/com/jcabi/github/RtReposTest.java
@@ -33,6 +33,7 @@ import com.rexsl.test.Request;
 import com.rexsl.test.mock.MkAnswer;
 import com.rexsl.test.mock.MkContainer;
 import com.rexsl.test.mock.MkGrizzlyContainer;
+import com.rexsl.test.mock.MkQuery;
 import com.rexsl.test.request.ApacheRequest;
 import java.net.HttpURLConnection;
 import javax.json.Json;
@@ -82,6 +83,35 @@ public final class RtReposTest {
             Matchers.equalTo((Coordinates) new Coordinates.Simple(owner, name))
         );
         container.stop();
+    }
+
+    /**
+     * RtRepos can remove a repo.
+     * @throws Exception if some problem inside
+     */
+    @Test
+    public void removeRepo() throws Exception {
+        final MkContainer container = new MkGrizzlyContainer().next(
+            new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
+        ).start();
+        final Repos repos = new RtRepos(
+            Mockito.mock(Github.class),
+            new ApacheRequest(container.home())
+        );
+        repos.remove(new Coordinates.Simple("", ""));
+        try {
+            final MkQuery query = container.take();
+            MatcherAssert.assertThat(
+                query.method(),
+                Matchers.equalTo(Request.DELETE)
+            );
+            MatcherAssert.assertThat(
+                query.body(),
+                Matchers.isEmptyString()
+            );
+        } finally {
+            container.stop();
+        }
     }
 
     /**


### PR DESCRIPTION
No need to create puzzle for integration tests on remove repository as it is in the scope of puzzle on Repo creation
