### PR TITLE
Make RtContents.get work with branches

### DIFF
--- a/src/main/java/com/jcabi/github/RtContents.java
+++ b/src/main/java/com/jcabi/github/RtContents.java
@@ -171,15 +171,10 @@ final class RtContents implements Contents {
         @NotNull(message = "ref can't be NULL") final String ref
     )
         throws IOException {
-        final JsonStructure json = Json.createObjectBuilder()
-            .add("path", path)
-            .add("ref", ref)
-            .build();
         return new RtContent(
-            this.entry, this.owner,
+            this.entry.uri().queryParam("ref", ref).back(), this.owner,
             this.request.method(Request.GET)
-                .uri().path(path).back()
-                .body().set(json).back()
+                .uri().path(path).queryParam("ref", ref).back()
                 .fetch()
                 .as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)

--- a/src/test/java/com/jcabi/github/RtContentsTest.java
+++ b/src/test/java/com/jcabi/github/RtContentsTest.java
@@ -160,12 +160,12 @@ public final class RtContentsTest {
         );
         try {
             final Content.Smart smart = new Content.Smart(
-                contents.get(path, "master")
+                contents.get(path, "branch1")
             );
             final MkQuery query = container.take();
             MatcherAssert.assertThat(
                 query.uri().toString(),
-                Matchers.endsWith("/repos/test/contents/contents/test/file")
+                Matchers.endsWith("/repos/test/contents/contents/test/file?ref=branch1")
             );
             MatcherAssert.assertThat(
                 smart.path(),
@@ -181,7 +181,7 @@ public final class RtContentsTest {
             );
             MatcherAssert.assertThat(
                 container.take().uri().toString(),
-                Matchers.endsWith("/repos/test/contents/contents/test/file")
+                Matchers.endsWith("/repos/test/contents/contents/test/file?ref=branch1")
             );
         } finally {
             container.stop();


### PR DESCRIPTION
Hi,

I've noticed that `Contents.get` method always returns content from master branch ignoring what I'm passing as second parameter. The reason is that for GET requests the json body is not passed, any additional parameters shall be included into url as query parameters.

Here is the fix for that.

Thanks.
