### PR TITLE
Issue 645. Gists.create doesn't allow specifying visibility bug fixed.

### DIFF
--- a/src/main/java/com/jcabi/github/Gists.java
+++ b/src/main/java/com/jcabi/github/Gists.java
@@ -56,13 +56,14 @@ public interface Gists {
      * Create a new gist.
      *
      * @param files Names and content of files
+     * @param visible Indicates whether the gist is public
      * @return Gist
      * @throws IOException If there is any I/O problem
      * @see <a href="http://developer.github.com/v3/gists/#create-a-gist">Create a Gist</a>
      */
     @NotNull(message = "gist is never NULL")
     Gist create(@NotNull(message = "list of files can't be NULL")
-        Map<String, String> files) throws IOException;
+        Map<String, String> files, boolean visible) throws IOException;
 
     /**
      * Get gist by name.

--- a/src/main/java/com/jcabi/github/RtGists.java
+++ b/src/main/java/com/jcabi/github/RtGists.java
@@ -98,7 +98,8 @@ final class RtGists implements Gists {
     @Override
     @NotNull(message = "Gist can't be NULL")
     public Gist create(@NotNull(message = "list of files can't be NULL")
-        final Map<String, String> files) throws IOException {
+        final Map<String, String> files, final boolean visible
+    ) throws IOException {
         JsonObjectBuilder builder = Json.createObjectBuilder();
         for (final Map.Entry<String, String> file : files.entrySet()) {
             builder = builder.add(
@@ -108,6 +109,7 @@ final class RtGists implements Gists {
         }
         final JsonStructure json = Json.createObjectBuilder()
             .add("files", builder)
+            .add("public", visible)
             .build();
         return this.get(
             this.request.method(Request.POST)

--- a/src/main/java/com/jcabi/github/mock/MkGists.java
+++ b/src/main/java/com/jcabi/github/mock/MkGists.java
@@ -92,7 +92,7 @@ final class MkGists implements Gists {
     @NotNull(message = "created gist is never NULL")
     public Gist create(
         @NotNull(message = "map of files can't be NULL")
-        final Map<String, String> files
+        final Map<String, String> files, final boolean visible
     ) throws IOException {
         this.storage.lock();
         final String number;
@@ -105,6 +105,7 @@ final class MkGists implements Gists {
             final Directives dirs = new Directives().xpath(this.xpath())
                 .add("gist")
                 .add("id").set(number).up()
+                .add("public").set(String.valueOf(visible)).up()
                 .add("files");
             for (final Map.Entry<String, String> file : files.entrySet()) {
                 dirs.add("file")

--- a/src/test/java/com/jcabi/github/RtGistCommentITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentITCase.java
@@ -138,6 +138,8 @@ public final class RtGistCommentITCase {
         Assume.assumeThat(key, Matchers.notNullValue());
         return new RtGithub(key)
             .gists()
-            .create(Collections.singletonMap("file.txt", "file content"));
+            .create(
+                Collections.singletonMap("file.txt", "file content"), false
+            );
     }
 }

--- a/src/test/java/com/jcabi/github/RtGistCommentsITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentsITCase.java
@@ -104,6 +104,8 @@ public final class RtGistCommentsITCase {
         Assume.assumeThat(key, Matchers.notNullValue());
         return new RtGithub(key)
             .gists()
-            .create(Collections.singletonMap("file.txt",  "file content"));
+            .create(
+                Collections.singletonMap("file.txt",  "file content"), false
+            );
     }
 }

--- a/src/test/java/com/jcabi/github/RtGistITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistITCase.java
@@ -58,7 +58,7 @@ public final class RtGistITCase {
         Gist.Smart smart = null;
         try {
             final Gist gist = gists.create(
-                Collections.singletonMap(filename, content)
+                Collections.singletonMap(filename, content), false
             );
             smart = new Gist.Smart(gist);
             final String file = smart.files().iterator().next();
@@ -88,7 +88,7 @@ public final class RtGistITCase {
         final Gists gists2 = RtGistITCase.github("failsafe.github.key.second")
             .gists();
         final Gist gist = gists1.get(
-            gists2.create(Collections.singletonMap(filename, content))
+            gists2.create(Collections.singletonMap(filename, content), false)
                 .identifier()
         );
         final Gist forked = gist.fork();

--- a/src/test/java/com/jcabi/github/RtGistsITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistsITCase.java
@@ -56,7 +56,7 @@ public final class RtGistsITCase {
         final String content = "content of file";
         final Gists gists = RtGistsITCase.gists();
         final Gist gist = gists.create(
-            Collections.singletonMap(filename, content)
+            Collections.singletonMap(filename, content), false
         );
         final Gist.Smart smart = new Gist.Smart(gist);
         MatcherAssert.assertThat(
@@ -74,7 +74,7 @@ public final class RtGistsITCase {
     public void iterateGists() throws Exception {
         final Gists gists = RtGistsITCase.gists();
         final Gist gist = gists.create(
-            Collections.singletonMap("test.txt", "content")
+            Collections.singletonMap("test.txt", "content"), false
         );
         MatcherAssert.assertThat(
             gists.iterate(),
@@ -91,7 +91,7 @@ public final class RtGistsITCase {
         final String filename = "single-name.txt";
         final Gists gists = RtGistsITCase.gists();
         final Gist gist = gists.create(
-            Collections.singletonMap(filename, "body")
+            Collections.singletonMap(filename, "body"), false
         );
         MatcherAssert.assertThat(
             gists.get(gist.identifier()).identifier(),
@@ -107,7 +107,8 @@ public final class RtGistsITCase {
     public void removesGistByName() throws Exception {
         final Gists gists = RtGistsITCase.gists();
         final Gist gist = gists.create(
-            Collections.singletonMap("fileName.txt", "content of test file")
+            Collections.singletonMap("fileName.txt", "content of test file"),
+            false
         );
         MatcherAssert.assertThat(
             gists.iterate(),

--- a/src/test/java/com/jcabi/github/RtGistsTest.java
+++ b/src/test/java/com/jcabi/github/RtGistsTest.java
@@ -69,7 +69,7 @@ public final class RtGistsTest {
         );
         try {
             MatcherAssert.assertThat(
-                gists.create(Collections.singletonMap("test", "")),
+                gists.create(Collections.singletonMap("test", ""), false),
                 Matchers.notNullValue()
             );
             MatcherAssert.assertThat(

--- a/src/test/java/com/jcabi/github/mock/MkGistTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkGistTest.java
@@ -51,7 +51,7 @@ public final class MkGistTest {
         // @checkstyle MultipleStringLiterals (1 lines)
         final String filename = "file.txt";
         final Gist gist = new MkGithub().gists().create(
-            Collections.singletonMap(filename, "")
+            Collections.singletonMap(filename, ""), false
         );
         MatcherAssert.assertThat(
             gist.read(filename),
@@ -67,7 +67,7 @@ public final class MkGistTest {
     public void fork() throws IOException {
         final String filename = "file.txt";
         final Gist gist = new MkGithub().gists().create(
-            Collections.singletonMap(filename, "")
+            Collections.singletonMap(filename, ""), false
         );
         gist.write(filename, "Hello, github!");
         final Gist forkedGist = gist.fork();

--- a/src/test/java/com/jcabi/github/mock/MkGistsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkGistsTest.java
@@ -52,7 +52,7 @@ public final class MkGistsTest {
     @Test
     public void worksWithMockedGists() throws Exception {
         final Gist gist = new MkGithub().gists().create(
-            Collections.singletonMap("test-file-name.txt", "none")
+            Collections.singletonMap("test-file-name.txt", "none"), false
         );
         final String file = "t.txt";
         gist.write(file, "hello, everybody!");
@@ -70,7 +70,7 @@ public final class MkGistsTest {
     public void removesGistByIdentifier() throws Exception {
         final Gists gists = new MkGithub().gists();
         final Gist gist = gists.create(
-            Collections.singletonMap("fileName.txt", "content")
+            Collections.singletonMap("fileName.txt", "content"), false
         );
         MatcherAssert.assertThat(
             gists.iterate(),
@@ -91,10 +91,10 @@ public final class MkGistsTest {
     public void worksWithSeveralGists() throws Exception {
         final Gists gists = new MkGithub().gists();
         final Gist gist = gists.create(
-            Collections.singletonMap("test-file-name.txt", "none")
+            Collections.singletonMap("test-file-name.txt", "none"), false
         );
         final Gist othergist = gists.create(
-            Collections.singletonMap("test-file-name2.txt", "")
+            Collections.singletonMap("test-file-name2.txt", ""), false
         );
         final String file = "t.txt";
         gist.write(file, "hello, everybody!");
@@ -116,7 +116,7 @@ public final class MkGistsTest {
     @Test
     public void testStar() throws Exception {
         final Gist gist = new MkGithub().gists().create(
-            Collections.singletonMap("file-name.txt", "")
+            Collections.singletonMap("file-name.txt", ""), false
         );
         MatcherAssert.assertThat(
             gist.starred(),
@@ -136,7 +136,7 @@ public final class MkGistsTest {
     @Test
     public void testUnstar() throws Exception {
         final Gist gist = new MkGithub().gists().create(
-            Collections.singletonMap("file-name.txt", "")
+            Collections.singletonMap("file-name.txt", ""), false
         );
         MatcherAssert.assertThat(
             gist.starred(),
@@ -162,7 +162,7 @@ public final class MkGistsTest {
     public void createGistWithEmptyFile() throws IOException {
         final String filename = "file.txt";
         final Gist gist = new MkGithub().gists().create(
-            Collections.singletonMap(filename, "")
+            Collections.singletonMap(filename, ""), false
         );
         MatcherAssert.assertThat(
             gist.read(filename),


### PR DESCRIPTION
I've added 'visible' parameter to `Gists.create` and implementation in mock and real classes implemented `Gists`. I didn't know which value should be set in different usages of this method, so I kept all clients behavior as it was i.e. set visible=false(according to documentation this parameter is `false` by default). I think that developers of issues that were blocked by this now have possibility to set this parameter as they needed. 
Documentation: http://developer.github.com/v3/gists/#create-a-gist
