### PR TITLE
Add possibility to merge pull requests with SHA

### DIFF
--- a/src/main/java/com/jcabi/github/MergeState.java
+++ b/src/main/java/com/jcabi/github/MergeState.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ * <p/>
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ * <p/>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+public enum MergeState {
+    /**
+     * If the Pull Request was successfully merged
+     */
+    SUCCESS,
+    /**
+     * If the Pull Request wasn't mergeable
+     */
+    NOT_MERGEABLE,
+    /**
+     * If the current Pull Request head doesn't match the specified SHA
+     */
+    BAD_HEAD
+}

--- a/src/main/java/com/jcabi/github/MergeState.java
+++ b/src/main/java/com/jcabi/github/MergeState.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2013-2015, jcabi.com
  * All rights reserved.
- * <p/>
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met: 1) Redistributions of source code must retain the above
@@ -13,7 +13,7 @@
  * the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written
  * permission.
- * <p/>
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
  * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
@@ -31,15 +31,15 @@ package com.jcabi.github;
 
 public enum MergeState {
     /**
-     * If the Pull Request was successfully merged
+     * If the Pull Request was successfully merged.
      */
     SUCCESS,
     /**
-     * If the Pull Request wasn't mergeable
+     * If the Pull Request wasn't mergeable.
      */
     NOT_MERGEABLE,
     /**
-     * If the current Pull Request head doesn't match the specified SHA
+     * If the current Pull Request head doesn't match the specified SHA.
      */
     BAD_HEAD
 }

--- a/src/main/java/com/jcabi/github/Pull.java
+++ b/src/main/java/com/jcabi/github/Pull.java
@@ -31,13 +31,16 @@ package com.jcabi.github;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
+
 import java.io.IOException;
 import java.net.URL;
 import java.text.ParseException;
 import java.util.Date;
+
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.validation.constraints.NotNull;
+
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -94,6 +97,16 @@ public interface Pull extends Comparable<Pull>, JsonReadable, JsonPatchable {
      */
     void merge(@NotNull(message = "message can't be NULL") String msg)
         throws IOException;
+
+  /**
+   * Merge it.
+   * @param msg Commit message
+   * @param sha Optional SHA hash for head comparison
+   * @return State of the Merge
+   * @throws IOException IOException If there is any I/O problem
+   */
+    MergeState merge(@NotNull(message = "message can't be NULL") String msg,
+        String sha) throws IOException;
 
     /**
      * Get Pull Comments.
@@ -321,6 +334,12 @@ public interface Pull extends Comparable<Pull>, JsonReadable, JsonPatchable {
             @NotNull(message = "msg can't be NULL") final String msg
         ) throws IOException {
             this.pull.merge(msg);
+        }
+
+        @Override
+        public MergeState merge(@NotNull(message = "msg can't be NULL") final String msg,
+            final String sha) throws IOException {
+            return this.pull.merge(msg, sha);
         }
 
         @Override

--- a/src/main/java/com/jcabi/github/Pull.java
+++ b/src/main/java/com/jcabi/github/Pull.java
@@ -31,16 +31,13 @@ package com.jcabi.github;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
-
 import java.io.IOException;
 import java.net.URL;
 import java.text.ParseException;
 import java.util.Date;
-
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.validation.constraints.NotNull;
-
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -337,7 +334,8 @@ public interface Pull extends Comparable<Pull>, JsonReadable, JsonPatchable {
         }
 
         @Override
-        public MergeState merge(@NotNull(message = "msg can't be NULL") final String msg,
+        public MergeState merge(
+            @NotNull(message = "msg can't be NULL") final String msg,
             final String sha) throws IOException {
             return this.pull.merge(msg, sha);
         }

--- a/src/main/java/com/jcabi/github/Pull.java
+++ b/src/main/java/com/jcabi/github/Pull.java
@@ -103,7 +103,7 @@ public interface Pull extends Comparable<Pull>, JsonReadable, JsonPatchable {
    * @throws IOException IOException If there is any I/O problem
    */
     MergeState merge(@NotNull(message = "message can't be NULL") String msg,
-        String sha) throws IOException;
+        @NotNull(message = "sha can't be NULL") String sha) throws IOException;
 
     /**
      * Get Pull Comments.
@@ -336,7 +336,8 @@ public interface Pull extends Comparable<Pull>, JsonReadable, JsonPatchable {
         @Override
         public MergeState merge(
             @NotNull(message = "msg can't be NULL") final String msg,
-            final String sha) throws IOException {
+            @NotNull(message = "sha can't be NULL") final String sha)
+            throws IOException {
             return this.pull.merge(msg, sha);
         }
 

--- a/src/main/java/com/jcabi/github/Pull.java
+++ b/src/main/java/com/jcabi/github/Pull.java
@@ -95,13 +95,13 @@ public interface Pull extends Comparable<Pull>, JsonReadable, JsonPatchable {
     void merge(@NotNull(message = "message can't be NULL") String msg)
         throws IOException;
 
-  /**
-   * Merge it.
-   * @param msg Commit message
-   * @param sha Optional SHA hash for head comparison
-   * @return State of the Merge
-   * @throws IOException IOException If there is any I/O problem
-   */
+    /**
+     * Merge it.
+     * @param msg Commit message
+     * @param sha Optional SHA hash for head comparison
+     * @return State of the Merge
+     * @throws IOException IOException If there is any I/O problem
+     */
     MergeState merge(@NotNull(message = "message can't be NULL") String msg,
         @NotNull(message = "sha can't be NULL") String sha) throws IOException;
 

