### PR TITLE
#975 Incomplete integration tests javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ accounts. This test case will try to fork a gist from first account into second.
 only), for example `yegor256/test`. OAuth access tokens should have permissions in their
 respective repos to all scopes needed by the integration test suite you want to run
 (including `delete_repo`, which is not set by default!).
+
 Please note that different integration tests may need keys with permissions to different
 [scopes](https://developer.github.com/v3/oauth/#scopes);
 To run all integration tests, the key should have the following OAuth scopes:
@@ -90,6 +91,7 @@ To run all integration tests, the key should have the following OAuth scopes:
 - admin:repo_hook
 - user
 - user:email
+
 `RtForksITCase` requires additional parameter `-Dfailsafe.github.organization=<organization>`
 where `<organization>` is an organization name to fork test github repository.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,15 @@ respective repos to all scopes needed by the integration test suite you want to 
 (including `delete_repo`, which is not set by default!).
 Please note that different integration tests may need keys with permissions to different
 [scopes](https://developer.github.com/v3/oauth/#scopes);
-the `RtGistITCase` test requires permissions to gist scope.
+To run all integration tests, the key should have the following OAuth scopes:
+- read:org
+- repo
+- delete_repo
+- admin:public_key
+- gist
+- admin:repo_hook
+- user
+- user:email
 `RtForksITCase` requires additional parameter `-Dfailsafe.github.organization=<organization>`
 where `<organization>` is an organization name to fork test github repository.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ respective repos to all scopes needed by the integration test suite you want to 
 (including `delete_repo`, which is not set by default!).
 
 Please note that different integration tests may need keys with permissions to different
-[scopes](https://developer.github.com/v3/oauth/#scopes);
+[scopes](https://developer.github.com/v3/oauth/#scopes).
 To run all integration tests, the key should have the following OAuth scopes:
 - read:org
 - repo

--- a/src/test/java/com/jcabi/github/OAuthScope.java
+++ b/src/test/java/com/jcabi/github/OAuthScope.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates an integration test case to indicate required OAuth scopes to run
+ * such case.
+ *
+ * @author Jason Wong (super132j@yahoo.com)
+ * @version $Id$
+ * @see <a href="https://developer.github.com/v3/oauth/#scopes">Github OAuth
+ * scopes</a>
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface OAuthScope {
+    /**
+     * The Github OAuth scopes required.
+     */
+    Scope[] value();
+
+    /**
+     * The enum represents the available OAuth scopes.
+     */
+    public enum Scope {
+        /**
+         * Represents "no scope" scope.
+         */
+        NO_SCOPE,
+        /**
+         * Represents "user" scope.
+         */
+        USER,
+        /**
+         * Represents "user:email" scope.
+         */
+        USER_EMAIL,
+        /**
+         * Represents "user:follow" scope.
+         */
+        USER_FOLLOW,
+        /**
+         * Represents "public_repo" scope.
+         */
+        PUBLIC_REPO,
+        /**
+         * Represents "repo" scope.
+         */
+        REPO,
+        /**
+         * Represents "repo_deployment" scope.
+         */
+        REPO_DEPLOYMENT,
+        /**
+         * Represents "repo_status" scope.
+         */
+        REPO_STATUS,
+        /**
+         * Represents "delete_repo" scope.
+         */
+        DELETE_REPO,
+        /**
+         * Represents "notifications" scope.
+         */
+        NOTIFICATIONS,
+        /**
+         * Represents "gist" scope.
+         */
+        GIST,
+        /**
+         * Represents "read:repo_hook" scope.
+         */
+        READ_REPO_HOOK,
+        /**
+         * Represents "write:repo_hook" scope.
+         */
+        WRITE_REPO_HOOK,
+        /**
+         * Represents "admin:repo_hook" scope.
+         */
+        ADMIN_REPO_HOOK,
+        /**
+         * Represents "admin:org_hook" scope.
+         */
+        ADMIN_ORG_HOOK,
+        /**
+         * Represents "read:org" scope.
+         */
+        READ_ORG,
+        /**
+         * Represents "write:org" scope.
+         */
+        WRITE_ORG,
+        /**
+         * Represents "admin:org" scope.
+         */
+        ADMIN_ORG,
+        /**
+         * Represents "read:public_key" scope.
+         */
+        READ_PUBLIC_KEY,
+        /**
+         * Represents "write:public_key" scope.
+         */
+        WRITE_PUBLIC_KEY,
+        /**
+         * Represents "admin:public_key" scope.
+         */
+        ADMIN_PUBLIC_KEY;
+    }
+}

--- a/src/test/java/com/jcabi/github/OAuthScope.java
+++ b/src/test/java/com/jcabi/github/OAuthScope.java
@@ -42,7 +42,7 @@ import java.lang.annotation.Target;
  *  to marked down its required scopes. A checker needs to be implemented to
  *  check if the supplied account can fulfill the IT case requirement before
  *  it is run and make the case fail if the required OAuth scopes is not
- *  present. 
+ *  present.
  * @author Jason Wong (super132j@yahoo.com)
  * @version $Id$
  * @see <a href="https://developer.github.com/v3/oauth/#scopes">Github OAuth

--- a/src/test/java/com/jcabi/github/OAuthScope.java
+++ b/src/test/java/com/jcabi/github/OAuthScope.java
@@ -38,7 +38,11 @@ import java.lang.annotation.Target;
 /**
  * Annotates an integration test case to indicate required OAuth scopes to run
  * such case.
- *
+ * @todo #975:30min Now all IT cases are annotated with OAuthScope annotation
+ *  to marked down its required scopes. A checker needs to be implemented to
+ *  check if the supplied account can fulfill the IT case requirement before
+ *  it is run and make the case fail if the required OAuth scopes is not
+ *  present. 
  * @author Jason Wong (super132j@yahoo.com)
  * @version $Id$
  * @see <a href="https://developer.github.com/v3/oauth/#scopes">Github OAuth

--- a/src/test/java/com/jcabi/github/RtAssigneesITCase.java
+++ b/src/test/java/com/jcabi/github/RtAssigneesITCase.java
@@ -40,7 +40,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtAssignees}.
+ * Test case for {@link RtAssignees}. This test requires OAuth scope
+ * "read:org".
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @since 0.7

--- a/src/test/java/com/jcabi/github/RtAssigneesITCase.java
+++ b/src/test/java/com/jcabi/github/RtAssigneesITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
@@ -40,12 +41,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtAssignees}. This test requires OAuth scope
- * "read:org".
+ * Test case for {@link RtAssignees}.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @since 0.7
  */
+@OAuthScope(Scope.READ_ORG)
 public final class RtAssigneesITCase {
     /**
      * Test repos.

--- a/src/test/java/com/jcabi/github/RtBlobsITCase.java
+++ b/src/test/java/com/jcabi/github/RtBlobsITCase.java
@@ -37,7 +37,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtBlobs}.
+ * Test case for {@link RtBlobs}. This test requires OAuth scope "repo".
  * @author Alexander Lukashevich (sanai56967@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiteralsCheck (100 lines)

--- a/src/test/java/com/jcabi/github/RtBlobsITCase.java
+++ b/src/test/java/com/jcabi/github/RtBlobsITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
@@ -37,11 +38,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtBlobs}. This test requires OAuth scope "repo".
+ * Test case for {@link RtBlobs}.
  * @author Alexander Lukashevich (sanai56967@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiteralsCheck (100 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtBlobsITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtContentsITCase.java
+++ b/src/test/java/com/jcabi/github/RtContentsITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.apache.commons.codec.binary.Base64;
@@ -42,12 +43,13 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtContents}. This test requires OAuth scope "repo".
+ * Test case for {@link RtContents}.
  * @author Andres Candal (andres.candal@rollasolution.com)
  * @version $Id$
  * @since 0.8
  * @checkstyle MultipleStringLiterals (500 lines)
  */
+@OAuthScope(Scope.REPO)
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RtContentsITCase {
 

--- a/src/test/java/com/jcabi/github/RtContentsITCase.java
+++ b/src/test/java/com/jcabi/github/RtContentsITCase.java
@@ -42,7 +42,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtContents}.
+ * Test case for {@link RtContents}. This test requires OAuth scope "repo".
  * @author Andres Candal (andres.candal@rollasolution.com)
  * @version $Id$
  * @since 0.8

--- a/src/test/java/com/jcabi/github/RtDeployKeysITCase.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeysITCase.java
@@ -43,7 +43,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtDeployKeys}.
+ * Test case for {@link RtDeployKeys}. This test requires OAuth scope
+ * "admin:public_key".
  * @author Andres Candal (andres.candal@rollasolution.com)
  * @version $Id$
  * @since 0.8

--- a/src/test/java/com/jcabi/github/RtDeployKeysITCase.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeysITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.KeyPair;
 import java.io.ByteArrayOutputStream;
@@ -43,12 +44,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtDeployKeys}. This test requires OAuth scope
- * "admin:public_key".
+ * Test case for {@link RtDeployKeys}.
  * @author Andres Candal (andres.candal@rollasolution.com)
  * @version $Id$
  * @since 0.8
  */
+@OAuthScope(Scope.ADMIN_PUBLIC_KEY)
 public final class RtDeployKeysITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtForksITCase.java
+++ b/src/test/java/com/jcabi/github/RtForksITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
@@ -36,11 +37,12 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtForks}. This test requires OAuth scope "repo".
+ * Test case for {@link RtForks}.
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  */
+@OAuthScope(Scope.REPO)
 public class RtForksITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtForksITCase.java
+++ b/src/test/java/com/jcabi/github/RtForksITCase.java
@@ -36,7 +36,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtForks}.
+ * Test case for {@link RtForks}. This test requires OAuth scope "repo".
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$

--- a/src/test/java/com/jcabi/github/RtGistCommentITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import java.util.Collections;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
@@ -37,13 +38,13 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration test for {@link RtGistComment}. This test requires OAuth scope
- * "gist".
+ * Integration test for {@link RtGistComment}.
  * @author Giang Le (giang@vn-smartsolutions.com)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/gists/comments/">Gist Comments API</a>
  * @since 0.8
  */
+@OAuthScope(Scope.GIST)
 public final class RtGistCommentITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtGistCommentITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentITCase.java
@@ -37,7 +37,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration test for {@link RtGistComment}.
+ * Integration test for {@link RtGistComment}. This test requires OAuth scope
+ * "gist".
  * @author Giang Le (giang@vn-smartsolutions.com)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/gists/comments/">Gist Comments API</a>

--- a/src/test/java/com/jcabi/github/RtGistCommentsITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentsITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -36,13 +37,13 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration test for {@link RtGistComments}. This test requires OAuth scope
- * "gist".
+ * Integration test for {@link RtGistComments}.
  * @author Giang Le (giang@vn-smartsolutions.com)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/gists/comments/">Gist Comments API</a>
  * @since 0.8
  */
+@OAuthScope(Scope.GIST)
 public final class RtGistCommentsITCase {
     /**
      * RtGistComments can create a comment.

--- a/src/test/java/com/jcabi/github/RtGistCommentsITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentsITCase.java
@@ -36,7 +36,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration test for {@link RtGistComments}.
+ * Integration test for {@link RtGistComments}. This test requires OAuth scope
+ * "gist".
  * @author Giang Le (giang@vn-smartsolutions.com)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/gists/comments/">Gist Comments API</a>

--- a/src/test/java/com/jcabi/github/RtGistITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistITCase.java
@@ -36,7 +36,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Gist}.
+ * Integration case for {@link Gist}. This test requires OAuth scope
+ * "gist".
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  */

--- a/src/test/java/com/jcabi/github/RtGistITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -36,11 +37,11 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Gist}. This test requires OAuth scope
- * "gist".
+ * Integration case for {@link Gist}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  */
+@OAuthScope(Scope.GIST)
 public final class RtGistITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtGistsITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistsITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -36,11 +37,11 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Gists}. This test requires OAuth scope
