### PR TITLE
Add RetryCarefulWire

### DIFF
--- a/src/main/java/com/jcabi/github/wire/RetryCarefulWire.java
+++ b/src/main/java/com/jcabi/github/wire/RetryCarefulWire.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github.wire;
+
+import com.jcabi.aspects.Immutable;
+import com.jcabi.http.Request;
+import com.jcabi.http.Response;
+import com.jcabi.http.Wire;
+import com.jcabi.http.wire.RetryWire;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * Wire that waits if the number of remaining requests per hour is less than
+ * a given threshold, and in the event of {@link IOException} retries a few
+ * times before giving up and rethrowing the exception.
+ *
+ * <p>Just a wrapper for a {@link com.jcabi.http.wire.RetryWire} that wraps a
+ * {@link com.jcabi.github.wire.CarefulWire} that wraps the underlying wire.
+ *
+ * <p>You can use {@code RetryCarefulWire} with a
+ * {@link com.jcabi.github.Github} object:
+ * <pre>
+ * {@code
+ * Github github = new RtGithub(
+ *     new RtGithub().entry().through(RetryCarefulWire.class, 50)
+ * );
+ * }
+ * </pre>
+ *
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.23
+ */
+@Immutable
+@ToString
+@EqualsAndHashCode(of = { "real" })
+public final class RetryCarefulWire implements Wire {
+    /**
+     * RetryWire which we're merely wrapping.
+     */
+    private final transient Wire real;
+
+    /**
+     * Public ctor.
+     *
+     * @param wire Original wire
+     * @param threshold Threshold of number of remaining requests, below which
+     *  requests are blocked until reset
+     */
+    public RetryCarefulWire(@NotNull(message = "wire can't be NULL")
+        final Wire wire, final int threshold) {
+        this.real = new RetryWire(new CarefulWire(wire, threshold));
+    }
+
+    /**
+     * {@inheritDoc}
+     * @checkstyle ParameterNumber (6 lines)
+     */
+    @Override
+    @NotNull(message = "response can't be NULL")
+    public Response send(
+        @NotNull(message = "req can't be NULL") final Request req,
+        @NotNull(message = "home can't be NULL") final String home,
+        @NotNull(message = "method can't be NULL")final String method,
+        @NotNull(message = "headers can't be NULL")
+        final Collection<Map.Entry<String, String>> headers,
+        @NotNull(message = "content can't be NULL")
+        final InputStream content
+    ) throws IOException {
+        return this.real.send(req, home, method, headers, content);
+    }
+}

