### PR TITLE
Issue #282 Gist Comment test implementation.

### DIFF
--- a/src/main/java/com/jcabi/github/Release.java
+++ b/src/main/java/com/jcabi/github/Release.java
@@ -59,6 +59,19 @@ public interface Release extends JsonReadable, JsonPatchable {
     int number();
 
     /**
+     * Todo: i wonder if that requires a new type of return object, ReleaseAsset
+     *
+     * Upload a release asset.
+     * @param name New name of release.
+     * @param contenttype New content type of release.
+     * @param body New body of release.
+     * @return Uploaded release.
+     * @throws IOException if has some problems with response parsing.
+     */
+    Release uploadAsset(String name, String contenttype, byte[] body)
+        throws IOException;
+
+    /**
      * Deletes a release.
      * @throws IOException If any I/O problems occur.
      */
@@ -104,6 +117,12 @@ public interface Release extends JsonReadable, JsonPatchable {
         @Override
         public int number() {
             return this.release.number();
+        }
+
+        @Override
+        public Release uploadAsset(final String name, final String contenttype,
+            final byte[] body) throws IOException {
+            return this.release.uploadAsset(name, contenttype, body);
         }
 
         /**

--- a/src/main/java/com/jcabi/github/mock/MkRelease.java
+++ b/src/main/java/com/jcabi/github/mock/MkRelease.java
@@ -83,6 +83,12 @@ public final class MkRelease implements Release {
     }
 
     @Override
+    public Release uploadAsset(final String name, final String contenttype,
+        final byte[] body) throws IOException {
+        return this;
+    }
+
+    @Override
     public JsonObject json() throws IOException {
         return new JsonNode(
             this.storage.xml().nodes(this.xpath()).get(0)

--- a/src/test/java/com/jcabi/github/RtReleaseTest.java
+++ b/src/test/java/com/jcabi/github/RtReleaseTest.java
@@ -34,6 +34,8 @@ import com.jcabi.http.mock.MkAnswer;
 import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.request.ApacheRequest;
+import com.jcabi.http.request.JdkRequest;
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
@@ -57,14 +59,15 @@ public class RtReleaseTest {
      * A test mnemo.
      */
     private static final String TEST_MNEMO = "tstuser/tstbranch";
+    public static final String NAME_STRING = "name";
 
     /**
      * RtRelease can edit a release.
      * @todo #180 RtRelease should be able to edit a release. Let's implement
-     *  this method, add integration test, declare a method in Release and
-     *  implement it. See
-     *  http://developer.github.com/v3/repos/releases/#edit-a-release. When
-     *  done, remove this puzzle and Ignore annotation from this method.
+     * this method, add integration test, declare a method in Release and
+     * implement it. See
+     * http://developer.github.com/v3/repos/releases/#edit-a-release. When
+     * done, remove this puzzle and Ignore annotation from this method.
      */
     @Test
     @Ignore
@@ -98,10 +101,10 @@ public class RtReleaseTest {
      * RtRelease can list assets for a release.
      * @checkstyle LineLength (4 lines)
      * @todo #180 RtRelease should be able to list assets for a release. Let's
-     *  implement this method, add integration test, declare a method in
-     *  Release and implement it. See
-     *  http://developer.github.com/v3/repos/releases/#list-assets-for-a-release.
-     *  When done, remove this puzzle and Ignore annotation from this method.
+     * implement this method, add integration test, declare a method in
+     * Release and implement it. See
+     * http://developer.github.com/v3/repos/releases/#list-assets-for-a-release.
+     * When done, remove this puzzle and Ignore annotation from this method.
      */
     @Test
     @Ignore
@@ -110,27 +113,59 @@ public class RtReleaseTest {
     }
 
     /**
-     * RtRelease can upload a release asset.
-     * @todo #180 RtRelease should be able to upload a release asset. Let's
-     *  implement this method, add integration test, declare a method in
-     *  Release and implement it. See
-     *  http://developer.github.com/v3/repos/releases/#upload-a-release-asset.
-     *  When done, remove this puzzle and Ignore annotation from this method.
+     * RtRelease can uploadAsset a release asset.
+     * @throws IOException if has some problems with json parsing.
      */
     @Test
-    @Ignore
-    public void uploadReleaseAsset() {
-        // to be implemented
+    public final void uploadReleaseAsset() throws IOException {
+        final int identifier = 1;
+        final String idString = "id";
+        final String name = "foo.zip";
+        final MkAnswer first = new MkAnswer.Simple(
+            HttpURLConnection.HTTP_CREATED,
+            Json.createObjectBuilder()
+                .add(idString, identifier)
+                .add(NAME_STRING, name)
+                .build().toString()
+        );
+        final MkAnswer second = new MkAnswer.Simple(
+            HttpURLConnection.HTTP_OK,
+            Json.createObjectBuilder()
+                .add(idString, identifier)
+                .add(NAME_STRING, name)
+                .build().toString()
+        );
+        final MkAnswer third = new MkAnswer.Simple(
+            HttpURLConnection.HTTP_OK,
+            Json.createObjectBuilder()
+                .add(idString, identifier)
+                .add(NAME_STRING, name)
+                .build().toString()
+        );
+        final MkContainer container =
+            new MkGrizzlyContainer().next(first).next(second).next(third)
+                .start();
+        final Release release = new RtRelease(new JdkRequest(container.home())
+            , new Coordinates.Simple("testuser", "testrepo"), identifier);
+        release.uploadAsset(name, "application/zip", "".getBytes());
+        MatcherAssert.assertThat(
+            release.json().getInt(idString),
+            Matchers.equalTo(identifier)
+        );
+        MatcherAssert.assertThat(
+            release.json().getString(NAME_STRING),
+            Matchers.equalTo(name)
+        );
     }
 
     /**
      * RtRelease can get a single release asset.
      * @checkstyle LineLength (4 lines)
      * @todo #180 RtRelease should be able to get a single release asset. Let's
-     *  implement this method, add integration test, declare a method in
-     *  Release and implement it. See
-     *  http://developer.github.com/v3/repos/releases/#get-a-single-release-asset.
-     *  When done, remove this puzzle and Ignore annotation from this method.
+     * implement this method, add integration test, declare a method in
+     * Release and implement it. See
+     * http://developer.github.com/v3/repos/releases/#get-a-single-release-asset.
+     * When done, remove this puzzle and Ignore annotation from this method.
      */
     @Test
     @Ignore
@@ -151,7 +186,7 @@ public class RtReleaseTest {
             new ApacheRequest(container.home()),
             new Coordinates.Simple(TEST_MNEMO), 2
         );
-        release.patch(Json.createObjectBuilder().add("name", "v1")
+        release.patch(Json.createObjectBuilder().add(NAME_STRING, "v1")
             .build()
         );
         MatcherAssert.assertThat(


### PR DESCRIPTION
Hello, 

PLEASE DO NOT MERGE THIS! 
It is rather an approach-offer. 

A) Sorry for delaying this. 
B) Unfortunately this task went a bit too complicated for my understnanding of PDD and current architecture. 

So, the issues which are there: 
1. Think we need an object for an Asset abstraction, which we don't have now. 
2. Thus, need to make all the necessary adjustments to accomodate for it (mock, etc). 
3. Bigger issue. What I see now is that `Request` object bearing base url migrates from object to object. This leads me to the idea the lib may be used not only with github.com but also with the hosted githubs. Now, the issue comes in: the rest of the calls are api calls, and are issued towards single well-defined URL (base one). For the upload-assert call, even Github uses different upload endpoint. How do we handle this? http://developer.github.com/v3/repos/releases/#upload-a-release-asset

I know this is quite huge, and sorry for delaying it. I will discuss technical issues with Yegor. 

Alex. 