- * "gist".
+ * Integration case for {@link Gists}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  */
+@OAuthScope(Scope.GIST)
 public final class RtGistsITCase {
     /**
      * RtGists can create a gist.

--- a/src/test/java/com/jcabi/github/RtGistsITCase.java
+++ b/src/test/java/com/jcabi/github/RtGistsITCase.java
@@ -36,7 +36,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Gists}.
+ * Integration case for {@link Gists}. This test requires OAuth scope
+ * "gist".
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  */

--- a/src/test/java/com/jcabi/github/RtGithubITCase.java
+++ b/src/test/java/com/jcabi/github/RtGithubITCase.java
@@ -35,7 +35,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Github}.
+ * Integration case for {@link Github}. This test requires OAuth scope
+ * "repo".
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle ClassDataAbstractionCoupling (500 lines)

--- a/src/test/java/com/jcabi/github/RtGithubITCase.java
+++ b/src/test/java/com/jcabi/github/RtGithubITCase.java
@@ -29,18 +29,19 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Github}. This test requires OAuth scope
- * "repo".
+ * Integration case for {@link Github}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtGithubITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtGitignoresITCase.java
+++ b/src/test/java/com/jcabi/github/RtGitignoresITCase.java
@@ -30,14 +30,14 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Immutable;
+import com.jcabi.github.OAuthScope.Scope;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RtGitignores}. This test requires OAuth scope
- * "repo".
+ * Integration case for {@link RtGitignores}.
  *
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
@@ -45,6 +45,7 @@ import org.junit.Test;
  *
  */
 @Immutable
