### PR TITLE
#760 Fixes for JDK 6 build

### DIFF
--- a/src/it/basic-usage/pom.xml
+++ b/src/it/basic-usage/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.jcabi</groupId>
         <artifactId>parent</artifactId>
-        <version>0.13.1</version>
+        <version>0.19.1</version>
     </parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi-github-test</artifactId>

--- a/src/test/java/com/jcabi/github/IssueLabelsTest.java
+++ b/src/test/java/com/jcabi/github/IssueLabelsTest.java
@@ -65,7 +65,7 @@ public final class IssueLabelsTest {
             new IssueLabels.Smart(labels).findByColor("c0c0c0"),
             Matchers.allOf(
                 Matchers.<Label>iterableWithSize(1),
-                Matchers.hasItem(first)
+                Matchers.hasItems(first)
             )
         );
     }

--- a/src/test/java/com/jcabi/github/mock/MkUserEmailsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkUserEmailsTest.java
@@ -61,7 +61,7 @@ public final class MkUserEmailsTest {
             added,
             Matchers.allOf(
                 Matchers.<String>iterableWithSize(1),
-                Matchers.contains(email)
+                Matchers.hasItems(email)
             )
         );
     }
@@ -86,8 +86,8 @@ public final class MkUserEmailsTest {
             emails.iterate(),
             Matchers.allOf(
                 Matchers.<String>iterableWithSize(1),
-                Matchers.contains(retained),
-                Matchers.not(Matchers.contains(removed))
+                Matchers.hasItems(retained),
+                Matchers.not(Matchers.hasItems(removed))
             )
         );
     }
@@ -109,7 +109,7 @@ public final class MkUserEmailsTest {
             emails.iterate(),
             Matchers.allOf(
                 Matchers.<String>iterableWithSize(2),
-                Matchers.containsInAnyOrder(added)
+                Matchers.hasItems(added)
             )
         );
     }


### PR DESCRIPTION
Two issues addressed here:
1. Some of Hamcrest's generics fail on JDK 6 but not on the more precise compiler of JDK 7. In particular, JDK 6 gets confused with the return type of `Matchers.contains()`, which is `Matcher<? extends T>` in conjunction with `Matchers.allOf(Matcher<? super T>)`. `Matchers.hasItems()` returns `Matcher<T>` which works in JDK 6. I converted it where it didn't change the meaning of the test.
2. In the maven invoker, an older reference of `jcabi-aspects` failed because of https://github.com/jcabi/jcabi-aspects/issues/21. I updated jcabi parent to suit.

Unfortunately we can't do much to test against the first scenario happening again in the future, except to watch for pull requests where JDK 6 doesn't want to compile the unit tests on Travis.
