### PR TITLE
Mark Java 7 as the minimum required Java version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 jdk:
   - oraclejdk7
   - oraclejdk8
-  - openjdk6
   - openjdk7
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 More details are here: [github.jcabi.com](http://github.jcabi.com/). Also,
 read this blog post: [Object-Oriented Github API](http://www.yegor256.com/2014/05/14/object-oriented-github-java-sdk.html).
+Java 7 or higher is required.
 
 Set of classes in `com.jcabi.github` package is
 an object oriented API of Github:

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -46,7 +46,7 @@ public class Main {
 
    * Entire Github API is available, at least through a configurable HTTP request
 
-  The only dependency you need is
+  Java 7 or higher is required. The only dependency you need is
   (you can also download
   {{{http://repo1.maven.org/maven2/com/jcabi/jcabi-github/${project.version}/jcabi-github-${project.version}.jar}<<<jcabi-github-${project.version}.jar>>>}}
   and add it to the classpath):


### PR DESCRIPTION
Fixes #1052 by no longer testing against Java 6 and by explicitly documenting that Java 7 or higher is required for jcabi-github.