+@OAuthScope(Scope.REPO)
 public final class RtGitignoresITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtGitignoresITCase.java
+++ b/src/test/java/com/jcabi/github/RtGitignoresITCase.java
@@ -36,7 +36,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RtGitignores}.
+ * Integration case for {@link RtGitignores}. This test requires OAuth scope
+ * "repo".
  *
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$

--- a/src/test/java/com/jcabi/github/RtHooksITCase.java
+++ b/src/test/java/com/jcabi/github/RtHooksITCase.java
@@ -38,7 +38,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtHooks}.
+ * Test case for {@link RtHooks}. This test requires OAuth scope
+ * "admin:repo_hook".
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @since 0.8

--- a/src/test/java/com/jcabi/github/RtHooksITCase.java
+++ b/src/test/java/com/jcabi/github/RtHooksITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import java.io.IOException;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
@@ -38,12 +39,12 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtHooks}. This test requires OAuth scope
- * "admin:repo_hook".
+ * Test case for {@link RtHooks}.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @since 0.8
  */
+@OAuthScope(Scope.ADMIN_REPO_HOOK)
 public final class RtHooksITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtIssueITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssueITCase.java
@@ -41,7 +41,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Issue}.
+ * Integration case for {@link Issue}. This test requires OAuth scope "repo".
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle ClassDataAbstractionCoupling (500 lines)

