### PR TITLE
#726: Explicit "master" ref instead of default when creating content

### DIFF
--- a/src/test/java/com/jcabi/github/RtContentsITCase.java
+++ b/src/test/java/com/jcabi/github/RtContentsITCase.java
@@ -46,6 +46,7 @@ import org.junit.Test;
  * @since 0.8
  * @checkstyle MultipleStringLiterals (300 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RtContentsITCase {
 
     /**


### PR DESCRIPTION
I haven't been able to reproduce the bug in #726, but noticed that `RtContentsITCase` creates on the default ref, which is usually but _not necessarily_ `master`. The `canUpdateFileContent()` test, however, _explicitly_ specifies that `master` be used. It's possible for the file to be created in one ref and updated in another, which will cause the test to fail.
