### PR TITLE
Add IssueEvents & Repo.issueEvents

### DIFF
--- a/src/main/java/com/jcabi/github/IssueEvents.java
+++ b/src/main/java/com/jcabi/github/IssueEvents.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.aspects.Immutable;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Github issue events.
+ *
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.23
+ * @see <a href="https://developer.github.com/v3/issues/events/">Issue Events API</a>
+ */
+@Immutable
+public interface IssueEvents {
+    /**
+     * Owner of them.
+     * @return Repo
+     */
+    @NotNull(message = "repository is never NULL")
+    Repo repo();
+
+    /**
+     * Get specific issue event by number.
+     * @param number Issue event number
+     * @return Event
+     * @see <a href="https://developer.github.com/v3/issues/events/#get-a-single-event">Get a single event</a>
+     */
+    @NotNull(message = "issue event is never NULL")
+    Event get(int number);
+
+    /**
+     * Iterate over all issue events.
+     * @return Iterator of issue events
+     * @see <a href="https://developer.github.com/v3/issues/events/#list-events-for-a-repository">List events for a repository</a>
+     */
+    @NotNull(message = "iterable is never NULL")
+    Iterable<Event> iterate();
+}

--- a/src/main/java/com/jcabi/github/Repo.java
+++ b/src/main/java/com/jcabi/github/Repo.java
@@ -93,16 +93,6 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
     Hooks hooks();
 
     /**
-     * Get all events for the repository.
-     * @return Events
-     * @see <a href="http://developer.github.com/v3/issues/events/#list-events-for-a-repository">List Events for a Repository</a>
-     * @deprecated Going to be replaced with {@link #issueEvents()} and {@link IssueEvents#iterate()}
-     */
-    @Deprecated
-    @NotNull(message = "iterable of events is never NULL")
-    Iterable<Event> events();
-
-    /**
      * Get all issue events for the repository.
      * @return Issue events
      * @see <a href="http://developer.github.com/v3/issues/events/#list-events-for-a-repository">List Events for a Repository</a>
@@ -283,12 +273,6 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
         @NotNull(message = "hooks is never NULL")
         public Hooks hooks() {
             return this.repo.hooks();
-        }
-
-        @Override
-        @NotNull(message = "Iterable of events is never NULL")
-        public Iterable<Event> events() {
-            return this.repo.events();
         }
         @Override
         @NotNull(message = "events are never NULL")

--- a/src/main/java/com/jcabi/github/Repo.java
+++ b/src/main/java/com/jcabi/github/Repo.java
@@ -96,9 +96,19 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
      * Get all events for the repository.
      * @return Events
      * @see <a href="http://developer.github.com/v3/issues/events/#list-events-for-a-repository">List Events for a Repository</a>
+     * @deprecated Going to be replaced with {@link #issueEvents()} and {@link IssueEvents#iterate()}
      */
+    @Deprecated
     @NotNull(message = "iterable of events is never NULL")
     Iterable<Event> events();
+
+    /**
+     * Get all issue events for the repository.
+     * @return Issue events
+     * @see <a href="http://developer.github.com/v3/issues/events/#list-events-for-a-repository">List Events for a Repository</a>
+     */
+    @NotNull(message = "events are never NULL")
+    IssueEvents issueEvents();
 
     /**
      * Get all labels of the repo.
@@ -279,6 +289,11 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
         @NotNull(message = "Iterable of events is never NULL")
         public Iterable<Event> events() {
             return this.repo.events();
+        }
+        @Override
+        @NotNull(message = "events are never NULL")
+        public IssueEvents issueEvents() {
+            return this.repo.issueEvents();
         }
         @Override
         @NotNull(message = "labels is never NULL")

--- a/src/main/java/com/jcabi/github/RtIssueEvents.java
+++ b/src/main/java/com/jcabi/github/RtIssueEvents.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.aspects.Immutable;
+import com.jcabi.aspects.Loggable;
+import com.jcabi.http.Request;
+import javax.json.JsonObject;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Github issue events.
+ *
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.23
+ */
+@Immutable
+@Loggable(Loggable.DEBUG)
+@EqualsAndHashCode(of = { "entry", "request", "owner" })
+final class RtIssueEvents implements IssueEvents {
+    /**
+     * API entry point.
+     */
+    private final transient Request entry;
+
+    /**
+     * RESTful request.
+     */
+    private final transient Request request;
+
+    /**
+     * Repository.
+     */
+    private final transient Repo owner;
+
+    /**
+     * Public constructor.
+     * @param req Request
+     * @param repo Repository
+     */
+    RtIssueEvents(final Request req, final Repo repo) {
+        this.entry = req;
+        final Coordinates coords = repo.coordinates();
+        this.request = this.entry.uri()
+            .path("/repos")
+            .path(coords.user())
+            .path(coords.repo())
+            .path("/issues")
+            .path("/events")
+            .back();
+        this.owner = repo;
+    }
+
+    @Override
+    @NotNull(message = "toString is never NULL")
+    public String toString() {
+        return this.request.uri().get().toString();
+    }
+
+    @Override
+    @NotNull(message = "repository is never NULL")
+    public Repo repo() {
+        return this.owner;
+    }
+
+    @Override
+    @NotNull(message = "issue event is never NULL")
+    public Event get(final int number) {
+        return new RtEvent(this.entry, this.owner, number);
+    }
+
+    @Override
+    @NotNull(message = "iterable is never NULL")
+    public Iterable<Event> iterate() {
+        return new RtPagination<Event>(
+            this.request,
+            new RtValuePagination.Mapping<Event, JsonObject>() {
+                @Override
+                public Event map(final JsonObject object) {
+                    return new RtEvent(
+                        RtIssueEvents.this.entry,
+                        RtIssueEvents.this.owner,
+                        object.getInt("id")
+                    );
+                }
+            }
+        );
+    }
+}

