### PR TITLE
Add Event.Smart.label()

### DIFF
--- a/src/main/java/com/jcabi/github/Event.java
+++ b/src/main/java/com/jcabi/github/Event.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.google.common.base.Optional;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import java.io.IOException;
@@ -245,6 +246,25 @@ public interface Event extends Comparable<Event>, JsonReadable {
             } catch (final ParseException ex) {
                 throw new IllegalStateException(ex);
             }
+        }
+        /**
+         * Label that was added or removed in this event (if any).
+         * @return Label that was added or removed
+         * @throws IOException If there is any I/O problem
+         * @since 0.24
+         */
+        @NotNull(message = "Optional itself is never NULL")
+        public Optional<Label> label() throws IOException {
+            Optional<Label> lab = Optional.absent();
+            final JsonObject lbl = this.jsn.json().getJsonObject("label");
+            if (lbl != null) {
+                lab = Optional.of(
+                    this.event.repo()
+                        .labels()
+                        .get(lbl.getString("name"))
+                );
+            }
+            return lab;
         }
         @Override
         @NotNull(message = "Repository is never NULL")

--- a/src/test/java/com/jcabi/github/mock/MkIssueEventsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssueEventsTest.java
@@ -104,16 +104,16 @@ public final class MkIssueEventsTest {
     public void createsIssueEventWithLabel() throws Exception {
         final MkIssueEvents events = this.issueEvents();
         final String label = "my label";
-        final Event event = events.create(
-            "labeled",
-            2,
-            "samuel",
-            Optional.of(label)
+        final Event.Smart event = new Event.Smart(
+            events.create(
+                "labeled",
+                2,
+                "samuel",
+                Optional.of(label)
+            )
         );
         MatcherAssert.assertThat(
-            event.json()
-                .getJsonObject("label")
-                .getString(MkIssueEventsTest.NAME),
+            event.label().get().name(),
             Matchers.equalTo(label)
         );
     }

--- a/src/test/java/com/jcabi/github/mock/MkIssueLabelsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssueLabelsTest.java
@@ -34,7 +34,6 @@ import com.jcabi.github.Issue;
 import com.jcabi.github.IssueLabels;
 import com.jcabi.github.Label;
 import com.jcabi.github.Repo;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import javax.json.Json;
@@ -122,7 +121,7 @@ public final class MkIssueLabelsTest {
             Matchers.equalTo(repo)
         );
         MatcherAssert.assertThat(
-            MkIssueLabelsTest.labelOf(labeled),
+            labeled.label().get().name(),
             Matchers.equalTo(name)
         );
     }
@@ -159,7 +158,7 @@ public final class MkIssueLabelsTest {
             Matchers.equalTo(repo)
         );
         MatcherAssert.assertThat(
-            MkIssueLabelsTest.labelOf(unlabeled),
+            unlabeled.label().get().name(),
             Matchers.equalTo(name)
         );
     }
@@ -173,15 +172,5 @@ public final class MkIssueLabelsTest {
         return new MkGithub().repos().create(
             Json.createObjectBuilder().add(NAME, "test").build()
         );
-    }
-
-    /**
-     * Get label from event.
-     * @param event Event to get label of
-     * @return Name of label
-     * @throws IOException If some I/O problem inside
-     */
-    private static String labelOf(final Event event) throws IOException {
-        return event.json().getJsonObject("label").getString(NAME);
     }
 }


### PR DESCRIPTION
This adds `Event.Smart.label()` to allow getting the `Label` added/removed by an `Event` without having to muck with the JSON object directly.
Fixes #1078.