### PR TITLE
Implement "List Branches" API

### DIFF
--- a/src/main/java/com/jcabi/github/Branch.java
+++ b/src/main/java/com/jcabi/github/Branch.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.aspects.Immutable;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Git branch.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ * @see <a href="https://developer.github.com/v3/repos/#list-branches">List Branches API</a>
+ */
+@Immutable
+public interface Branch {
+    /**
+     * The repo we're in.
+     * @return Repo
+     */
+    @NotNull(message = "repo is never NULL")
+    Repo repo();
+
+    /**
+     * Name of the branch.
+     * @return Branch name
+     */
+    @NotNull(message = "name is never NULL")
+    String name();
+
+    /**
+     * Commit that the branch currently points to.
+     * @return Commit the branch currently points to
+     */
+    @NotNull(message = "commit is never NULL")
+    Commit commit();
+}

--- a/src/main/java/com/jcabi/github/Branches.java
+++ b/src/main/java/com/jcabi/github/Branches.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.aspects.Immutable;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Git branches.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ * @see <a href="https://developer.github.com/v3/repos/#list-branches">List Branches API</a>
+ */
+@Immutable
+public interface Branches {
+    /**
+     * Repo which the branches are in.
+     * @return Repo
+     */
+    @NotNull(message = "repository is never NULL")
+    Repo repo();
+
+    /**
+     * Iterate over all branches in the repo.
+     * @return Iterator of branches
+     * @see <a href="https://developer.github.com/v3/repos/#list-branches">List Branches API</a>
+     */
+    @NotNull(message = "iterable is never NULL")
+    Iterable<Branch> iterate();
+}

--- a/src/main/java/com/jcabi/github/Repo.java
+++ b/src/main/java/com/jcabi/github/Repo.java
@@ -45,7 +45,7 @@ import lombok.ToString;
  * @since 0.1
  */
 @Immutable
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({ "PMD.TooManyMethods", "PMD.ExcessivePublicCount" })
 public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
 
     /**
@@ -147,6 +147,14 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
      */
     @NotNull(message = "RepoCommits are never NULL")
     RepoCommits commits();
