### PR TITLE
remove ignore from RT hooks test, now that test is working. Tests perfor...

### DIFF
--- a/src/test/java/com/jcabi/github/RtHooksITCase.java
+++ b/src/test/java/com/jcabi/github/RtHooksITCase.java
@@ -36,7 +36,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -44,9 +43,6 @@ import org.junit.Test;
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @since 0.8
- * @todo #551 RtHooksITCase methods are disabled since they don't work
- *  with real Github account. Let's fix them all and remove their
- *  Ignore annotations.
  */
 public final class RtHooksITCase {
 
@@ -55,7 +51,6 @@ public final class RtHooksITCase {
      * @throws Exception If some problem inside
      */
     @Test
-    @Ignore
     public void canFetchAllHooks() throws Exception {
         final Repos repos = RtHooksITCase.repos();
         final Repo repo = RtHooksITCase.repo(repos);
@@ -74,7 +69,6 @@ public final class RtHooksITCase {
      * @throws Exception If some problem inside
      */
     @Test
-    @Ignore
     public void canCreateAHook() throws Exception {
         final Repos repos = RtHooksITCase.repos();
         final Repo repo = RtHooksITCase.repo(repos);
@@ -93,7 +87,6 @@ public final class RtHooksITCase {
      * @throws Exception If some problem inside.
      */
     @Test
-    @Ignore
     public void canFetchSingleHook() throws Exception {
         final Repos repos = RtHooksITCase.repos();
         final Repo repo = RtHooksITCase.repo(repos);
@@ -114,7 +107,6 @@ public final class RtHooksITCase {
      * @throws Exception If something goes wrong.
      */
     @Test
-    @Ignore
     public void canRemoveHook() throws Exception {
         final Repos repos = RtHooksITCase.repos();
         final Repo repo = RtHooksITCase.repo(repos);


### PR DESCRIPTION
This pull request is for puzzle 551-2759c576 ==> "RtHooksITCase methods are disabled since they don't work  with real Github account. Let's fix them all and remove their Ignore annotations"
I just removed @Ignore tags and performed tests with my personal github account. Tests were sucessfull