--- a/src/main/java/com/jcabi/github/RtRepo.java
+++ b/src/main/java/com/jcabi/github/RtRepo.java
@@ -138,12 +138,6 @@ final class RtRepo implements Repo {
     }
 
     @Override
-    @NotNull(message = "Iterable of events is never NULL")
-    public Iterable<Event> events() {
-        return this.issueEvents().iterate();
-    }
-
-    @Override
     @NotNull(message = "events are never NULL")
     public IssueEvents issueEvents() {
         return new RtIssueEvents(this.entry, this);

--- a/src/main/java/com/jcabi/github/RtRepo.java
+++ b/src/main/java/com/jcabi/github/RtRepo.java
@@ -140,19 +140,13 @@ final class RtRepo implements Repo {
     @Override
     @NotNull(message = "Iterable of events is never NULL")
     public Iterable<Event> events() {
-        return new RtPagination<Event>(
-            this.request.uri().path("/issues/events").back(),
-            new RtValuePagination.Mapping<Event, JsonObject>() {
-                @Override
-                public Event map(final JsonObject object) {
-                    return new RtEvent(
-                        RtRepo.this.entry,
-                        RtRepo.this,
-                        object.getInt("id")
-                    );
-                }
-            }
-        );
+        return this.issueEvents().iterate();
+    }
+
+    @Override
+    @NotNull(message = "events are never NULL")
+    public IssueEvents issueEvents() {
+        return new RtIssueEvents(this.entry, this);
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/mock/MkRepo.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepo.java
@@ -36,7 +36,6 @@ import com.jcabi.github.Collaborators;
 import com.jcabi.github.Contents;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.DeployKeys;
-import com.jcabi.github.Event;
 import com.jcabi.github.Forks;
 import com.jcabi.github.Git;
 import com.jcabi.github.Github;
@@ -161,12 +160,6 @@ final class MkRepo implements Repo {
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);
         }
-    }
-
-    @Override
-    @NotNull(message = "Iterable of events is never NULL")
-    public Iterable<Event> events() {
-        return null;
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/mock/MkRepo.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepo.java
@@ -41,6 +41,7 @@ import com.jcabi.github.Forks;
 import com.jcabi.github.Git;
 import com.jcabi.github.Github;
 import com.jcabi.github.Hooks;
+import com.jcabi.github.IssueEvents;
 import com.jcabi.github.Issues;
 import com.jcabi.github.Labels;
 import com.jcabi.github.Language;
@@ -72,7 +73,11 @@ import lombok.ToString;
 @Loggable(Loggable.DEBUG)
 @ToString
 @EqualsAndHashCode(of = {"storage", "self", "coords" })
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessiveImports" })
+@SuppressWarnings({
+    "PMD.TooManyMethods",
+    "PMD.ExcessiveImports",
+    "PMD.CouplingBetweenObjects"
+})
 final class MkRepo implements Repo {
 
     /**
@@ -161,6 +166,12 @@ final class MkRepo implements Repo {
     @Override
     @NotNull(message = "Iterable of events is never NULL")
     public Iterable<Event> events() {
+        return null;
+    }
+
+    @Override
+    @NotNull(message = "events are never NULL")
+    public IssueEvents issueEvents() {
         return null;
     }
 

--- a/src/main/java/com/jcabi/github/mock/MkRepo.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepo.java
@@ -67,6 +67,7 @@ import lombok.ToString;
  * @since 0.5
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle ClassFanOutComplexity (500 lines)
+ * @todo #1061 Fix code to avoid CouplingBetweenObjects
  */
 @Immutable
 @Loggable(Loggable.DEBUG)

--- a/src/test/java/com/jcabi/github/RtRepoITCase.java
+++ b/src/test/java/com/jcabi/github/RtRepoITCase.java
@@ -120,7 +120,7 @@ public final class RtRepoITCase {
         final Issue issue = repo.issues().create("Test", "This is a bug");
         new Issue.Smart(issue).close();
         MatcherAssert.assertThat(
-            repo.events(),
+            repo.issueEvents().iterate(),
             Matchers.not(Matchers.emptyIterable())
         );
     }

--- a/src/test/java/com/jcabi/github/RtRepoTest.java
+++ b/src/test/java/com/jcabi/github/RtRepoTest.java
@@ -72,7 +72,7 @@ public final class RtRepoTest {
             new ApacheRequest(container.home())
         );
         MatcherAssert.assertThat(
-            repo.events(),
+            repo.issueEvents().iterate(),
             Matchers.<Event>iterableWithSize(2)
         );
         container.stop();


### PR DESCRIPTION
This is more symmetrical with `Repo.issues`, `Repo.pulls`, etc.
This also adds the ability to fetch an issue event by its number, which doesn't seem to have been possible previously.
Also, this means there will eventually be an `MkIssueEvents`, which will be a logical place to house an `MkEvent` creation method, which will be necessary when adding tests for #1055, #1056.
This PR is a prerequisite for some other code changes I'm working on that will fix those two issues.