--- a/src/main/java/com/jcabi/github/RtPull.java
+++ b/src/main/java/com/jcabi/github/RtPull.java
@@ -180,8 +180,8 @@ final class RtPull implements Pull {
                     HttpURLConnection.HTTP_OK,
                     HttpURLConnection.HTTP_BAD_METHOD,
                     HttpURLConnection.HTTP_CONFLICT
-                )
-            );
+            )
+        );
         final MergeState mergeState;
         switch (response.status()) {
             case HttpURLConnection.HTTP_OK:

--- a/src/main/java/com/jcabi/github/RtPull.java
+++ b/src/main/java/com/jcabi/github/RtPull.java
@@ -162,8 +162,8 @@ final class RtPull implements Pull {
 
     @Override
     public MergeState merge(
-        @NotNull(message = "message can't be NULL") final String msg, final String sha)
-        throws IOException {
+        @NotNull(message = "message can't be NULL") final String msg,
+        final String sha) throws IOException {
         final JsonObjectBuilder builder = Json.createObjectBuilder()
             .add("commit_message", msg);
         if (sha != null) {
@@ -175,11 +175,11 @@ final class RtPull implements Pull {
             .method(Request.PUT)
             .fetch()
             .as(RestResponse.class)
-            .assertStatus(Matchers.isOneOf(
-                HttpURLConnection.HTTP_OK,
-                HttpURLConnection.HTTP_BAD_METHOD,
-                HttpURLConnection.HTTP_CONFLICT
-            ));
+            .assertStatus(
+                Matchers.isOneOf(
+                    HttpURLConnection.HTTP_OK,
+                    HttpURLConnection.HTTP_BAD_METHOD,
+                    HttpURLConnection.HTTP_CONFLICT));
         final MergeState mergeState;
         switch (response.status()) {
             case HttpURLConnection.HTTP_OK:

--- a/src/main/java/com/jcabi/github/RtPull.java
+++ b/src/main/java/com/jcabi/github/RtPull.java
@@ -179,7 +179,9 @@ final class RtPull implements Pull {
                 Matchers.isOneOf(
                     HttpURLConnection.HTTP_OK,
                     HttpURLConnection.HTTP_BAD_METHOD,
-                    HttpURLConnection.HTTP_CONFLICT));
+                    HttpURLConnection.HTTP_CONFLICT
+                )
+            );
         final MergeState mergeState;
         switch (response.status()) {
             case HttpURLConnection.HTTP_OK:

--- a/src/main/java/com/jcabi/github/RtPull.java
+++ b/src/main/java/com/jcabi/github/RtPull.java
@@ -157,12 +157,10 @@ final class RtPull implements Pull {
     @Override
     public MergeState merge(
         @NotNull(message = "message can't be NULL") final String msg,
-        final String sha) throws IOException {
+        @NotNull(message = "sha can't be NULL") final String sha)
+        throws IOException {
         final JsonObjectBuilder builder = Json.createObjectBuilder()
-            .add("commit_message", msg);
-        if (sha != null) {
-            builder.add("sha", sha);
-        }
+            .add("commit_message", msg).add("sha", sha);
         final RestResponse response = this.merge(builder.build())
             .assertStatus(
                 Matchers.isOneOf(

--- a/src/main/java/com/jcabi/github/mock/MkPull.java
+++ b/src/main/java/com/jcabi/github/mock/MkPull.java
@@ -135,7 +135,7 @@ final class MkPull implements Pull {
         @NotNull(message = "message can't be NULL") final String msg,
         @NotNull(message = "sha can't be NULL") final String sha)
         throws IOException {
-        return null;
+        throw new UnsupportedOperationException("Merge not supported");
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/mock/MkPull.java
+++ b/src/main/java/com/jcabi/github/mock/MkPull.java
@@ -133,7 +133,8 @@ final class MkPull implements Pull {
     @Override
     public MergeState merge(
         @NotNull(message = "message can't be NULL") final String msg,
-        final String sha) throws IOException {
+        @NotNull(message = "sha can't be NULL") final String sha)
+        throws IOException {
         return null;
     }
 

--- a/src/main/java/com/jcabi/github/mock/MkPull.java
+++ b/src/main/java/com/jcabi/github/mock/MkPull.java
@@ -33,10 +33,10 @@ import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Commit;
 import com.jcabi.github.Coordinates;
+import com.jcabi.github.MergeState;
 import com.jcabi.github.Pull;
 import com.jcabi.github.PullComments;
 import com.jcabi.github.Repo;
-import com.jcabi.github.MergeState;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -47,6 +47,7 @@ import javax.json.JsonValue;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+
 /**
  * Mock Github pull.
  * @author Yegor Bugayenko (yegor@tpc2.com)

--- a/src/main/java/com/jcabi/github/mock/MkPull.java
+++ b/src/main/java/com/jcabi/github/mock/MkPull.java
@@ -31,11 +31,8 @@ package com.jcabi.github.mock;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
-import com.jcabi.github.Commit;
-import com.jcabi.github.Coordinates;
-import com.jcabi.github.Pull;
-import com.jcabi.github.PullComments;
-import com.jcabi.github.Repo;
+import com.jcabi.github.*;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -127,6 +124,12 @@ final class MkPull implements Pull {
         @NotNull(message = "msg can't be NULL") final String msg
     ) throws IOException {
         // nothing to do here
+    }
+
+    @Override
+    public MergeState merge(@NotNull(message = "message can't be NULL") final String msg,
+        String sha) throws IOException {
+        return null;
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/mock/MkPull.java
+++ b/src/main/java/com/jcabi/github/mock/MkPull.java
@@ -31,8 +31,12 @@ package com.jcabi.github.mock;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
-import com.jcabi.github.*;
-
+import com.jcabi.github.Commit;
+import com.jcabi.github.Coordinates;
+import com.jcabi.github.Pull;
+import com.jcabi.github.PullComments;
+import com.jcabi.github.Repo;
+import com.jcabi.github.MergeState;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -43,7 +47,6 @@ import javax.json.JsonValue;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-
 /**
  * Mock Github pull.
  * @author Yegor Bugayenko (yegor@tpc2.com)
@@ -127,8 +130,9 @@ final class MkPull implements Pull {
     }
 
     @Override
-    public MergeState merge(@NotNull(message = "message can't be NULL") final String msg,
-        String sha) throws IOException {
+    public MergeState merge(
+        @NotNull(message = "message can't be NULL") final String msg,
+        final String sha) throws IOException {
         return null;
     }
 


### PR DESCRIPTION
This feature allows to merge a Pull Request giving a SHA-Hash of the
Pull Request's head. If the given SHA doesn't match the actual head of
the Pull Request on GitHub, the merge fails, and BAD_HEAD is returned.
Instead of throwing an exception if the merge fails, NOT_MERGEABLE is
returned. On a successful merge, SUCCESS is returned. IOException is
thrown if any other unexpected status is returned by GitHub.

I tested this locally with a small program: https://gist.github.com/sonOfRa/40fe32d9f06cb1719d62. The repo I tested against is here: https://github.com/sonOfRa/jcabi-test

PR 1 got merged and printed SUCCESS, PR 2 and PR 3 both failed, each time with the error I expected (NOT_MERGEABLE and BAD_HEAD respectively).