### PR TITLE
Add Pull.Smart.author() method

### DIFF
--- a/src/main/java/com/jcabi/github/Pull.java
+++ b/src/main/java/com/jcabi/github/Pull.java
@@ -291,6 +291,20 @@ public interface Pull extends Comparable<Pull>, JsonReadable, JsonPatchable {
         }
 
         /**
+         * Get its author.
+         * @return Author of pull request (who submitted it)
+         * @throws IOException If there is any I/O problem
+         */
+        @NotNull(message = "author is never NULL")
+        public User author() throws IOException {
+            return this.pull.repo().github().users().get(
+                this.jsn.value(
+                    "user", JsonObject.class
+                ).getString("login")
+            );
+        }
+
+        /**
          * Get an issue where the pull request is submitted.
          * @return Issue
          */

--- a/src/main/java/com/jcabi/github/mock/MkPulls.java
+++ b/src/main/java/com/jcabi/github/mock/MkPulls.java
@@ -126,6 +126,9 @@ final class MkPulls implements Pulls {
                     .add("number").set(Integer.toString(number)).up()
                     .add("head").set(head).up()
                     .add("base").set(base).up()
+                    .add("user")
+                    .add("login").set(this.self)
+                    .up()
             );
         } finally {
             this.storage.unlock();

--- a/src/test/java/com/jcabi/github/PullTest.java
+++ b/src/test/java/com/jcabi/github/PullTest.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.mock.MkGithub;
 import java.io.IOException;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
@@ -100,4 +101,30 @@ public final class PullTest {
         );
     }
 
+    /**
+     * Pull.Smart can get the author.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void getsAuthor() throws IOException {
+        final String login = "rose";
+        final Repo repo = Mockito.mock(Repo.class);
+        Mockito.when(repo.github()).thenReturn(new MkGithub());
+        final Pull pull = Mockito.mock(Pull.class);
+        Mockito.when(pull.json()).thenReturn(
+            Json.createObjectBuilder()
+                .add(
+                    "user",
+                    Json.createObjectBuilder()
+                        .add("login", login)
+                        .build()
+                )
+                .build()
+        );
+        Mockito.when(pull.repo()).thenReturn(repo);
+        MatcherAssert.assertThat(
+            new Pull.Smart(pull).author().login(),
+            Matchers.equalTo(login)
+        );
+    }
 }

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -47,6 +47,10 @@ import org.mockito.Mockito;
  * @checkstyle MultipleStringLiterals (500 lines)
  */
 public final class MkPullTest {
+    /**
+     * Login of test user.
+     */
+    private static final String USERNAME = "patrick";
 
     /**
      * MkPull should be able to compare different instances.
@@ -146,6 +150,10 @@ public final class MkPullTest {
             json.getString("base"),
             Matchers.equalTo(base)
         );
+        MatcherAssert.assertThat(
+            json.getJsonObject("user").getString("login"),
+            Matchers.equalTo(USERNAME)
+        );
     }
 
     /**
@@ -172,7 +180,7 @@ public final class MkPullTest {
      * @throws Exception If some problem inside
      */
     private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
+        return new MkGithub(USERNAME).repos().create(
             Json.createObjectBuilder().add("name", "test").build()
         );
     }


### PR DESCRIPTION
Fixes #1087 by adding a `Pull.Smart.author()` method to get the author of a pull request. This method grabs the user from the existing JSON and does not perform any re-fetch of the PR as an Issue.