--- a/src/test/java/com/jcabi/github/wire/CarefulWireTest.java
+++ b/src/test/java/com/jcabi/github/wire/CarefulWireTest.java
@@ -44,6 +44,14 @@ import org.junit.Test;
  * @version $Id$
  */
 public final class CarefulWireTest {
+    /**
+     * HTTP 200 status reason.
+     */
+    private static final String OK = "OK";
+    /**
+     * Name of GitHub's number-of-requests-remaining rate limit header.
+     */
+    private static final String REMAINING_HEADER = "X-RateLimit-Remaining";
 
     /**
      * CarefulWire can wait until the limit reset.
@@ -57,13 +65,52 @@ public final class CarefulWireTest {
             .toSeconds(System.currentTimeMillis()) + 5L;
         new FakeRequest()
             .withStatus(HttpURLConnection.HTTP_OK)
-            .withReason("OK")
-            .withHeader("X-RateLimit-Remaining", "9")
+            .withReason(OK)
+            .withHeader(REMAINING_HEADER, "9")
             .withHeader("X-RateLimit-Reset", String.valueOf(reset))
             .through(CarefulWire.class, threshold)
             .fetch();
         final long now = TimeUnit.MILLISECONDS
             .toSeconds(System.currentTimeMillis());
         MatcherAssert.assertThat(now, Matchers.greaterThanOrEqualTo(reset));
+    }
+
+    /**
+     * CarefulWire can tolerate the lack the X-RateLimit-Remaining header.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void tolerateMissingRateLimitRemainingHeader() throws IOException {
+        final int threshold = 10;
+        // @checkstyle MagicNumber (1 lines)
+        new FakeRequest()
+            .withStatus(HttpURLConnection.HTTP_OK)
+            .withReason(OK)
+            .through(CarefulWire.class, threshold)
+            .fetch();
+        MatcherAssert.assertThat(
+            "Did not crash when X-RateLimit-Remaining header was absent",
+            true
+        );
+    }
+
+    /**
+     * CarefulWire can tolerate the lack the X-RateLimit-Reset header.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void tolerateMissingRateLimitResetHeader() throws IOException {
+        final int threshold = 8;
+        // @checkstyle MagicNumber (1 lines)
+        new FakeRequest()
+            .withStatus(HttpURLConnection.HTTP_OK)
+            .withReason(OK)
+            .withHeader(REMAINING_HEADER, "7")
+            .through(CarefulWire.class, threshold)
+            .fetch();
+        MatcherAssert.assertThat(
+            "Did not crash when X-RateLimit-Reset header was absent",
+            true
+        );
     }
 }

--- a/src/test/java/com/jcabi/github/wire/RetryCarefulWireTest.java
+++ b/src/test/java/com/jcabi/github/wire/RetryCarefulWireTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github.wire;
+
+import com.jcabi.http.mock.MkAnswer;
+import com.jcabi.http.mock.MkContainer;
+import com.jcabi.http.mock.MkGrizzlyContainer;
+import com.jcabi.http.request.FakeRequest;
+import com.jcabi.http.request.JdkRequest;
+import com.jcabi.http.response.RestResponse;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RetryCarefulWire}.
+ * Just combines the RetryWire and CarefulWire test cases.
+ * @version $Id$
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @author Yegor Bugayenko (yegor@tpc2.com)
+ * @author Alexander Sinyagin (sinyagin.alexander@gmail.com)
+ */
+public final class RetryCarefulWireTest {
+    /**
+     * HTTP 200 status reason.
+     */
+    private static final String OK = "OK";
+    /**
+     * Name of GitHub's number-of-requests-remaining rate limit header.
+     */
+    private static final String REMAINING_HEADER = "X-RateLimit-Remaining";
+
+    /**
+     * RetryCarefulWire can make a few requests before giving up and
+     * can wait until the rate limit resets.
+     * @throws Exception If something goes wrong inside
+     */
+    @Test
+    public void makesMultipleRequestsAndWaitUntilReset() throws Exception {
+        final int threshold = 10;
+        // @checkstyle MagicNumber (2 lines)
+        final long reset = TimeUnit.MILLISECONDS
+            .toSeconds(System.currentTimeMillis()) + 5L;
+        final MkContainer container = new MkGrizzlyContainer()
+            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_INTERNAL_ERROR))
+            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_INTERNAL_ERROR))
+            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK)
+                .withHeader(REMAINING_HEADER, "9")
+                .withHeader("X-RateLimit-Reset", String.valueOf(reset))
+            )
+            .start();
+        new JdkRequest(container.home())
+            .through(RetryCarefulWire.class, threshold)
+            .fetch()
+            .as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK);
+        final long now = TimeUnit.MILLISECONDS
+            .toSeconds(System.currentTimeMillis());
+        MatcherAssert.assertThat(now, Matchers.greaterThanOrEqualTo(reset));
+        container.stop();
+    }
+
+    /**
+     * RetryCarefulWire can tolerate the lack the X-RateLimit-Remaining header.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void tolerateMissingRateLimitRemainingHeader() throws IOException {
+        final int threshold = 11;
+        // @checkstyle MagicNumber (1 lines)
+        new FakeRequest()
+            .withStatus(HttpURLConnection.HTTP_OK)
+            .withReason(OK)
+            .through(RetryCarefulWire.class, threshold)
+            .fetch();
+        MatcherAssert.assertThat(
+            "Did not crash when X-RateLimit-Remaining header was absent",
+            true
+        );
+    }
+
+    /**
+     * RetryCarefulWire can tolerate the lack the X-RateLimit-Reset header.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void tolerateMissingRateLimitResetHeader() throws IOException {
+        final int threshold = 8;
+        // @checkstyle MagicNumber (1 lines)
+        new FakeRequest()
+            .withStatus(HttpURLConnection.HTTP_OK)
+            .withReason(OK)
+            .withHeader(REMAINING_HEADER, "7")
+            .through(RetryCarefulWire.class, threshold)
+            .fetch();
+        MatcherAssert.assertThat(
+            "Did not crash when X-RateLimit-Reset header was absent",
+            true
+        );
+    }
+}


### PR DESCRIPTION
This adds `RetryCarefulWire`, which both honors the GitHub API's rate limit and retries requests in the event of transient I/O errors.