### PR TITLE
Issue #346 Fixed bug where MkDeployKeys XML nodes were not being written

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkDeployKey.java
+++ b/src/main/java/com/jcabi/github/mock/MkDeployKey.java
@@ -102,9 +102,8 @@ public final class MkDeployKey implements DeployKey {
      */
     private String xpath() {
         return String.format(
-            "/repos/%s/%s/deployKeys/deployKey[id=%d]",
-            this.owner.coordinates().user(),
-            this.owner.coordinates().repo(),
+            "/github/repos/repo[@coords='%s']/deploykeys/deploykey[id='%d']",
+            this.owner.coordinates(),
             this.key
         );
     }

--- a/src/main/java/com/jcabi/github/mock/MkDeployKeys.java
+++ b/src/main/java/com/jcabi/github/mock/MkDeployKeys.java
@@ -74,12 +74,18 @@ public final class MkDeployKeys implements DeployKeys {
      * @param stg Storage
      * @param login User to login
      * @param rep Repo
+     * @throws IOException If there is any I/O problem
      */
     MkDeployKeys(final MkStorage stg, final String login,
-        final Coordinates rep) {
+        final Coordinates rep) throws IOException {
         this.storage = stg;
         this.self = login;
         this.coords = rep;
+        this.storage.apply(
+            new Directives().xpath(
+                String.format("/github/repos/repo[@coords='%s']", this.coords)
+            ).addIf("deploykeys")
+        );
     }
 
     @Override
@@ -104,11 +110,11 @@ public final class MkDeployKeys implements DeployKeys {
         final int number;
         try {
             number = 1 + this.storage.xml().xpath(
-                String.format("%s/deployKey/id/text()", this.xpath())
+                String.format("%s/deploykey/id/text()", this.xpath())
             ).size();
             this.storage.apply(
                 new Directives().xpath(this.xpath())
-                    .add("deployKey")
+                    .add("deploykey")
                     .add("id").set(String.valueOf(number)).up()
                     .add("title").set(title).up()
                     .add("key").set(key)
@@ -125,7 +131,8 @@ public final class MkDeployKeys implements DeployKeys {
      */
     private String xpath() {
         return String.format(
-            "/repos/%s/%s/deployKeys", this.coords.user(), this.coords.repo()
+            "/github/repos/repo[@coords='%s']/deploykeys",
+            this.coords
         );
     }
 

--- a/src/main/java/com/jcabi/github/mock/MkRepo.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepo.java
@@ -189,7 +189,11 @@ final class MkRepo implements Repo {
 
     @Override
     public DeployKeys keys() {
-        return new MkDeployKeys(this.storage, this.self, this.coords);
+        try {
+            return new MkDeployKeys(this.storage, this.self, this.coords);
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     @Override

--- a/src/test/java/com/jcabi/github/mock/MkDeployKeysTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkDeployKeysTest.java
@@ -80,6 +80,44 @@ public final class MkDeployKeysTest {
     }
 
     /**
+     * MkDeployKeys can create distinct deploy keys.
+     * Reproduces bug described in issue #346.
+     * @throws Exception If some problem inside.
+     */
+    @Test
+    public void canCreateDistinctDeployKeys() throws Exception {
+        final DeployKeys keys = MkDeployKeysTest.repo().keys();
+        final DeployKey first = keys.create("Title2", "Key2");
+        final DeployKey second = keys.create("Title3", "Key3");
+        MatcherAssert.assertThat(
+            first,
+            Matchers.not(Matchers.is(second))
+        );
+        MatcherAssert.assertThat(
+            first.number(),
+            Matchers.not(Matchers.is(second.number()))
+        );
+    }
+
+    /**
+     * MkDeployKeys can be represented in JSON format.
+     * Reproduces bug described in issue #346.
+     * @throws Exception If some problem inside.
+     */
+    @Test
+    public void canRepresentAsJson() throws Exception {
+        final DeployKeys keys = MkDeployKeysTest.repo().keys();
+        final DeployKey first = keys.create("Title4", "Key4");
+        MatcherAssert.assertThat(
+            first.json().toString(),
+            Matchers.allOf(
+                Matchers.containsString("\"title\":\"Title4\""),
+                Matchers.containsString("\"key\":\"Key4\"")
+            )
+        );
+    }
+
+    /**
      * Create a repo to work with.
      * @return Repo
      * @throws Exception If some problem inside


### PR DESCRIPTION
There were a few things that were incorrect. Fixes done are:
1. Adding the `<deploykeys/>` node if not present (`addIf` call in `MkDeployKeys` constructor).
2. Fixing the XPath strings to look for the `coords` _attribute_ instead of _XML nodes_.
3. Converted XML node names and XPath strings to all-lowercase (`deployKeys` to deploykeys`). 

As for 3. above, Xembly converts them to lowercase when generating directives. This means I can create a node by using `add("deployKeys")` and the resulting XML will be `<deploykeys/>`. However, I can't retrieve the same node when I reference `deployKeys` in XPath (e.g. when you call `xml().nodes("/deployKeys")`. This seems like a bug either in Jcabi-XML or Xembly; I think it's the latter because as far as I know XML node names are case sensitive.

 @yegor256 what do you think about the XML behavior? I can create an issue in either Xembly or Jcabi-XML depending on where you think it's a valid bug.