--- a/src/test/java/com/jcabi/github/RtIssueITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssueITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import com.jcabi.log.Logger;
 import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -41,11 +42,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Issue}. This test requires OAuth scope "repo".
+ * Integration case for {@link Issue}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtIssueITCase {
     /**
      * Test repos.

--- a/src/test/java/com/jcabi/github/RtIssueLabelsITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssueLabelsITCase.java
@@ -40,7 +40,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration case for {@link IssueLabels}. This test requires OAuth scope "repo".
+ * Integration case for {@link IssueLabels}. This test requires OAuth scope
+ * "repo".
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.6

--- a/src/test/java/com/jcabi/github/RtIssueLabelsITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssueLabelsITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
@@ -40,13 +41,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration case for {@link IssueLabels}. This test requires OAuth scope
- * "repo".
+ * Integration case for {@link IssueLabels}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.6
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtIssueLabelsITCase {
     /**
      * Test repos.

--- a/src/test/java/com/jcabi/github/RtIssueLabelsITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssueLabelsITCase.java
@@ -40,7 +40,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration case for {@link IssueLabels}.
+ * Integration case for {@link IssueLabels}. This test requires OAuth scope "repo".
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.6

--- a/src/test/java/com/jcabi/github/RtIssuesITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssuesITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import com.jcabi.immutable.ArrayMap;
 import java.util.Date;
 import java.util.EnumMap;
@@ -45,10 +46,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Github}. This test requires OAuth scope "repo".
+ * Integration case for {@link Github}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  */
+@OAuthScope(Scope.REPO)
 public final class RtIssuesITCase {
     /**
      * Test repos.

--- a/src/test/java/com/jcabi/github/RtIssuesITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssuesITCase.java
@@ -45,7 +45,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Github}.
+ * Integration case for {@link Github}. This test requires OAuth scope "repo".
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  */

--- a/src/test/java/com/jcabi/github/RtLabelsITCase.java
+++ b/src/test/java/com/jcabi/github/RtLabelsITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
@@ -40,12 +41,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Labels}. This test requires OAuth scope "repo".
+ * Integration case for {@link Labels}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.6
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtLabelsITCase {
     /**
      * Test repos.

--- a/src/test/java/com/jcabi/github/RtLabelsITCase.java
+++ b/src/test/java/com/jcabi/github/RtLabelsITCase.java
@@ -40,7 +40,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Labels}.
+ * Integration case for {@link Labels}. This test requires OAuth scope "repo".
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.6

--- a/src/test/java/com/jcabi/github/RtLimitsITCase.java
+++ b/src/test/java/com/jcabi/github/RtLimitsITCase.java
@@ -35,7 +35,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RtLimits}.
+ * Integration case for {@link RtLimits}. This test requires OAuth scope
+ * "repo".
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle ClassDataAbstractionCoupling (500 lines)

--- a/src/test/java/com/jcabi/github/RtLimitsITCase.java
+++ b/src/test/java/com/jcabi/github/RtLimitsITCase.java
@@ -29,18 +29,19 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RtLimits}. This test requires OAuth scope
- * "repo".
+ * Integration case for {@link RtLimits}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtLimitsITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtMarkdownITCase.java
+++ b/src/test/java/com/jcabi/github/RtMarkdownITCase.java
@@ -36,7 +36,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RtMarkdown}.
+ * Integration case for {@link RtMarkdown}. This test requires OAuth scope
+ * "repo".
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  */

--- a/src/test/java/com/jcabi/github/RtMarkdownITCase.java
+++ b/src/test/java/com/jcabi/github/RtMarkdownITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -36,11 +37,11 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RtMarkdown}. This test requires OAuth scope
- * "repo".
+ * Integration case for {@link RtMarkdown}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  */
+@OAuthScope(Scope.REPO)
 public final class RtMarkdownITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtMilestonesITCase.java
+++ b/src/test/java/com/jcabi/github/RtMilestonesITCase.java
@@ -42,7 +42,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Milestones}.
+ * Integration case for {@link Milestones}. This test requires OAuth scope
+ * "repo".
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @checkstyle MultipleStringLiteralsCheck (500 lines)

