### PR TITLE
Fix apidoc link

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@ public class Main {
   }
 }
 </pre></div>
-<p>Read <a href="./apidocs-0.8.1/com/jcabi/github/index.html">JavaDoc</a> for more information and examples.</p>
+<p>Read <a href="./apidocs-0.8.1/index.html">JavaDoc</a> for more information and examples.</p>
 <p>There are <a class="externalLink" href="http://developer.github.com/libraries/">a few other Java adapters</a> of Github API, but our implementation has its advantages, including:</p>
 
 <ul>


### PR DESCRIPTION
The current link in the index page is pointing to the wrong location, this fixes that link.
