### PR TITLE
Fix MkEvent to be storage-based like the other proper mocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/src/main/java/com/jcabi/github/mock/MkEvent.java
+++ b/src/main/java/com/jcabi/github/mock/MkEvent.java
@@ -33,10 +33,12 @@ import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Event;
-import com.jcabi.github.Github;
 import com.jcabi.github.Repo;
+import java.io.IOException;
 import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonValue;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -51,8 +53,20 @@ import lombok.ToString;
 @Immutable
 @Loggable(Loggable.DEBUG)
 @ToString
-@EqualsAndHashCode(of = "type")
+@EqualsAndHashCode(of = { "storage", "self", "coords", "num" })
 final class MkEvent implements Event {
+    /**
+     * Created at.
+     */
+    private static final String CREATED_AT = "created_at";
+    /**
+     * Event.
+     */
+    private static final String EVENT = "event";
+    /**
+     * Login.
+     */
+    private static final String LOGIN = "login";
 
     /**
      * Storage.
@@ -70,28 +84,28 @@ final class MkEvent implements Event {
     private final transient Coordinates coords;
 
     /**
-     * Type of event.
+     * ID number of event.
      */
-    private final transient String type;
+    private final transient int num;
 
     /**
      * Public ctor.
      * @param stg Storage
      * @param login User to login
      * @param rep Repo
-     * @param tpe Type
+     * @param nmbr Number
      * @checkstyle ParameterNumber (5 lines)
      */
     MkEvent(
         @NotNull(message = "stg can't be NULL") final MkStorage stg,
         @NotNull(message = "login can't be NULL") final String login,
         @NotNull(message = "rep can't be NULL") final Coordinates rep,
-        @NotNull(message = "tpe can't be NULL") final String tpe
+        final int nmbr
     ) {
         this.storage = stg;
         this.self = login;
         this.coords = rep;
-        this.type = tpe;
+        this.num = nmbr;
     }
 
     @Override
@@ -102,7 +116,7 @@ final class MkEvent implements Event {
 
     @Override
     public int number() {
-        return 0;
+        return this.num;
     }
 
     @Override
@@ -112,11 +126,65 @@ final class MkEvent implements Event {
         throw new UnsupportedOperationException("#compareTo()");
     }
 
+    /**
+     * Describes the event in a JSON object.
+     * @return JSON object
+     * @throws IOException If there is any I/O problem
+     * @todo #1063:30min When the event has a label, retrieve and include the
+     *  label's color too. MkIssueEvents.create() will also need to be
+     *  updated accordingly.
+     */
     @Override
     @NotNull(message = "JSON is never NULL")
-    public JsonObject json() {
-        return Json.createObjectBuilder().add("event", this.type).add(
-            "actor", Json.createObjectBuilder().add("login", "test").build()
-        ).add("created_at", new Github.Time().toString()).build();
+    public JsonObject json() throws IOException {
+        final JsonObject obj = new JsonNode(
+            this.storage.xml().nodes(this.xpath()).get(0)
+        ).json();
+        JsonObjectBuilder builder = Json.createObjectBuilder()
+            .add("id", this.num)
+            .add(
+                "url",
+                String.format(
+                    // @checkstyle LineLength (1 line)
+                    "https://api.jcabi-github.invalid/repos/%s/issues/events/%s",
+                    this.coords,
+                    this.num
+                )
+            )
+            .add("commit_id", JsonValue.NULL)
+            // @checkstyle MultipleStringLiteralsCheck (1 line)
+            .add(MkEvent.EVENT, obj.getString(MkEvent.EVENT))
+            .add(
+                "actor",
+                Json.createObjectBuilder()
+                    // @checkstyle MultipleStringLiteralsCheck (1 line)
+                    .add(MkEvent.LOGIN, obj.getString(MkEvent.LOGIN))
+                    .build()
+            )
+            // @checkstyle MultipleStringLiteralsCheck (1 line)
+            .add(MkEvent.CREATED_AT, obj.getString(MkEvent.CREATED_AT));
+        final String label = "label";
+        if (obj.containsKey(label)) {
+            builder = builder.add(
+                label,
+                Json.createObjectBuilder()
+                    .add("name", obj.getString(label))
+                    .build()
+            );
+        }
+        return builder.build();
+    }
+
+    /**
+     * XPath of this element in XML tree.
+     * @return XPath
+     */
+    @NotNull(message = "Xpath is never NULL")
+    private String xpath() {
+        return String.format(
+            // @checkstyle LineLength (1 line)
+            "/github/repos/repo[@coords='%s']/issue-events/issue-event[number='%d']",
+            this.coords, this.num
+        );
     }
 }

--- a/src/main/java/com/jcabi/github/mock/MkIssueEvents.java
+++ b/src/main/java/com/jcabi/github/mock/MkIssueEvents.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github.mock;
+
+import com.jcabi.aspects.Immutable;
+import com.jcabi.aspects.Loggable;
+import com.jcabi.github.Coordinates;
+import com.jcabi.github.Event;
+import com.jcabi.github.Github;
+import com.jcabi.github.IssueEvents;
+import com.jcabi.github.Repo;
+import com.jcabi.log.Logger;
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.xembly.Directives;
+
+/**
+ * Mock GitHub issue events.
+ *
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.23
+ */
+@Immutable
+@Loggable(Loggable.DEBUG)
+@ToString
+@EqualsAndHashCode(of = { "storage", "self", "coords" })
+final class MkIssueEvents implements IssueEvents {
+    /**
+     * Storage.
+     */
+    private final transient MkStorage storage;
+
+    /**
+     * Login of the user logged in.
+     */
+    private final transient String self;
+
+    /**
+     * Repo name.
+     */
+    private final transient Coordinates coords;
+
+    /**
+     * Public constructor.
+     * @param stg Storage
+     * @param login User to login
+     * @param rep Repo
+     * @throws IOException If there is any I/O problem
+     */
+    MkIssueEvents(
+        @NotNull(message = "stg can't be NULL") final MkStorage stg,
+        @NotNull(message = "login can't be NULL") final String login,
+        @NotNull(message = "rep can't be NULL") final Coordinates rep
+    ) throws IOException {
+        this.storage = stg;
+        this.self = login;
+        this.coords = rep;
+        this.storage.apply(
+            new Directives().xpath(
+                String.format(
+                    "/github/repos/repo[@coords='%s']",
+                    this.coords
+                )
+            ).addIf("issue-events")
+        );
+    }
+
+    @Override
+    @NotNull(message = "repository is never NULL")
+    public Repo repo() {
+        return new MkRepo(this.storage, this.self, this.coords);
+    }
+
+    @Override
+    @NotNull(message = "issue event is never NULL")
+    public Event get(final int number) {
+        return new MkEvent(this.storage, this.self, this.coords, number);
+    }
+
+    @Override
+    @NotNull(message = "iterable is never NULL")
+    public Iterable<Event> iterate() {
+        return new MkIterable<Event>(
+            this.storage,
+            String.format("%s/issue-event", this.xpath()),
+            new MkIterable.Mapping<Event>() {
+                @Override
+                public Event map(final XML xml) {
+                    return MkIssueEvents.this.get(
+                        Integer.parseInt(xml.xpath("number/text()").get(0))
+                    );
+                }
+            }
+        );
+    }
+
+    /**
+     * Creates a new issue event.
+     * This has no equivalent in GitHub's public API, since GitHub generates
+     * events automatically in response to some other API calls.
+     * @param type Type of event
+     * @param issue ID number of issue the event is regarding
+     * @param login Username of actor who caused the event
+     * @param label Label added or removed
+     * @return The newly created issue event
+     * @throws IOException If there is any I/O problem
+     * @todo #1063:30min Make it possible to set the "assignee" field for
+     *  "assigned"/"unassigned" events. Make it possible to set the
+     *  "milestone" field for "milestoned"/"demilestoned" events. Make it
+     *  possible to set the "rename" field for "renamed" events. Make it
+     *  possible to set the "commit_id" field for events related to commits.
+     *  See https://developer.github.com/v3/issues/events/ for details.
+     */
+    @NotNull(message = "event is never NULL")
+    // @checkstyle ParameterNumberCheck (7 lines)
+    public Event create(
+        @NotNull(message = "type can't be NULL") final String type,
+        final int issue, @NotNull(message = "login can't be NULL")
+        final String login, final String label
+    ) throws IOException {
+        final String created = new Github.Time().toString();
+        this.storage.lock();
+        final int number;
+        try {
+            number = 1 + this.storage.xml().xpath(
+                String.format("%s/issue-event/number/text()", this.xpath())
+            ).size();
+            Directives directives = new Directives()
+                .xpath(this.xpath())
+                .add("issue-event")
+                .add("issue").set(Integer.toString(issue)).up()
+                .add("number").set(Integer.toString(number)).up()
+                .add("event").set(type).up()
+                .add("created_at").set(created).up()
+                .add("login").set(login).up();
+            if (label != null) {
+                directives = directives.add("label").set(label).up();
+            }
+            this.storage.apply(directives);
+        } finally {
+            this.storage.unlock();
+        }
+        Logger.info(
+            MkEvent.class,
+            "issue event #%d of type %s created in %s for issue #%d by %s",
+            number, type, this.self, issue, login
+        );
+        return this.get(number);
+    }
+
+    /**
+     * XPath of this element in XML tree.
+     * @return XPath
+     */
+    @NotNull(message = "Xpath is never NULL")
+    private String xpath() {
+        return String.format(
+            "/github/repos/repo[@coords='%s']/issue-events",
+            this.coords
+        );
+    }
+}

--- a/src/main/java/com/jcabi/github/mock/MkIssueEvents.java
+++ b/src/main/java/com/jcabi/github/mock/MkIssueEvents.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github.mock;
 
+import com.google.common.base.Optional;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Coordinates;
@@ -143,11 +144,12 @@ final class MkIssueEvents implements IssueEvents {
      *  See https://developer.github.com/v3/issues/events/ for details.
      */
     @NotNull(message = "event is never NULL")
-    // @checkstyle ParameterNumberCheck (7 lines)
+    // @checkstyle ParameterNumberCheck (4 lines)
     public Event create(
         @NotNull(message = "type can't be NULL") final String type,
         final int issue, @NotNull(message = "login can't be NULL")
-        final String login, final String label
+        final String login, @NotNull(message = "option itself can't be NULL")
+        final Optional<String> label
     ) throws IOException {
         final String created = new Github.Time().toString();
         this.storage.lock();
@@ -164,8 +166,8 @@ final class MkIssueEvents implements IssueEvents {
                 .add("event").set(type).up()
                 .add("created_at").set(created).up()
                 .add("login").set(login).up();
-            if (label != null) {
-                directives = directives.add("label").set(label).up();
+            if (label.isPresent()) {
+                directives = directives.add("label").set(label.get()).up();
             }
             this.storage.apply(directives);
         } finally {

--- a/src/main/java/com/jcabi/github/mock/MkRepo.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepo.java
@@ -164,9 +164,13 @@ final class MkRepo implements Repo {
     }
 
     @Override
-    @NotNull(message = "events are never NULL")
+    @NotNull(message = "issue events is never NULL")
     public IssueEvents issueEvents() {
-        return null;
+        try {
+            return new MkIssueEvents(this.storage, this.self, this.coords);
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     @Override

--- a/src/test/java/com/jcabi/github/mock/MkEventTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkEventTest.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github.mock;
 
+import com.google.common.base.Optional;
 import com.jcabi.github.Repo;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
@@ -58,7 +59,7 @@ public final class MkEventTest {
             "test_type",
             1,
             user,
-            "test_label"
+            Optional.of("test_label")
         ).number();
         MatcherAssert.assertThat(
             new MkEvent(

--- a/src/test/java/com/jcabi/github/mock/MkEventTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkEventTest.java
@@ -29,7 +29,8 @@
  */
 package com.jcabi.github.mock;
 
-import com.jcabi.github.Coordinates;
+import com.jcabi.github.Repo;
+import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -47,12 +48,26 @@ public final class MkEventTest {
      */
     @Test
     public void canGetCreatedAt() throws Exception {
+        final MkStorage storage = new MkStorage.InFile();
+        final String user = "test_user";
+        final Repo repo = new MkGithub(storage, user).repos().create(
+            Json.createObjectBuilder().add("name", "test").build()
+        );
+        final MkIssueEvents events = (MkIssueEvents) (repo.issueEvents());
+        final int eventnum = events.create(
+            "test_type",
+            1,
+            user,
+            "test_label"
+        ).number();
         MatcherAssert.assertThat(
             new MkEvent(
-                new MkStorage.InFile(), "test", new Coordinates.Simple(
-                    "test_user", "test_repo"
-                ), "test_type"
-            ).json().getString("created_at"),
+                storage,
+                user,
+                repo.coordinates(),
+                eventnum
+            )
+                .json().getString("created_at"),
             Matchers.notNullValue()
         );
     }

--- a/src/test/java/com/jcabi/github/mock/MkIssueEventsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssueEventsTest.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github.mock;
+
+import com.jcabi.aspects.Tv;
+import com.jcabi.github.Event;
+import java.util.Iterator;
+import javax.json.Json;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link MkIssueEvents}.
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.23
+ */
+public final class MkIssueEventsTest {
+    /**
+     * Name string used in various APIs.
+     */
+    private static final String NAME = "name";
+
+    /**
+     * MkIssueEvents can create issue events.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void createsIssueEvent() throws Exception {
+        final MkIssueEvents events = this.issueEvents();
+        final String login = "jack";
+        final String type = "locked";
+        final long before = MkIssueEventsTest.now();
+        final Event.Smart event = new Event.Smart(
+            events.create(type, 2, login, null)
+        );
+        final long after = MkIssueEventsTest.now();
+        MatcherAssert.assertThat(
+            event.type(),
+            Matchers.equalTo(type)
+        );
+        MatcherAssert.assertThat(
+            event.author().login(),
+            Matchers.equalTo(login)
+        );
+        MatcherAssert.assertThat(
+            event.url().toString(),
+            // @checkstyle LineLength (1 line)
+            Matchers.equalTo("https://api.jcabi-github.invalid/repos/jeff/test/issues/events/1")
+        );
+        MatcherAssert.assertThat(
+            event.createdAt().getTime(),
+            Matchers.greaterThanOrEqualTo(before)
+        );
+        MatcherAssert.assertThat(
+            event.createdAt().getTime(),
+            Matchers.lessThanOrEqualTo(after)
+        );
+    }
+
+    /**
+     * MkIssueEvents can create an issue event with a label attribute.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void createsIssueEventWithLabel() throws Exception {
+        final MkIssueEvents events = this.issueEvents();
+        final String label = "my label";
+        final Event event = events.create("labeled", 2, "samuel", label);
+        MatcherAssert.assertThat(
+            event.json()
+                .getJsonObject("label")
+                .getString(MkIssueEventsTest.NAME),
+            Matchers.equalTo(label)
+        );
+    }
+
+    /**
+     * MkIssueEvents can get a single issue event.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void getsIssueEvent() throws Exception {
+        final MkIssueEvents events = this.issueEvents();
+        final String type = "unlocked";
+        final String login = "jill";
+        final int eventnum = events.create(type, 2, login, null).number();
+        final Event.Smart event = new Event.Smart(events.get(eventnum));
+        MatcherAssert.assertThat(
+            event.number(),
+            Matchers.equalTo(eventnum)
+        );
+        MatcherAssert.assertThat(
+            event.type(),
+            Matchers.equalTo(type)
+        );
+        MatcherAssert.assertThat(
+            event.author().login(),
+            Matchers.equalTo(login)
+        );
+    }
+
+    /**
+     * MkIssueEvents can iterate over issue events in correct order.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void iteratesIssueEvents() throws Exception {
+        final MkIssueEvents events = this.issueEvents();
+        final Event first = events.create("closed", 3, "john", null);
+        final Event second = events.create("reopened", 3, "jane", null);
+        MatcherAssert.assertThat(
+            events.iterate(),
+            Matchers.<Event>iterableWithSize(2)
+        );
+        final Iterator<Event> iter = events.iterate().iterator();
+        MatcherAssert.assertThat(
+            iter.next(),
+            Matchers.equalTo(first)
+        );
+        MatcherAssert.assertThat(
+            iter.next(),
+            Matchers.equalTo(second)
+        );
+    }
+
+    /**
+     * Create an MkIssueEvents to work with.
+     * Can't use normal IssueEvents because we need the mock-only
+     * {@link MkIssueEvents#create(String, int, String, String)} method.
+     * @return MkIssueEvents
+     * @throws Exception If some problem inside
+     */
+    private MkIssueEvents issueEvents() throws Exception {
+        return MkIssueEvents.class.cast(
+            new MkGithub().repos().create(
+                Json.createObjectBuilder()
+                    .add(MkIssueEventsTest.NAME, "test")
+                    .build()
+            ).issueEvents()
+        );
+    }
+
+    /**
+     * Obtains the current time.
+     * @return Current time (in milliseconds since epoch) truncated to the nearest second
+     */
+    private static long now() {
+        final long sinceepoch = System.currentTimeMillis();
+        return sinceepoch - (sinceepoch % Tv.THOUSAND);
+    }
+}

--- a/src/test/java/com/jcabi/github/mock/MkIssueEventsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssueEventsTest.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github.mock;
 
+import com.google.common.base.Optional;
 import com.jcabi.aspects.Tv;
 import com.jcabi.github.Event;
 import java.util.Iterator;
@@ -48,6 +49,10 @@ public final class MkIssueEventsTest {
      * Name string used in various APIs.
      */
     private static final String NAME = "name";
+    /**
+     * Absent optional string.
+     */
+    private static final Optional<String> ABSENT_STR = Optional.absent();
 
     /**
      * MkIssueEvents can create issue events.
@@ -60,7 +65,12 @@ public final class MkIssueEventsTest {
         final String type = "locked";
         final long before = MkIssueEventsTest.now();
         final Event.Smart event = new Event.Smart(
-            events.create(type, 2, login, null)
+            events.create(
+                type,
+                2,
+                login,
+                MkIssueEventsTest.ABSENT_STR
+            )
         );
         final long after = MkIssueEventsTest.now();
         MatcherAssert.assertThat(
@@ -94,7 +104,12 @@ public final class MkIssueEventsTest {
     public void createsIssueEventWithLabel() throws Exception {
         final MkIssueEvents events = this.issueEvents();
         final String label = "my label";
-        final Event event = events.create("labeled", 2, "samuel", label);
+        final Event event = events.create(
+            "labeled",
+            2,
+            "samuel",
+            Optional.of(label)
+        );
         MatcherAssert.assertThat(
             event.json()
                 .getJsonObject("label")
@@ -112,7 +127,12 @@ public final class MkIssueEventsTest {
         final MkIssueEvents events = this.issueEvents();
         final String type = "unlocked";
         final String login = "jill";
-        final int eventnum = events.create(type, 2, login, null).number();
+        final int eventnum = events.create(
+            type,
+            2,
+            login,
+            MkIssueEventsTest.ABSENT_STR
+        ).number();
         final Event.Smart event = new Event.Smart(events.get(eventnum));
         MatcherAssert.assertThat(
             event.number(),
@@ -135,8 +155,18 @@ public final class MkIssueEventsTest {
     @Test
     public void iteratesIssueEvents() throws Exception {
         final MkIssueEvents events = this.issueEvents();
-        final Event first = events.create("closed", 3, "john", null);
-        final Event second = events.create("reopened", 3, "jane", null);
+        final Event first = events.create(
+            "closed",
+            3,
+            "john",
+            MkIssueEventsTest.ABSENT_STR
+        );
+        final Event second = events.create(
+            "reopened",
+            3,
+            "jane",
+            MkIssueEventsTest.ABSENT_STR
+        );
         MatcherAssert.assertThat(
             events.iterate(),
             Matchers.<Event>iterableWithSize(2)
@@ -155,7 +185,7 @@ public final class MkIssueEventsTest {
     /**
      * Create an MkIssueEvents to work with.
      * Can't use normal IssueEvents because we need the mock-only
-     * {@link MkIssueEvents#create(String, int, String, String)} method.
+     * {@link MkIssueEvents#create(String, int, String, Optional)} method.
      * @return MkIssueEvents
      * @throws Exception If some problem inside
      */


### PR DESCRIPTION
This will make possible the fixing of #1055 and #1056, since mock events can now be properly persisted.