### PR TITLE
Issue-765 MkPublicKeyTest.canBePatched() fixed.

### DIFF
--- a/src/test/java/com/jcabi/github/mock/MkPublicKeyTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPublicKeyTest.java
@@ -32,7 +32,6 @@ package com.jcabi.github.mock;
 import com.jcabi.github.PublicKey;
 import javax.json.Json;
 import javax.json.JsonObject;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -82,17 +81,16 @@ public final class MkPublicKeyTest {
      */
     @Test
     public void canBePatched() throws Exception {
-        final String title = RandomStringUtils.random(10);
-        final String original = RandomStringUtils.random(10);
+        final String original = "PublicKey2";
         final PublicKey key = new MkGithub().users().get("jeff")
-            .keys().create(title, original);
-        final String patch = String.format("%s_patch", original);
+            .keys().create("Title2", original);
+        final String patched = String.format("%s_patch", original);
         key.patch(
-            Json.createObjectBuilder().add(KEY, patch).build()
+            Json.createObjectBuilder().add(KEY, patched).build()
         );
         MatcherAssert.assertThat(
             key.json().getString(KEY),
-            Matchers.equalTo(patch)
+            Matchers.equalTo(patched)
         );
     }
 


### PR DESCRIPTION
- Key value and title hard-coded instead of random generation that was cause of test's instability.
