### PR TITLE
Issue 661 - Fix checkNullabilityTest

### DIFF
--- a/src/test/java/com/jcabi/github/NullabilityTest.java
+++ b/src/test/java/com/jcabi/github/NullabilityTest.java
@@ -108,8 +108,9 @@ public final class NullabilityTest {
             new Predicate<Integer>() {
                 @Override
                 public boolean apply(final Integer index) {
-                    return method.getParameterTypes()[index].isPrimitive()
-                        || (!method.getParameterTypes()[index].isPrimitive()
+                    final boolean primitive = method.getParameterTypes()[index]
+                        .isPrimitive();
+                    return primitive || (!primitive
                         && Collections2.transform(
                             // @checkstyle LineLength (2 lines)
                             Arrays.asList(method.getParameterAnnotations()[index]),


### PR DESCRIPTION
Fixed original IndexOutOfBounds exception. Couldn't remove the Ignore annotation since there are around 35 methods that are missing the NotNull annotation for the return value and/or the input arguments, so I created a new puzzle.