--- a/src/test/java/com/jcabi/github/RtMilestonesITCase.java
+++ b/src/test/java/com/jcabi/github/RtMilestonesITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import com.jcabi.immutable.ArrayMap;
 import java.util.Collections;
 import javax.json.Json;
@@ -42,12 +43,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Milestones}. This test requires OAuth scope
- * "repo".
+ * Integration case for {@link Milestones}.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtMilestonesITCase {
     /**
      * Test repos.

--- a/src/test/java/com/jcabi/github/RtOrganizationsITCase.java
+++ b/src/test/java/com/jcabi/github/RtOrganizationsITCase.java
@@ -35,7 +35,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtOrganizations}.
+ * Test case for {@link RtOrganizations}. This test requires OAuth scope
+ * "read:org".
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>

--- a/src/test/java/com/jcabi/github/RtOrganizationsITCase.java
+++ b/src/test/java/com/jcabi/github/RtOrganizationsITCase.java
@@ -29,19 +29,20 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtOrganizations}. This test requires OAuth scope
- * "read:org".
+ * Test case for {@link RtOrganizations}.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
  * @since 0.7
  */
+@OAuthScope(Scope.READ_ORG)
 public final class RtOrganizationsITCase {
     /**
      * RtOrganizations can get an organization.

--- a/src/test/java/com/jcabi/github/RtPublicKeyITCase.java
+++ b/src/test/java/com/jcabi/github/RtPublicKeyITCase.java
@@ -35,7 +35,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtPublicKey}.
+ * Test case for {@link RtPublicKey}. This test requires OAuth scope
+ * "read:public_key".
  *
  * @author Giang Le (giang@vn-smartsolutions.com)
  * @version $Id$

--- a/src/test/java/com/jcabi/github/RtPublicKeyITCase.java
+++ b/src/test/java/com/jcabi/github/RtPublicKeyITCase.java
@@ -29,18 +29,19 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtPublicKey}. This test requires OAuth scope
- * "read:public_key".
+ * Test case for {@link RtPublicKey}.
  *
  * @author Giang Le (giang@vn-smartsolutions.com)
  * @version $Id$
  */
+@OAuthScope(Scope.READ_PUBLIC_KEY)
 public final class RtPublicKeyITCase {
     /**
      * RtPublicKey can retrieve correctly URI.

--- a/src/test/java/com/jcabi/github/RtPublicKeysITCase.java
+++ b/src/test/java/com/jcabi/github/RtPublicKeysITCase.java
@@ -38,7 +38,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtPublicKeys}.
+ * Test case for {@link RtPublicKeys}. This test requires OAuth scope
+ * "admin:public_key".
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$

--- a/src/test/java/com/jcabi/github/RtPublicKeysITCase.java
+++ b/src/test/java/com/jcabi/github/RtPublicKeysITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.KeyPair;
 import java.io.ByteArrayOutputStream;
@@ -38,12 +39,12 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtPublicKeys}. This test requires OAuth scope
- * "admin:public_key".
+ * Test case for {@link RtPublicKeys}.
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  */
+@OAuthScope(Scope.ADMIN_PUBLIC_KEY)
 public class RtPublicKeysITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtReferencesITCase.java
+++ b/src/test/java/com/jcabi/github/RtReferencesITCase.java
@@ -39,7 +39,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtReferences}.
+ * Test case for {@link RtReferences}. This test requires OAuth scope "repo".
  *
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$

--- a/src/test/java/com/jcabi/github/RtReferencesITCase.java
+++ b/src/test/java/com/jcabi/github/RtReferencesITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -39,12 +40,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtReferences}. This test requires OAuth scope "repo".
- *
+ * Test case for {@link RtReferences}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiterals (500 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtReferencesITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtReleaseAssetITCase.java
+++ b/src/test/java/com/jcabi/github/RtReleaseAssetITCase.java
@@ -40,7 +40,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration test for {@link RtReleaseAsset}.
+ * Integration test for {@link RtReleaseAsset}. This test requires OAuth scope
+ * "repo".
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$

--- a/src/test/java/com/jcabi/github/RtReleaseAssetITCase.java
+++ b/src/test/java/com/jcabi/github/RtReleaseAssetITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
@@ -40,14 +41,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration test for {@link RtReleaseAsset}. This test requires OAuth scope
- * "repo".
+ * Integration test for {@link RtReleaseAsset}.
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 0.8
  * @checkstyle MultipleStringLiterals (300 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtReleaseAssetITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtReleaseAssetsITCase.java
+++ b/src/test/java/com/jcabi/github/RtReleaseAssetsITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -39,13 +40,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration test for {@link RtReleaseAssets}. This test requires OAuth scope
- * "repo".
+ * Integration test for {@link RtReleaseAssets}.
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiteralsCheck (200 lines)
  */
+@OAuthScope(Scope.REPO)
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RtReleaseAssetsITCase {
 

--- a/src/test/java/com/jcabi/github/RtReleaseAssetsITCase.java
+++ b/src/test/java/com/jcabi/github/RtReleaseAssetsITCase.java
@@ -39,7 +39,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration test for {@link RtReleaseAssets}.
+ * Integration test for {@link RtReleaseAssets}. This test requires OAuth scope
+ * "repo".
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$

--- a/src/test/java/com/jcabi/github/RtReleaseITCase.java
+++ b/src/test/java/com/jcabi/github/RtReleaseITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -41,12 +42,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtRelease}. This test requires OAuth scope "repo".
+ * Test case for {@link RtRelease}.
  * @author Haris Osmanagic (haris.osmanagic@gmail.com)
  * @version $Id$
  * @since 0.8
  * @checkstyle MultipleStringLiteralsCheck (200 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtReleaseITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtReleaseITCase.java
+++ b/src/test/java/com/jcabi/github/RtReleaseITCase.java
@@ -41,7 +41,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtRelease}.
+ * Test case for {@link RtRelease}. This test requires OAuth scope "repo".
  * @author Haris Osmanagic (haris.osmanagic@gmail.com)
  * @version $Id$
  * @since 0.8

--- a/src/test/java/com/jcabi/github/RtReleasesITCase.java
+++ b/src/test/java/com/jcabi/github/RtReleasesITCase.java
@@ -39,7 +39,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtReleases}.
+ * Test case for {@link RtReleases}. This test requires OAuth scope "repo".
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @since 0.8

--- a/src/test/java/com/jcabi/github/RtReleasesITCase.java
+++ b/src/test/java/com/jcabi/github/RtReleasesITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -39,11 +40,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtReleases}. This test requires OAuth scope "repo".
+ * Test case for {@link RtReleases}.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @since 0.8
  */
+@OAuthScope(Scope.REPO)
 public final class RtReleasesITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtRepoCommitsITCase.java
+++ b/src/test/java/com/jcabi/github/RtRepoCommitsITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import com.jcabi.immutable.ArrayMap;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -39,8 +40,7 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RepoCommits}. This test requires OAuth scope
- * "repo".
+ * Integration case for {@link RepoCommits}.
  *
  * <p>
  * WARNING: As there is no way to create Commit directly it was decided to use
