### PR TITLE
Add hibernate-validator to test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,11 @@
             <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
Fixes #1034 by adding the required JSR-303 implementation (I chose `hibernate-validator` based on its usage in other jcabi projects) to the list of test suite dependencies in `pom.xml`.