### PR TITLE
Make MkIssue create events when opened/closed

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkIssue.java
+++ b/src/main/java/com/jcabi/github/mock/MkIssue.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github.mock;
 
+import com.google.common.base.Optional;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Comments;
@@ -176,7 +177,20 @@ final class MkIssue implements Issue {
     public void patch(
         @NotNull(message = "json can't be NULL") final JsonObject json
     ) throws IOException {
+        final Issue.Smart smart = new Issue.Smart(this);
+        final boolean was = smart.isOpen();
         new JsonPatch(this.storage).patch(this.xpath(), json);
+        final boolean now = smart.isOpen();
+        if (now != was) {
+            final String type;
+            if (now) {
+                type = Event.REOPENED;
+            } else {
+                type = Event.CLOSED;
+            }
+            new MkIssueEvents(this.storage, this.self, this.coords)
+                .create(type, this.num, this.self, Optional.<String>absent());
+        }
     }
 
     @Override

--- a/src/test/java/com/jcabi/github/mock/MkIssueTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssueTest.java
@@ -30,11 +30,13 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Coordinates;
+import com.jcabi.github.Event;
 import com.jcabi.github.Github;
 import com.jcabi.github.Issue;
 import com.jcabi.github.Label;
 import com.jcabi.github.Repo;
 import java.util.Collections;
+import java.util.Iterator;
 import javax.json.Json;
 import org.hamcrest.CustomMatcher;
 import org.hamcrest.MatcherAssert;
@@ -249,6 +251,53 @@ public final class MkIssueTest {
         MatcherAssert.assertThat(
             issue.assignee().login(),
             Matchers.startsWith("wal")
+        );
+    }
+
+    /**
+     * MkIssue can create a closed event when closing an issue.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void createsClosedEvent() throws Exception {
+        final Issue.Smart issue = new Issue.Smart(this.issue());
+        issue.close();
+        MatcherAssert.assertThat(
+            issue.events(),
+            Matchers.<Event>iterableWithSize(1)
+        );
+        final Event.Smart closed = new Event.Smart(
+            issue.events().iterator().next()
+        );
+        MatcherAssert.assertThat(
+            closed.type(),
+            Matchers.equalTo(Event.CLOSED)
+        );
+    }
+
+    /**
+     * MkIssue can create a reopened event when closing an issue.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void createsReopenedEvent() throws Exception {
+        final Issue.Smart issue = new Issue.Smart(this.issue());
+        issue.close();
+        issue.open();
+        MatcherAssert.assertThat(
+            issue.events(),
+            Matchers.<Event>iterableWithSize(2)
+        );
+        final Iterator<Event> events = issue.events().iterator();
+        final Event.Smart closed = new Event.Smart(events.next());
+        final Event.Smart reopened = new Event.Smart(events.next());
+        MatcherAssert.assertThat(
+            closed.type(),
+            Matchers.equalTo(Event.CLOSED)
+        );
+        MatcherAssert.assertThat(
+            reopened.type(),
+            Matchers.equalTo(Event.REOPENED)
         );
     }
 


### PR DESCRIPTION
Fixes #1055.
This adds diffing logic to `MkIssue.patch` to check whether the openness of the issue gets changed, and if it has changed, it creates the appropriate persisted "closed" or "reopened" event using `MkIssueEvents.create`.