@@ -50,6 +50,7 @@ import org.junit.Test;
  * @author Alexander Sinyagin (sinyagin.alexander@gmail.com)
  * @version $Id$
  */
+@OAuthScope(Scope.REPO)
 public class RtRepoCommitsITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtRepoCommitsITCase.java
+++ b/src/test/java/com/jcabi/github/RtRepoCommitsITCase.java
@@ -39,7 +39,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RepoCommits}.
+ * Integration case for {@link RepoCommits}. This test requires OAuth scope
+ * "repo".
  *
  * <p>
  * WARNING: As there is no way to create Commit directly it was decided to use

--- a/src/test/java/com/jcabi/github/RtRepoITCase.java
+++ b/src/test/java/com/jcabi/github/RtRepoITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -42,12 +43,13 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Github}. This test requires OAuth scope "repo".
+ * Integration case for {@link Github}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  *  See https://developer.github.com/v3/repos/#list-languages for API details
  */
+@OAuthScope(Scope.REPO)
 public final class RtRepoITCase {
     /**
      * Test repos.

--- a/src/test/java/com/jcabi/github/RtRepoITCase.java
+++ b/src/test/java/com/jcabi/github/RtRepoITCase.java
@@ -42,7 +42,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 /**
- * Integration case for {@link Github}.
+ * Integration case for {@link Github}. This test requires OAuth scope "repo".
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle ClassDataAbstractionCoupling (500 lines)

--- a/src/test/java/com/jcabi/github/RtReposITCase.java
+++ b/src/test/java/com/jcabi/github/RtReposITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -37,12 +38,12 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RtRepos}. This test requires OAuth scope
- * "repo, delete_repo".
+ * Integration case for {@link RtRepos}.
  *
  * @author Andrej Istomin (andrej.istomin.ikeen@gmail.com)
  * @version $Id$
  */
+@OAuthScope({ Scope.REPO, Scope.DELETE_REPO })
 public class RtReposITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtReposITCase.java
+++ b/src/test/java/com/jcabi/github/RtReposITCase.java
@@ -37,7 +37,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RtRepos}.
+ * Integration case for {@link RtRepos}. This test requires OAuth scope
+ * "repo, delete_repo".
  *
  * @author Andrej Istomin (andrej.istomin.ikeen@gmail.com)
  * @version $Id$

