### PR TITLE
Issue 290. MkPublicKey.patch() method implemented.

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkPublicKey.java
+++ b/src/main/java/com/jcabi/github/mock/MkPublicKey.java
@@ -84,7 +84,7 @@ final class MkPublicKey implements PublicKey {
 
     @Override
     public void patch(final JsonObject json) throws IOException {
-        throw new UnsupportedOperationException("Patch not yet implemented.");
+        new JsonPatch(this.storage).patch(this.xpath(), json);
     }
 
     @Override

--- a/src/test/java/com/jcabi/github/mock/MkPublicKeyTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPublicKeyTest.java
@@ -29,10 +29,12 @@
  */
 package com.jcabi.github.mock;
 
+import com.jcabi.github.PublicKey;
+import javax.json.Json;
 import javax.json.JsonObject;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -44,12 +46,16 @@ import org.junit.Test;
 public final class MkPublicKeyTest {
 
     /**
-     * MkHooks can be represented as JSON.
+     * Json name of key.
+     */
+    public static final String KEY = "key";
+
+    /**
+     * MkPublicKey can be represented as JSON.
      *
      * @throws Exception If a problem occurs.
      */
     @Test
-    @Ignore
     public void canRetrieveAsJson() throws Exception {
         final String title = "Title1";
         final String key = "PublicKey1";
@@ -64,22 +70,30 @@ public final class MkPublicKeyTest {
             Matchers.equalTo(title)
         );
         MatcherAssert.assertThat(
-            json.getString("key"),
+            json.getString(KEY),
             Matchers.equalTo(key)
         );
     }
 
     /**
-     * MkHooks can accept a PATCH request.
+     * MkPublicKey can accept a PATCH request.
      *
      * @throws Exception If a problem occurs.
-     * @todo #24 Implement the patch() method of MkPublicKey. Implement this
-     *  unit test method and remove the Ignore annotation when done.
      */
     @Test
-    @Ignore
     public void canBePatched() throws Exception {
-        //To be implemented.
+        final String title = RandomStringUtils.random(10);
+        final String original = RandomStringUtils.random(10);
+        final PublicKey key = new MkGithub().users().get("jeff")
+            .keys().create(title, original);
+        final String patch = String.format("%s_patch", original);
+        key.patch(
+            Json.createObjectBuilder().add(KEY, patch).build()
+        );
+        MatcherAssert.assertThat(
+            key.json().getString(KEY),
+            Matchers.equalTo(patch)
+        );
     }
 
 }


### PR DESCRIPTION
In this pull request I want you to review and merge to 'master' following changes:
1. MkPublicKey.patch() method implemented
2. MkPublicKeyTest.canBePatched() test implemented and ignore annotation removed.
3. MkPublicKeyTest.canRetrieveAsJson ignore annotation removed(sorry but I forgot it in my previous task)
4. Some Java-docs changes in MkPublicKeyTest.