+
+    /**
+     * Get repository's branches.
+     * @return Branches
+     * @see <a href="https://developer.github.com/v3/repos/#list-branches">List Branches API</a>
+     */
+    @NotNull(message = "Branches are never NULL")
+    Branches branches();
 
     /**
      * Get all contents of the repo.
@@ -344,6 +352,11 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
         @NotNull(message = "commits is never NULL")
         public RepoCommits commits() {
             return this.repo.commits();
+        }
+        @Override
+        @NotNull(message = "branches is never NULL")
+        public Branches branches() {
+            return this.repo.branches();
         }
         @Override
         @NotNull(message = "JSON is never NULL")

--- a/src/main/java/com/jcabi/github/RtBranch.java
+++ b/src/main/java/com/jcabi/github/RtBranch.java
@@ -72,6 +72,8 @@ public final class RtBranch implements Branch {
      * @param repo Repository
      * @param nom Name of branch
      * @param sha Commit SHA hash
+     * @todo #1085:30m Refactor to reduce number of arguments to avoid
+     *  ParameterNumberCheck warning.
      * @checkstyle ParameterNumberCheck (6 lines)
      */
     RtBranch(

--- a/src/main/java/com/jcabi/github/RtBranch.java
+++ b/src/main/java/com/jcabi/github/RtBranch.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.aspects.Immutable;
+import com.jcabi.aspects.Loggable;
+import com.jcabi.http.Request;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Git branch.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ */
+@Immutable
+@Loggable(Loggable.DEBUG)
+@EqualsAndHashCode(of = { "entry", "owner", "nam", "hash" })
+public final class RtBranch implements Branch {
+    /**
+     * API entry point.
+     */
+    private final transient Request entry;
+
+    /**
+     * Repository we're in.
+     */
+    private final transient Repo owner;
+
+    /**
+     * Name of this branch.
+     */
+    private final transient String nam;
+
+    /**
+     * Commit SHA hash.
+     */
+    private final transient String hash;
+
+    /**
+     * Public ctor.
+     * @param req Request
+     * @param repo Repository
+     * @param nom Name of branch
+     * @param sha Commit SHA hash
+     * @checkstyle ParameterNumberCheck (6 lines)
+     */
+    RtBranch(
+        final Request req,
+        final Repo repo,
+        final String nom,
+        final String sha) {
+        this.entry = req;
+        this.owner = repo;
+        this.nam = nom;
+        this.hash = sha;
+    }
+
+    @Override
+    @NotNull(message = "repo is never NULL")
+    public Repo repo() {
+        return this.owner;
+    }
+
+    @Override
+    @NotNull(message = "name is never NULL")
+    public String name() {
+        return this.nam;
+    }
+
+    @Override
+    @NotNull(message = "commit is never NULL")
+    public Commit commit() {
+        return new RtCommit(this.entry, this.owner, this.hash);
+    }
+}

--- a/src/main/java/com/jcabi/github/RtBranches.java
+++ b/src/main/java/com/jcabi/github/RtBranches.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.aspects.Immutable;
+import com.jcabi.aspects.Loggable;
+import com.jcabi.http.Request;
+import javax.json.JsonObject;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Git branches.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ */
+@Immutable
+@Loggable(Loggable.DEBUG)
+@EqualsAndHashCode(of = {"entry", "request", "owner" })
+final class RtBranches implements Branches {
+    /**
+     * RESTful API entry point.
+     */
+    private final transient Request entry;
+
+    /**
+     * RESTful request for the branches.
+     */
+    private final transient Request request;
+
+    /**
+     * Parent repository.
+     */
+    private final transient Repo owner;
+
+    /**
+     * Public ctor.
+     * @param req Entry point of API
+     * @param repo Repository
+     */
+    RtBranches(final Request req, final Repo repo) {
+        this.entry = req;
+        this.owner = repo;
+        final Coordinates coords = repo.coordinates();
+        this.request = this.entry.uri()
+            .path("/repos")
+            .path(coords.user())
+            .path(coords.repo())
+            .path("/branches")
+            .back();
+    }
+
+    @Override
+    @NotNull(message = "repository is never NULL")
+    public Repo repo() {
+        return this.owner;
+    }
+
+    @Override
+    @NotNull(message = "iterable is never NULL")
+    public Iterable<Branch> iterate() {
+        return new RtPagination<Branch>(
+            this.request,
+            new RtValuePagination.Mapping<Branch, JsonObject>() {
+                @Override
+                public Branch map(final JsonObject object) {
+                    return new RtBranch(
+                        RtBranches.this.entry,
+                        RtBranches.this.owner,
+                        object.getString("name"),
+                        object.getJsonObject("commit").getString("sha")
+                    );
+                }
+            }
+        );
+    }
+}

--- a/src/main/java/com/jcabi/github/RtRepo.java
+++ b/src/main/java/com/jcabi/github/RtRepo.java
@@ -240,6 +240,12 @@ final class RtRepo implements Repo {
     }
 
     @Override
+    @NotNull(message = "Branches is never NULL")
+    public Branches branches() {
+        return new RtBranches(this.entry, this);
+    }
+
+    @Override
     @NotNull(message = "JSON is never NULL")
     public JsonObject json() throws IOException {
         return new RtJson(this.request).fetch();

--- a/src/main/java/com/jcabi/github/mock/MkBranch.java
+++ b/src/main/java/com/jcabi/github/mock/MkBranch.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github.mock;
+
+import com.jcabi.github.Branch;
+import com.jcabi.github.Commit;
+import com.jcabi.github.Coordinates;
+import com.jcabi.github.Repo;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Mock Git branch.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ */
+public final class MkBranch implements Branch {
+    /**
+     * Storage.
+     */
+    private final transient MkStorage storage;
+
+    /**
+     * Login of the user logged in.
+     */
+    private final transient String self;
+
+    /**
+     * Repo name.
+     */
+    private final transient Coordinates coords;
+
+    /**
+     * Branch name.
+     */
+    private final transient String nam;
+
+    /**
+     * Commit sha.
+     */
+    private final transient String hash;
+
+    /**
+     * Public ctor.
+     * @param stg Storage
+     * @param login User to login
+     * @param rep Repo
+     * @param nom Branch name
+     * @param sha Commit sha
+     * @checkstyle ParameterNumberCheck (7 lines)
+     */
+    MkBranch(
+        @NotNull(message = "stg can't be NULL") final MkStorage stg,
+        @NotNull(message = "login can't be NULL") final String login,
+        @NotNull(message = "rep can't be NULL") final Coordinates rep,
+        @NotNull(message = "nom can't be NULL") final String nom,
+        @NotNull(message = "sha can't be NULL") final String sha
+    ) {
+        this.storage = stg;
+        this.self = login;
+        this.coords = rep;
+        this.nam = nom;
+        this.hash = sha;
+    }
+
+    @Override
+    @NotNull(message = "repository can't be NULL")
+    public Repo repo() {
+        return new MkRepo(this.storage, this.self, this.coords);
+    }
+
+    @Override
+    @NotNull(message = "name is never NULL")
+    public String name() {
+        return this.nam;
+    }
+
+    @Override
+    @NotNull(message = "commit is never NULL")
+    public Commit commit() {
+        return new MkCommit(this.storage, this.self, this.coords, this.hash);
+    }
+}

--- a/src/main/java/com/jcabi/github/mock/MkBranch.java
+++ b/src/main/java/com/jcabi/github/mock/MkBranch.java
@@ -75,6 +75,8 @@ public final class MkBranch implements Branch {
      * @param rep Repo
      * @param nom Branch name
      * @param sha Commit sha
+     * @todo #1085:30m Refactor this to reduce number of arguments to avoid
+     *  ParameterNumberCheck warning.
      * @checkstyle ParameterNumberCheck (7 lines)
      */
     MkBranch(

--- a/src/main/java/com/jcabi/github/mock/MkBranches.java
+++ b/src/main/java/com/jcabi/github/mock/MkBranches.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github.mock;
+
+import com.jcabi.aspects.Immutable;
+import com.jcabi.aspects.Loggable;
+import com.jcabi.github.Branch;
+import com.jcabi.github.Branches;
+import com.jcabi.github.Coordinates;
+import com.jcabi.github.Repo;
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.xembly.Directives;
+
+/**
+ * Mock Git branches.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ */
+@Immutable
+@Loggable(Loggable.DEBUG)
+@ToString
+@EqualsAndHashCode(of = { "storage", "self", "coords" })
+public final class MkBranches implements Branches {
+    /**
+     * Storage.
+     */
+    private final transient MkStorage storage;
+
+    /**
+     * Login of the user logged in.
+     */
+    private final transient String self;
+
+    /**
+     * Repo name.
+     */
+    private final transient Coordinates coords;
+
+    /**
+     * Public ctor.
+     * @param stg Storage
+     * @param login Username
+     * @param rep Repo
+     * @throws IOException If there is any I/O problem
+     */
+    MkBranches(
+        @NotNull(message = "stg can't be NULL") final MkStorage stg,
+        @NotNull(message = "login can't be NULL") final String login,
+        @NotNull(message = "rep can't be NULL") final Coordinates rep
+    ) throws IOException {
+        this.storage = stg;
+        this.self = login;
+        this.coords = rep;
+        this.storage.apply(
+            new Directives().xpath(
+                String.format(
+                    "/github/repos/repo[@coords='%s']",
+                    this.coords
+                )
+            ).addIf("branches")
+        );
+    }
+
+    @Override
+    @NotNull(message = "repository can't be NULL")
+    public Repo repo() {
+        return new MkRepo(this.storage, this.self, this.coords);
+    }
+
+    @Override
+    @NotNull(message = "Iterable of branches is never NULL")
+    public Iterable<Branch> iterate() {
+        return new MkIterable<Branch>(
+            this.storage,
+            String.format("%s/branch", this.xpath()),
+            new MkIterable.Mapping<Branch>() {
+                @Override
+                public Branch map(final XML xml) {
+                    return new MkBranch(
+                        MkBranches.this.storage,
+                        MkBranches.this.self,
+                        MkBranches.this.coords,
+                        xml.xpath("@name").get(0),
+                        xml.xpath("sha/text()").get(0)
+                    );
+                }
+            }
+        );
+    }
+
+    /**
+     * Creates a new branch.
+     * @param name Name of branch
+     * @param sha Commit SHA
+     * @return New branch
+     * @throws IOException if there is an I/O problem
+     */
+    @NotNull(message = "new branch is never NULL")
+    public Branch create(
+        @NotNull(message = "name cannot be NULL") final String name,
+        @NotNull(message = "sha cannot be NULL") final String sha)
+        throws IOException {
+        final Directives directives = new Directives()
+            .xpath(this.xpath())
+            .add("branch")
+            .attr("name", name)
+            .add("sha").set(sha).up();
+        this.storage.apply(directives);
+        return new MkBranch(this.storage, this.self, this.coords, name, sha);
+    }
+
+    /**
+     * XPath of this element in XML tree.
+     * @return XPath
+     */
+    @NotNull(message = "Xpath is never NULL")
+    private String xpath() {
+        return String.format(
+            "/github/repos/repo[@coords='%s']/branches",
+            this.coords
+        );
+    }
+}

--- a/src/main/java/com/jcabi/github/mock/MkRepo.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepo.java
@@ -32,6 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Assignees;
+import com.jcabi.github.Branches;
 import com.jcabi.github.Collaborators;
 import com.jcabi.github.Contents;
 import com.jcabi.github.Coordinates;
@@ -255,6 +256,18 @@ final class MkRepo implements Repo {
     public RepoCommits commits() {
         try {
             return new MkRepoCommits(
+                this.storage, this.self, this.coordinates()
+            );
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @Override
+    @NotNull(message = "branches is never NULL")
+    public Branches branches() {
+        try {
+            return new MkBranches(
                 this.storage, this.self, this.coordinates()
             );
         } catch (final IOException ex) {

--- a/src/test/java/com/jcabi/github/RtBranchTest.java
+++ b/src/test/java/com/jcabi/github/RtBranchTest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.github.mock.MkGithub;
+import com.jcabi.http.request.FakeRequest;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RtBranch}.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ */
+public final class RtBranchTest {
+    /**
+     * Test username to own test repo.
+     */
+    private static final String REPO_USER = "jack";
+    /**
+     * Test repo name.
+     */
+    private static final String REPO_NAME = "project-42";
+    /**
+     * Test branch name.
+     */
+    private static final String BRANCH_NAME = "topic";
+    /**
+     * Commit SHA for test branch.
+     * @checkstyle LineLengthCheck (2 lines)
+     */
+    private static final String SHA = "b9b0b8a357bbf70f7c9f8ef17160ee31feb508a9";
+
+    /**
+     * RtBranch can fetch its commit.
+     * @throws Exception if a problem occurs.
+     */
+    @Test
+    public void fetchesCommit() throws Exception {
+        final Commit commit = RtBranchTest.newBranch().commit();
+        MatcherAssert.assertThat(commit.sha(), Matchers.equalTo(SHA));
+        final Coordinates coords = commit.repo().coordinates();
+        MatcherAssert.assertThat(coords.user(), Matchers.equalTo(REPO_USER));
+        MatcherAssert.assertThat(coords.repo(), Matchers.equalTo(REPO_NAME));
+    }
+
+    /**
+     * RtBranch can fetch its branch name.
+     * @throws Exception if a problem occurs.
+     */
+    @Test
+    public void fetchesName() throws Exception {
+        MatcherAssert.assertThat(
+            RtBranchTest.newBranch().name(),
+            Matchers.equalTo(BRANCH_NAME)
+        );
+    }
+
+    /**
+     * RtBranch can fetch its repo.
+     * @throws Exception if a problem occurs.
+     */
+    @Test
+    public void fetchesRepo() throws Exception {
+        final Coordinates coords = RtBranchTest.newBranch()
+            .repo().coordinates();
+        MatcherAssert.assertThat(coords.user(), Matchers.equalTo(REPO_USER));
+        MatcherAssert.assertThat(coords.repo(), Matchers.equalTo(REPO_NAME));
+    }
+
+    /**
+     * RtBranch for testing.
+     * @return The RtBranch.
+     * @throws IOException If there is any I/O problem
+     */
+    private static Branch newBranch() throws IOException {
+        return new RtBranch(
+            new FakeRequest(),
+            RtBranchTest.repository(),
+            BRANCH_NAME,
+            SHA
+        );
+    }
+
+    /**
+     * Mock repo for RtBranch creation.
+     * @return The mock repo.
+     * @throws IOException If there is any I/O problem
+     */
+    private static Repo repository() throws IOException {
+        return new MkGithub(REPO_USER).repos().create(
+            new Repos.RepoCreate(REPO_NAME, false)
+        );
+    }
+}

--- a/src/test/java/com/jcabi/github/RtBranchesTest.java
+++ b/src/test/java/com/jcabi/github/RtBranchesTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.github.mock.MkGithub;
+import com.jcabi.http.mock.MkAnswer;
+import com.jcabi.http.mock.MkContainer;
+import com.jcabi.http.mock.MkGrizzlyContainer;
+import com.jcabi.http.request.FakeRequest;
+import com.jcabi.http.request.JdkRequest;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Iterator;
+import javax.json.Json;
+import javax.json.JsonObject;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RtBranches}.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ */
+public final class RtBranchesTest {
+    /**
+     * Name parameter.
+     */
+    private static final String NAME_PARAM = "name";
+    /**
+     * Name of test user to own test repository.
+     */
+    private static final String REPO_USER = "mary";
+    /**
+     * Name of test repository.
+     */
+    private static final String REPO_NAME = "epicness";
+
+    /**
+     * RtBranches can iterate over all branches.
+     * @throws Exception if there is any error
+     */
+    @Test
+    public void iteratesOverBranches() throws Exception {
+        final String firstname = "first";
+        final String firstsha = "a971b1aca044105897297b87b0b0983a54dd5817";
+        final String secondname = "second";
+        final String secondsha = "5d8dc2acf9c95d0d4e8881eebe04c2f0cbb249ff";
+        final MkAnswer answer = new MkAnswer.Simple(
+            HttpURLConnection.HTTP_OK,
+            Json.createArrayBuilder()
+                .add(branch(firstname, firstsha))
+                .add(branch(secondname, secondsha))
+                .build().toString()
+        );
+        final MkContainer container = new MkGrizzlyContainer()
+            .next(answer)
+            .next(answer)
+            .start();
+        final RtBranches branches = new RtBranches(
+            new JdkRequest(container.home()),
+            repository()
+        );
+        MatcherAssert.assertThat(
+            branches.iterate(),
+            Matchers.<Branch>iterableWithSize(2)
+        );
+        final Iterator<Branch> iter = branches.iterate().iterator();
+        final Branch first = iter.next();
+        MatcherAssert.assertThat(first.name(), Matchers.equalTo(firstname));
+        MatcherAssert.assertThat(
+            first.commit().sha(),
+            Matchers.equalTo(firstsha)
+        );
+        final Branch second = iter.next();
+        MatcherAssert.assertThat(second.name(), Matchers.equalTo(secondname));
+        MatcherAssert.assertThat(
+            second.commit().sha(),
+            Matchers.equalTo(secondsha)
+        );
+        container.stop();
+    }
+
+    /**
+     * RtBranches can fetch its repository.
+     * @throws IOException If there is any I/O problem
+     */
+    @Test
+    public void fetchesRepo() throws IOException {
+        final Repo repo = RtBranchesTest.repository();
+        final RtBranches branch = new RtBranches(new FakeRequest(), repo);
+        final Coordinates coords = branch.repo().coordinates();
+        MatcherAssert.assertThat(coords.user(), Matchers.equalTo(REPO_USER));
+        MatcherAssert.assertThat(coords.repo(), Matchers.equalTo(REPO_NAME));
+    }
+
+    /**
+     * Create and return JsonObject to test.
+     * @param name Name of the branch
+     * @param sha Commit SHA of the branch
+     * @return JsonObject
+     * @throws Exception If some problem inside
+     */
+    private static JsonObject branch(final String name, final String sha)
+        throws Exception {
+        return Json.createObjectBuilder()
+            .add(NAME_PARAM, name)
+            .add(
+                "commit",
+                Json.createObjectBuilder()
+                    .add("sha", sha)
+                    // @checkstyle LineLengthCheck (1 line)
+                    .add("url", String.format("https://api.jcabi-github.invalid/repos/user/repo/commits/%s", sha))
+            )
+            .build();
+    }
+
+    /**
+     * Mock repo for RtBranch creation.
+     * @return The mock repo.
+     * @throws IOException If there is any I/O problem
+     */
+    private static Repo repository() throws IOException {
+        return new MkGithub(REPO_USER).repos().create(
+            new Repos.RepoCreate(REPO_NAME, false)
+        );
+    }
+}

--- a/src/test/java/com/jcabi/github/RtRepoTest.java
+++ b/src/test/java/com/jcabi/github/RtRepoTest.java
@@ -111,6 +111,22 @@ public final class RtRepoTest {
     }
 
     /**
+     * RtRepo can fetch its branches.
+     *
+     * @throws Exception if a problem occurs.
+     */
+    @Test
+    public void fetchesBranches() throws Exception {
+        final Repo repo = RtRepoTest.repo(
+            new FakeRequest()
+        );
+        MatcherAssert.assertThat(
+            repo.branches(),
+            Matchers.notNullValue()
+        );
+    }
+
+    /**
      * RtRepo can fetch its pulls.
      *
      * @throws Exception if a problem occurs.

--- a/src/test/java/com/jcabi/github/mock/MkBranchTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkBranchTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github.mock;
+
+import com.jcabi.github.Coordinates;
+import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link MkBranch}.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ */
+public final class MkBranchTest {
+    /**
+     * Test user to own test repository.
+     */
+    private static final String REPO_USER = "jacqueline";
+    /**
+     * Test repository name.
+     */
+    private static final String REPO_NAME = "wonderful";
+
+    /**
+     * MkBranch can fetch its name.
+     * @throws IOException If an I/O problem occurs
+     */
+    @Test
+    public void fetchesName() throws IOException {
+        final String name = "topic";
+        MatcherAssert.assertThat(
+            MkBranchTest.branches()
+                .create(name, "f8dfc75138a2b57859b65cfc45239978081b8de4")
+                .name(),
+            Matchers.equalTo(name)
+        );
+    }
+
+    /**
+     * MkBranch can fetch its commit.
+     * @throws IOException If an I/O problem occurs
+     */
+    @Test
+    public void fetchesCommit() throws IOException {
+        final String sha = "ad1298cac285d601cd66b37ec8989836d7c6e651";
+        MatcherAssert.assertThat(
+            MkBranchTest.branches()
+                .create("feature-branch", sha).commit().sha(),
+            Matchers.equalTo(sha)
+        );
+    }
+
+    /**
+     * MkBranch can fetch its repo.
+     * @throws IOException If an I/O problem occurs
+     */
+    @Test
+    public void fetchesRepo() throws IOException {
+        final Coordinates coords = MkBranchTest.branches()
+            .create("test", "sha")
+            .repo().coordinates();
+        MatcherAssert.assertThat(coords.user(), Matchers.equalTo(REPO_USER));
+        MatcherAssert.assertThat(coords.repo(), Matchers.equalTo(REPO_NAME));
+    }
+
+    /**
+     * Mock repo for MkBranch creation.
+     * @return The mock repo.
+     * @throws IOException If there is any I/O problem
+     */
+    private static Repo repository() throws IOException {
+        return new MkGithub(REPO_USER).repos().create(
+            new Repos.RepoCreate(REPO_NAME, false)
+        );
+    }
+
+    /**
+     * MkBranches for MkBranch creation.
+     * @return MkBranches
+     * @throws IOException If there is any I/O problem
+     */
+    private static MkBranches branches() throws IOException {
+        return (MkBranches) (repository().branches());
+    }
+}

--- a/src/test/java/com/jcabi/github/mock/MkBranchesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkBranchesTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github.mock;
+
+import com.jcabi.github.Branch;
+import com.jcabi.github.Coordinates;
+import com.jcabi.github.Repos;
+import java.io.IOException;
+import java.util.Iterator;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link MkBranches}.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ */
+public final class MkBranchesTest {
+    /**
+     * MkBranches can create a new branch.
+     * @throws IOException if there is any I/O problem
+     */
+    @Test
+    public void createsBranch() throws IOException {
+        final String name = "my-new-feature";
+        final String sha = "590e188e3d52a8da38cf51d3f9bf598bb46911af";
+        final String user = "johnson";
+        final String repo = "my-repo";
+        final Branch branch = ((MkBranches) (new MkGithub(user).repos().create(
+            new Repos.RepoCreate(repo, false)
+        ).branches())).create(name, sha);
+        MatcherAssert.assertThat(branch.name(), Matchers.equalTo(name));
+        MatcherAssert.assertThat(branch.commit().sha(), Matchers.equalTo(sha));
+        final Coordinates coords = branch.commit().repo().coordinates();
+        MatcherAssert.assertThat(coords.user(), Matchers.equalTo(user));
+        MatcherAssert.assertThat(coords.repo(), Matchers.equalTo(repo));
+    }
+
+    /**
+     * MkBranches can iterate over the repo's branches.
+     * @throws IOException if there is any I/O problem
+     */
+    @Test
+    public void iteratesOverBranches() throws IOException {
+        final MkBranches branches = (MkBranches) (new MkGithub().repos().create(
+            new Repos.RepoCreate("test", false)
+        ).branches());
+        final String onename = "narf";
+        final String onesha = "a86da33b875e8ecbaf75cefcf6d8957cbecb654e";
+        branches.create(onename, onesha);
+        final String twoname = "zort";
+        final String twosha = "ba00fa4fe331c59736b87f52f760e1ccfb293b5f";
+        branches.create(twoname, twosha);
+        MatcherAssert.assertThat(
+            branches.iterate(),
+            Matchers.<Branch>iterableWithSize(2)
+        );
+        final Iterator<Branch> iter = branches.iterate().iterator();
+        final Branch one = iter.next();
+        MatcherAssert.assertThat(one.name(), Matchers.equalTo(onename));
+        MatcherAssert.assertThat(one.commit().sha(), Matchers.equalTo(onesha));
+        final Branch two = iter.next();
+        MatcherAssert.assertThat(two.name(), Matchers.equalTo(twoname));
+        MatcherAssert.assertThat(two.commit().sha(), Matchers.equalTo(twosha));
+    }
+}

--- a/src/test/java/com/jcabi/github/mock/MkRepoTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkRepoTest.java
@@ -96,6 +96,22 @@ public final class MkRepoTest {
     }
 
     /**
+     * Repo can fetch its branches.
+     *
+     * @throws IOException if some problem inside
+     */
+    @Test
+    public void fetchBranches() throws IOException {
+        final String user = "testuser";
+        final Repo repo = new MkRepo(
+            new MkStorage.InFile(),
+            user,
+            new Coordinates.Simple(user, "testrepo")
+        );
+        MatcherAssert.assertThat(repo.branches(), Matchers.notNullValue());
+    }
+
+    /**
      * Repo can exponse attributes.
      * @throws Exception If some problem inside
      */


### PR DESCRIPTION
Fixes #1084 by adding `Repo.branches()`, which returns a `Branches`, which has a `Branches.iterate()` method, which returns an iterator of `Branch` objects representing all branches in the repository using the relevant GitHub API endpoint.