--- a/src/test/java/com/jcabi/github/RtSearchITCase.java
+++ b/src/test/java/com/jcabi/github/RtSearchITCase.java
@@ -38,7 +38,7 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtSearch}.
+ * Test case for {@link RtSearch}. This test requires OAuth scope "repo, user".
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$

--- a/src/test/java/com/jcabi/github/RtSearchITCase.java
+++ b/src/test/java/com/jcabi/github/RtSearchITCase.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import java.util.EnumMap;
 import java.util.Iterator;
 import org.hamcrest.MatcherAssert;
@@ -38,12 +39,13 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtSearch}. This test requires OAuth scope "repo, user".
+ * Test case for {@link RtSearch}.
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiterals (140 lines)
  */
+@OAuthScope({ Scope.REPO, Scope.USER })
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RtSearchITCase {
 

--- a/src/test/java/com/jcabi/github/RtStarsITCase.java
+++ b/src/test/java/com/jcabi/github/RtStarsITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -38,12 +39,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration test case for {@link RtStars}. This test requires OAuth scope
- * "repo, user".
+ * Integration test case for {@link RtStars}.
  *
  * @author Artem Nakonechny (wentwogcq@gmail.com)
  * @version $Id$
  */
+@OAuthScope({ Scope.REPO, Scope.USER })
 public final class RtStarsITCase {
     /**
      * Test repos.

--- a/src/test/java/com/jcabi/github/RtStarsITCase.java
+++ b/src/test/java/com/jcabi/github/RtStarsITCase.java
@@ -38,7 +38,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration test case for {@link RtStars}.
+ * Integration test case for {@link RtStars}. This test requires OAuth scope
+ * "repo, user".
  *
  * @author Artem Nakonechny (wentwogcq@gmail.com)
  * @version $Id$

--- a/src/test/java/com/jcabi/github/RtTagITCase.java
+++ b/src/test/java/com/jcabi/github/RtTagITCase.java
@@ -31,6 +31,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -42,11 +43,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration testcase for RtTag. This test requires OAuth scope "repo".
+ * Integration testcase for RtTag.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiterals (500 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtTagITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtTagITCase.java
+++ b/src/test/java/com/jcabi/github/RtTagITCase.java
@@ -42,7 +42,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration testcase for RtTag.
+ * Integration testcase for RtTag. This test requires OAuth scope "repo".
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiterals (500 lines)

--- a/src/test/java/com/jcabi/github/RtTagsITCase.java
+++ b/src/test/java/com/jcabi/github/RtTagsITCase.java
@@ -42,7 +42,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration testcase for RtTags.
+ * Integration testcase for RtTags. This test requires OAuth scope "repo".
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiterals (500 lines)

--- a/src/test/java/com/jcabi/github/RtTagsITCase.java
+++ b/src/test/java/com/jcabi/github/RtTagsITCase.java
@@ -31,6 +31,7 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -42,11 +43,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Integration testcase for RtTags. This test requires OAuth scope "repo".
+ * Integration testcase for RtTags.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiterals (500 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtTagsITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtTreesITCase.java
+++ b/src/test/java/com/jcabi/github/RtTreesITCase.java
@@ -39,7 +39,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtTrees}.
+ * Test case for {@link RtTrees}. This test requires OAuth scope "repo".
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiteralsCheck (100 lines)

--- a/src/test/java/com/jcabi/github/RtTreesITCase.java
+++ b/src/test/java/com/jcabi/github/RtTreesITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
@@ -39,11 +40,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtTrees}. This test requires OAuth scope "repo".
+ * Test case for {@link RtTrees}.
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiteralsCheck (100 lines)
  */
+@OAuthScope(Scope.REPO)
 public final class RtTreesITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtUserEmailsITCase.java
+++ b/src/test/java/com/jcabi/github/RtUserEmailsITCase.java
@@ -36,7 +36,8 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtUserEmails}.
+ * Test case for {@link RtUserEmails}. This test requires OAuth scope
+ * "user:email".
  * @author Alexander Sinyagin (sinyagin.alexander@gmail.com)
  * @version $Id$
  */

--- a/src/test/java/com/jcabi/github/RtUserEmailsITCase.java
+++ b/src/test/java/com/jcabi/github/RtUserEmailsITCase.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -36,11 +37,11 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtUserEmails}. This test requires OAuth scope
- * "user:email".
+ * Test case for {@link RtUserEmails}.
  * @author Alexander Sinyagin (sinyagin.alexander@gmail.com)
  * @version $Id$
  */
+@OAuthScope(Scope.USER_EMAIL)
 public final class RtUserEmailsITCase {
 
     /**

--- a/src/test/java/com/jcabi/github/RtUserITCase.java
+++ b/src/test/java/com/jcabi/github/RtUserITCase.java
@@ -35,7 +35,7 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RtUser}.
+ * Integration case for {@link RtUser}. This test requires OAuth scope "user".
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  */

--- a/src/test/java/com/jcabi/github/RtUserITCase.java
+++ b/src/test/java/com/jcabi/github/RtUserITCase.java
@@ -29,16 +29,18 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Integration case for {@link RtUser}. This test requires OAuth scope "user".
+ * Integration case for {@link RtUser}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  */
+@OAuthScope(Scope.USER)
 public final class RtUserITCase {
 
     /**


### PR DESCRIPTION
For #975 
- Adding OAuth scopes requirement for all integration test cases.
- Updating README.md to list down all required OAuth scopes to run integration tests.