### PR TITLE
Make Repo.create() use new RepoCreate class for settings

### DIFF
--- a/src/main/java/com/jcabi/github/Repos.java
+++ b/src/main/java/com/jcabi/github/Repos.java
@@ -29,10 +29,16 @@
  */
 package com.jcabi.github;
 
+import com.google.common.base.Optional;
 import com.jcabi.aspects.Immutable;
+import com.jcabi.aspects.Loggable;
 import java.io.IOException;
+import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
 import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Github Repo API.
@@ -42,6 +48,7 @@ import javax.validation.constraints.NotNull;
  * @since 0.5
  * @see <a href="http://developer.github.com/v3/repos/">Repos API</a>
  */
+@SuppressWarnings("PMD.TooManyMethods")
 @Immutable
 public interface Repos {
 
@@ -55,14 +62,15 @@ public interface Repos {
 
     /**
      * Create repository.
-     * @param json Repository creation JSON
+     * @param settings Settings to use for creating the new repository
      * @return Repository
      * @throws IOException If there is any I/O problem
      * @since 0.5
      * @see <a href="http://developer.github.com/v3/repos/#create">Create Repository</a>
      */
     @NotNull(message = "repository is never NULL")
-    Repo create(@NotNull(message = "JSON can't be NULL") JsonObject json)
+    Repo create(@NotNull(message = "new repo settings can't be NULL")
+                RepoCreate settings)
         throws IOException;
 
     /**
@@ -98,4 +106,243 @@ public interface Repos {
     Iterable<Repo> iterate(
         @NotNull(message = "identifier can't be NULL") String identifier
     );
+
+    /**
+     * Settings to use when creating a new GitHub repository.
+     *
+     * @author Chris Rebert (github@rebertia.com)
+     * @version $Id$
+     * @since 0.24
+     * @see <a href="https://developer.github.com/v3/repos/#create">Create Repo API</a>
+     * @todo #1095:30m Add the ability to set the other parameters of
+     *  the repo creation API (has_issues, has_wiki, has_downloads,
+     *  team_id, gitignore_template, license_template).
+     */
+    @SuppressWarnings("PMD.TooManyMethods")
+    @ToString
+    @Loggable(Loggable.DEBUG)
+    @EqualsAndHashCode(of = { "nam", "priv", "descr", "home", "init" })
+    final class RepoCreate implements JsonReadable {
+        /**
+         * Name of the new repo.
+         */
+        private final transient String nam;
+        /**
+         * Privateness of the new repo.
+         */
+        private final transient boolean priv;
+        /**
+         * Description of the new repo.
+         */
+        private final transient String descr;
+        /**
+         * Homepage of the new repo.
+         */
+        private final transient String home;
+        /**
+         * Auto-init the new repo?
+         */
+        private final transient Optional<Boolean> init;
+
+        /**
+         * Public ctor.
+         * @param nme Name of the new repository. Cannot be empty.
+         * @param prvt Will the new repo be private?
+         *  If not, then it will be public.
+         */
+        public RepoCreate(final String nme, final boolean prvt) {
+            this(nme, prvt, "", "", Optional.<Boolean>absent());
+        }
+
+        /**
+         * Private ctor.
+         * @param nme Name of the new repo. Cannot be empty.
+         * @param prvt Will the new repo be private?
+         *  If not, then it will be public.
+         * @param desc Description of the new repo
+         * @param page Homepage of the new repo
+         * @param auto Auto-init the new repo?
+         * @checkstyle ParameterNumberCheck (7 lines)
+         */
+        private RepoCreate(
+            @NotNull(message = "name can't be NULL") final String nme,
+            final boolean prvt,
+            @NotNull(message = "description can't be NULL") final String desc,
+            @NotNull(message = "homepage can't be NULL") final String page,
+            @NotNull(message = "optional itself can't be NULL")
+            final Optional<Boolean> auto) {
+            if (nme.isEmpty()) {
+                throw new IllegalArgumentException("Name cannot be empty!");
+            }
+            this.nam = nme;
+            this.priv = prvt;
+            this.descr = desc;
+            this.home = page;
+            this.init = auto;
+        }
+
+        /**
+         * Name of the new repo.
+         * @return Name
+         */
+        @NotNull(message = "name is never NULL")
+        public String name() {
+            return this.nam;
+        }
+
+        /**
+         * Will the new repo be private? If not, then it will be public.
+         * @return Is this repo private?
+         */
+        public boolean isPrivate() {
+            return this.priv;
+        }
+
+        /**
+         * Description of the new repo.
+         * If it has no description, this is an empty string.
+         * @return Description
+         */
+        @NotNull(message = "description is never NULL")
+        public String description() {
+            return this.descr;
+        }
+
+        /**
+         * Homepage of the new repo.
+         * If it has no homepage, this is an empty string.
+         * @return Homepage
+         */
+        @NotNull(message = "homepage is never NULL")
+        public String homepage() {
+            return this.home;
+        }
+
+        /**
+         * Auto-init the new repo?
+         * If absent, the GitHub default will be used.
+         * @return Optional boolean
+         */
+        @NotNull(message = "optional itself is never NULL")
+        public Optional<Boolean> autoInit() {
+            return this.init;
+        }
+
+        /**
+         * Returns a RepoCreate with the given name.
+         * The name cannot be empty.
+         * @param nme Name of the new repo
+         * @return RepoCreate
+         */
+        @NotNull(message = "renamed settings is never NULL")
+        public RepoCreate withName(
+            @NotNull(message = "name can't be NULL") final String nme
+        ) {
+            return new RepoCreate(
+                nme,
+                this.priv,
+                this.descr,
+                this.home,
+                this.init
+            );
+        }
+
+        /**
+         * Returns a RepoCreate with the given privacy.
+         * @param privacy Privateness of the new repo
+         * @return RepoCreate
+         */
+        @NotNull(message = "new repo settings is never NULL")
+        public RepoCreate withPrivacy(final boolean privacy) {
+            return new RepoCreate(
+                this.nam,
+                privacy,
+                this.descr,
+                this.home,
+                this.init
+            );
+        }
+
+        /**
+         * Returns a RepoCreate with the given description.
+         * @param desc Description
+         * @return RepoCreate
+         */
+        @NotNull(message = "adjusted settings is never NULL")
+        public RepoCreate withDescription(
+            @NotNull(message = "description can't be NULL") final String desc
+        ) {
+            return new RepoCreate(
+                this.nam,
+                this.priv,
+                desc,
+                this.home,
+                this.init
+            );
+        }
+
+        /**
+         * Returns a RepoCreate with the given homepage.
+         * @param page Homepage URL
+         * @return RepoCreate
+         */
+        @NotNull(message = "changed settings is never NULL")
+        public RepoCreate withHomepage(
+            @NotNull(message = "homepage can't be NULL") final String page
+        ) {
+            return new RepoCreate(
+                this.nam,
+                this.priv,
+                this.descr,
+                page,
+                this.init
+            );
+        }
+
+        /**
+         * Returns a RepoCreate with the given auto-init enabledness.
+         * @param auto Auto-init the new repo?
+         * @return RepoCreate
+         */
+        @NotNull(message = "modified settings is never NULL")
+        public RepoCreate withAutoInit(final Optional<Boolean> auto) {
+            return new RepoCreate(
+                this.nam,
+                this.priv,
+                this.descr,
+                this.home,
+                auto
+            );
+        }
+
+        /**
+         * Returns a RepoCreate with the given auto-init enabledness.
+         * @param auto Auto-init the new repo?
+         * @return RepoCreate
+         */
+        @NotNull(message = "new settings is never NULL")
+        public RepoCreate withAutoInit(final boolean auto) {
+            return new RepoCreate(
+                this.nam,
+                this.priv,
+                this.descr,
+                this.home,
+                Optional.of(auto)
+            );
+        }
+
+        @Override
+        @NotNull(message = "JSON is never NULL")
+        public JsonObject json() {
+            JsonObjectBuilder builder = Json.createObjectBuilder()
+                .add("name", this.nam)
+                .add("description", this.descr)
+                .add("homepage", this.home)
+                .add("private", this.priv);
+            if (this.init.isPresent()) {
+                builder = builder.add("auto_init", this.init.get());
+            }
+            return builder.build();
+        }
+    }
 }

--- a/src/main/java/com/jcabi/github/RtRepos.java
+++ b/src/main/java/com/jcabi/github/RtRepos.java
@@ -87,13 +87,13 @@ final class RtRepos implements Repos {
 
     @Override
     @NotNull(message = "repo is never NULL")
-    public Repo create(@NotNull(message = "JSON can't be NULL")
-        final JsonObject json) throws IOException {
+    public Repo create(@NotNull(message = "settings can't be NULL")
+        final RepoCreate settings) throws IOException {
         return this.get(
             new Coordinates.Simple(
                 this.entry.uri().path("user/repos")
                     .back().method(Request.POST)
-                    .body().set(json).back()
+                    .body().set(settings.json()).back()
                     .fetch().as(RestResponse.class)
                     .assertStatus(HttpURLConnection.HTTP_CREATED)
                     .as(JsonResponse.class)

--- a/src/main/java/com/jcabi/github/mock/MkGithub.java
+++ b/src/main/java/com/jcabi/github/mock/MkGithub.java
@@ -226,10 +226,10 @@ public final class MkGithub implements Github {
     @NotNull(message = "Repo is never NULL")
     public Repo randomRepo() throws IOException {
         return this.repos().create(
-            Json.createObjectBuilder().add(
-                "name",
-                RandomStringUtils.randomAlphanumeric(Tv.TEN)
-            ).build()
+            new Repos.RepoCreate(
+                RandomStringUtils.randomAlphanumeric(Tv.TEN),
+                true
+            )
         );
     }
 }

--- a/src/main/java/com/jcabi/github/mock/MkRepos.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepos.java
@@ -38,7 +38,6 @@ import com.jcabi.github.Repos;
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import java.io.IOException;
-import javax.json.JsonObject;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -92,19 +91,22 @@ final class MkRepos implements Repos {
     @Override
     @NotNull(message = "repo is never NULL")
     public Repo create(
-        @NotNull(message = "json can't be NULL") final JsonObject json
+        @NotNull(message = "settings can't be NULL")
+        final RepoCreate settings
     ) throws IOException {
-        final String name = json.getString("name");
-        final Coordinates coords = new Coordinates.Simple(this.self, name);
+        final Coordinates coords = new Coordinates.Simple(
+            this.self,
+            settings.name()
+        );
         this.storage.apply(
             new Directives().xpath(this.xpath()).add("repo")
                 .attr("coords", coords.toString())
-                .add("name").set(name).up()
+                .add("name").set(settings.name()).up()
                 .add("description").set("test repository").up()
                 .add("private").set("false").up()
         );
         final Repo repo = this.get(coords);
-        repo.patch(json);
+        repo.patch(settings.json());
         Logger.info(
             this, "repository %s created by %s",
             coords, this.self

--- a/src/test/java/com/jcabi/github/RepoRule.java
+++ b/src/test/java/com/jcabi/github/RepoRule.java
@@ -32,7 +32,6 @@ package com.jcabi.github;
 import com.jcabi.aspects.Tv;
 import com.jcabi.log.Logger;
 import java.io.IOException;
-import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -64,14 +63,17 @@ public final class RepoRule implements TestRule {
      * @throws IOException If error occurred.
      */
     public Repo repo(final Repos repos) throws IOException {
+        final Repos.RepoCreate settings = new Repos.RepoCreate(
+            "foo",
+            false
+        ).withAutoInit(true);
         Repo repo = null;
         while (repo == null) {
             try {
                 repo = repos.create(
-                    Json.createObjectBuilder()
-                        .add(
-                            "name", RandomStringUtils.randomAlphanumeric(Tv.TEN)
-                        ).add("auto_init", true).build()
+                    settings.withName(
+                        RandomStringUtils.randomAlphanumeric(Tv.TEN)
+                    )
                 );
             } catch (final AssertionError exception) {
                 Logger.warn(

--- a/src/test/java/com/jcabi/github/RtAssigneesITCase.java
+++ b/src/test/java/com/jcabi/github/RtAssigneesITCase.java
@@ -31,7 +31,6 @@ package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
-import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -69,9 +68,10 @@ public final class RtAssigneesITCase {
         final Github github = new RtGithub(key);
         repos = github.repos();
         repo = repos.create(
-            Json.createObjectBuilder().add(
-                "name", RandomStringUtils.randomAlphanumeric(Tv.TEN)
-            ).add("auto_init", true).build()
+            new Repos.RepoCreate(
+                RandomStringUtils.randomAlphanumeric(Tv.TEN),
+                false
+            ).withAutoInit(true)
         );
     }
 

--- a/src/test/java/com/jcabi/github/RtCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtCommentTest.java
@@ -207,7 +207,7 @@ public final class RtCommentTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/RtCommitsTest.java
+++ b/src/test/java/com/jcabi/github/RtCommitsTest.java
@@ -101,7 +101,7 @@ public class RtCommitsTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/RtDeployKeysITCase.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeysITCase.java
@@ -34,7 +34,6 @@ import com.jcabi.github.OAuthScope.Scope;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.KeyPair;
 import java.io.ByteArrayOutputStream;
-import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -73,9 +72,10 @@ public final class RtDeployKeysITCase {
         final Github github = new RtGithub(key);
         repos = github.repos();
         repo = repos.create(
-            Json.createObjectBuilder().add(
-                "name", RandomStringUtils.randomAlphanumeric(Tv.TEN)
-            ).add("auto_init", true).build()
+            new Repos.RepoCreate(
+                RandomStringUtils.randomAlphanumeric(Tv.TEN),
+                false
+            ).withAutoInit(true)
         );
     }
 

--- a/src/test/java/com/jcabi/github/RtIssueITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssueITCase.java
@@ -32,7 +32,6 @@ package com.jcabi.github;
 import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
 import com.jcabi.log.Logger;
-import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -70,9 +69,10 @@ public final class RtIssueITCase {
         final Github github = new RtGithub(key);
         repos = github.repos();
         repo = repos.create(
-            Json.createObjectBuilder().add(
-                "name", RandomStringUtils.randomAlphanumeric(Tv.TEN)
-            ).add("auto_init", true).build()
+            new Repos.RepoCreate(
+                RandomStringUtils.randomAlphanumeric(Tv.TEN),
+                false
+            ).withAutoInit(true)
         );
     }
 

--- a/src/test/java/com/jcabi/github/RtIssueLabelsITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssueLabelsITCase.java
@@ -31,7 +31,6 @@ package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
-import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -70,9 +69,10 @@ public final class RtIssueLabelsITCase {
         final Github github = new RtGithub(key);
         repos = github.repos();
         repo = repos.create(
-            Json.createObjectBuilder().add(
-                "name", RandomStringUtils.randomAlphanumeric(Tv.TEN)
-            ).add("auto_init", true).build()
+            new Repos.RepoCreate(
+                RandomStringUtils.randomAlphanumeric(Tv.TEN),
+                false
+            ).withAutoInit(true)
         );
     }
 

--- a/src/test/java/com/jcabi/github/RtIssuesITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssuesITCase.java
@@ -36,7 +36,6 @@ import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Set;
-import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -73,9 +72,10 @@ public final class RtIssuesITCase {
         final Github github = new RtGithub(key);
         repos = github.repos();
         repo = repos.create(
-            Json.createObjectBuilder().add(
-                "name", RandomStringUtils.randomAlphanumeric(Tv.TEN)
-            ).add("auto_init", true).build()
+            new Repos.RepoCreate(
+                RandomStringUtils.randomAlphanumeric(Tv.TEN),
+                false
+            ).withAutoInit(true)
         );
     }
 

--- a/src/test/java/com/jcabi/github/RtLabelsITCase.java
+++ b/src/test/java/com/jcabi/github/RtLabelsITCase.java
@@ -31,7 +31,6 @@ package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
-import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -70,9 +69,10 @@ public final class RtLabelsITCase {
         final Github github = new RtGithub(key);
         repos = github.repos();
         repo = repos.create(
-            Json.createObjectBuilder().add(
-                "name", RandomStringUtils.randomAlphanumeric(Tv.TEN)
-            ).add("auto_init", true).build()
+            new Repos.RepoCreate(
+                RandomStringUtils.randomAlphanumeric(Tv.TEN),
+                false
+            ).withAutoInit(true)
         );
     }
 

--- a/src/test/java/com/jcabi/github/RtMilestonesITCase.java
+++ b/src/test/java/com/jcabi/github/RtMilestonesITCase.java
@@ -31,6 +31,7 @@ package com.jcabi.github;
 
 import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
+import com.jcabi.http.wire.RetryWire;
 import com.jcabi.immutable.ArrayMap;
 import java.util.Collections;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -67,7 +68,9 @@ public final class RtMilestonesITCase {
     public static void setUp() throws Exception {
         final String key = System.getProperty("failsafe.github.key");
         Assume.assumeThat(key, Matchers.notNullValue());
-        final Github github = new RtGithub(key);
+        final Github github = new RtGithub(
+            new RtGithub(key).entry().through(RetryWire.class)
+        );
         repos = github.repos();
         repo = repos.create(
             new Repos.RepoCreate(

--- a/src/test/java/com/jcabi/github/RtMilestonesITCase.java
+++ b/src/test/java/com/jcabi/github/RtMilestonesITCase.java
@@ -33,7 +33,6 @@ import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
 import com.jcabi.immutable.ArrayMap;
 import java.util.Collections;
-import javax.json.Json;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -71,9 +70,10 @@ public final class RtMilestonesITCase {
         final Github github = new RtGithub(key);
         repos = github.repos();
         repo = repos.create(
-            Json.createObjectBuilder().add(
-                "name", RandomStringUtils.randomAlphanumeric(Tv.TEN)
-            ).add("auto_init", true).build()
+            new Repos.RepoCreate(
+                RandomStringUtils.randomAlphanumeric(Tv.TEN),
+                false
+            ).withAutoInit(true)
         );
     }
 

--- a/src/test/java/com/jcabi/github/RtPullCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtPullCommentTest.java
@@ -147,7 +147,7 @@ public final class RtPullCommentTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub("joe").repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/RtPullCommentsTest.java
+++ b/src/test/java/com/jcabi/github/RtPullCommentsTest.java
@@ -256,7 +256,7 @@ public final class RtPullCommentsTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub("johnny").repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/RtReferenceTest.java
+++ b/src/test/java/com/jcabi/github/RtReferenceTest.java
@@ -163,7 +163,7 @@ public final class RtReferenceTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/RtReferencesTest.java
+++ b/src/test/java/com/jcabi/github/RtReferencesTest.java
@@ -36,7 +36,6 @@ import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.request.ApacheRequest;
 import java.net.HttpURLConnection;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -196,7 +195,7 @@ public final class RtReferencesTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/RtReleaseAssetTest.java
+++ b/src/test/java/com/jcabi/github/RtReleaseAssetTest.java
@@ -189,7 +189,7 @@ public final class RtReleaseAssetTest {
     private static Release release() throws Exception {
         final Release release = Mockito.mock(Release.class);
         final Repo repo = new MkGithub("john").repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
         Mockito.doReturn(repo).when(release).repo();
         Mockito.doReturn(1).when(release).number();

--- a/src/test/java/com/jcabi/github/RtReleaseAssetsTest.java
+++ b/src/test/java/com/jcabi/github/RtReleaseAssetsTest.java
@@ -33,7 +33,6 @@ import com.jcabi.aspects.Tv;
 import com.jcabi.github.mock.MkGithub;
 import com.jcabi.http.request.FakeRequest;
 import java.net.HttpURLConnection;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -110,7 +109,7 @@ public final class RtReleaseAssetsTest {
     private static Release release() throws Exception {
         final Release release = Mockito.mock(Release.class);
         final Repo repo = new MkGithub("john").repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
         Mockito.doReturn(repo).when(release).repo();
         Mockito.doReturn(1).when(release).number();

--- a/src/test/java/com/jcabi/github/RtRepoITCase.java
+++ b/src/test/java/com/jcabi/github/RtRepoITCase.java
@@ -72,9 +72,10 @@ public final class RtRepoITCase {
         final Github github = new RtGithub(key);
         repos = github.repos();
         repo = repos.create(
-            Json.createObjectBuilder().add(
-                "name", RandomStringUtils.randomAlphanumeric(Tv.TEN)
-            ).add("auto_init", true).build()
+            new Repos.RepoCreate(
+                RandomStringUtils.randomAlphanumeric(Tv.TEN),
+                false
+            ).withAutoInit(true)
         );
         repo.contents().create(
             Json.createObjectBuilder()

--- a/src/test/java/com/jcabi/github/RtReposITCase.java
+++ b/src/test/java/com/jcabi/github/RtReposITCase.java
@@ -30,7 +30,6 @@
 package com.jcabi.github;
 
 import com.jcabi.github.OAuthScope.Scope;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
@@ -79,9 +78,7 @@ public class RtReposITCase {
         final Repo repo = this.rule.repo(repos);
         try {
             repos.create(
-                Json.createObjectBuilder().add(
-                    "name", repo.coordinates().repo()
-                ).build()
+                new Repos.RepoCreate(repo.coordinates().repo(), false)
             );
         } finally {
             repos.remove(repo.coordinates());

--- a/src/test/java/com/jcabi/github/RtStatusesTest.java
+++ b/src/test/java/com/jcabi/github/RtStatusesTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
  * @author Marcin Cylke (marcin.cylke+github@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiterals (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public class RtStatusesTest {
 
@@ -96,7 +97,7 @@ public class RtStatusesTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/RtTagTest.java
+++ b/src/test/java/com/jcabi/github/RtTagTest.java
@@ -36,7 +36,6 @@ import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.request.ApacheRequest;
 import java.net.HttpURLConnection;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -81,7 +80,7 @@ public final class RtTagTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/RtTagsTest.java
+++ b/src/test/java/com/jcabi/github/RtTagsTest.java
@@ -105,7 +105,7 @@ public final class RtTagsTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkAssigneesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkAssigneesTest.java
@@ -30,8 +30,8 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import com.jcabi.github.User;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -90,7 +90,7 @@ public final class MkAssigneesTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub("Jonathan").repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkBlobsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkBlobsTest.java
@@ -32,7 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Blob;
 import com.jcabi.github.Blobs;
 import com.jcabi.github.Repo;
-import javax.json.Json;
+import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -80,7 +80,7 @@ public final class MkBlobsTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub("Jonathan").repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkCollaboratorsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCollaboratorsTest.java
@@ -30,8 +30,8 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Collaborators;
+import com.jcabi.github.Repos;
 import com.jcabi.github.User;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -94,7 +94,7 @@ public final class MkCollaboratorsTest {
      */
     private Collaborators collaborators() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         ).collaborators();
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkCommentTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCommentTest.java
@@ -32,9 +32,9 @@ package com.jcabi.github.mock;
 import com.jcabi.aspects.Tv;
 import com.jcabi.github.Comment;
 import com.jcabi.github.Coordinates;
+import com.jcabi.github.Repos;
 import java.net.URL;
 import java.util.Date;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -154,7 +154,7 @@ public final class MkCommentTest {
      */
     private Comment comment(final String text) throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         ).issues().create("hey", "how are you?").comments().post(text);
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkCommentsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCommentsTest.java
@@ -31,7 +31,7 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.Comment;
 import com.jcabi.github.Comments;
-import javax.json.Json;
+import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -65,7 +65,7 @@ public final class MkCommentsTest {
      */
     private Comments comments() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         ).issues().create("hey", "how are you?").comments();
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkCommitsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCommitsTest.java
@@ -32,6 +32,7 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.Commit;
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
@@ -82,7 +83,7 @@ public class MkCommitsTest {
      */
     private Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkContentTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkContentTest.java
@@ -32,6 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Content;
 import com.jcabi.github.Contents;
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import javax.json.Json;
@@ -160,7 +161,7 @@ public final class MkContentTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkContentsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkContentsTest.java
@@ -33,6 +33,7 @@ import com.jcabi.github.Content;
 import com.jcabi.github.Contents;
 import com.jcabi.github.Repo;
 import com.jcabi.github.RepoCommit;
+import com.jcabi.github.Repos;
 import com.jcabi.xml.XML;
 import java.io.IOException;
 import javax.json.Json;
@@ -443,7 +444,7 @@ public final class MkContentsTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 
@@ -457,7 +458,7 @@ public final class MkContentsTest {
         final MkStorage storage) throws IOException {
         final String login = "test";
         return new MkGithub(storage, login).repos().create(
-            Json.createObjectBuilder().add("name", login).build()
+            new Repos.RepoCreate(login, false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkDeployKeysTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkDeployKeysTest.java
@@ -32,7 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.github.DeployKey;
 import com.jcabi.github.DeployKeys;
 import com.jcabi.github.Repo;
-import javax.json.Json;
+import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -124,7 +124,7 @@ public final class MkDeployKeysTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkEventTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkEventTest.java
@@ -33,7 +33,7 @@ import com.google.common.base.Optional;
 import com.jcabi.github.Event;
 import com.jcabi.github.Label;
 import com.jcabi.github.Repo;
-import javax.json.Json;
+import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -45,11 +45,6 @@ import org.junit.Test;
  */
 public final class MkEventTest {
     /**
-     * Name of field for name of repository.
-     */
-    private static final String NAME = "name";
-
-    /**
      * Can get created_at value from json object.
      * @throws Exception If some problem inside
      */
@@ -58,7 +53,7 @@ public final class MkEventTest {
         final MkStorage storage = new MkStorage.InFile();
         final String user = "test_user";
         final Repo repo = new MkGithub(storage, user).repos().create(
-            Json.createObjectBuilder().add(NAME, "test").build()
+            new Repos.RepoCreate("test", false)
         );
         final MkIssueEvents events = (MkIssueEvents) (repo.issueEvents());
         final int eventnum = events.create(
@@ -88,7 +83,7 @@ public final class MkEventTest {
         final MkStorage storage = new MkStorage.InFile();
         final String user = "ken";
         final Repo repo = new MkGithub(storage, user).repos().create(
-            Json.createObjectBuilder().add(NAME, "foo").build()
+            new Repos.RepoCreate("foo", false)
         );
         final MkIssueEvents events = (MkIssueEvents) (repo.issueEvents());
         final String label = "problem";
@@ -120,7 +115,7 @@ public final class MkEventTest {
         final MkStorage storage = new MkStorage.InFile();
         final String user = "barbie";
         final Repo repo = new MkGithub(storage, user).repos().create(
-            Json.createObjectBuilder().add(NAME, "bar").build()
+            new Repos.RepoCreate("bar", false)
         );
         final int num = ((MkIssueEvents) (repo.issueEvents())).create(
             Event.LABELED,

--- a/src/test/java/com/jcabi/github/mock/MkForkTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkForkTest.java
@@ -31,7 +31,7 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.Fork;
 import com.jcabi.github.Forks;
-import javax.json.Json;
+import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -64,7 +64,7 @@ public final class MkForkTest {
      */
     private static Forks forks() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         ).forks();
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkForksTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkForksTest.java
@@ -32,7 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Fork;
 import com.jcabi.github.Repo;
-import javax.json.Json;
+import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
@@ -91,7 +91,7 @@ public final class MkForksTest {
      */
     private Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkGitTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkGitTest.java
@@ -30,7 +30,7 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Repo;
-import javax.json.Json;
+import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -76,7 +76,7 @@ public final class MkGitTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkGithubTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkGithubTest.java
@@ -34,6 +34,7 @@ import com.jcabi.github.Comment;
 import com.jcabi.github.Github;
 import com.jcabi.github.Issue;
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import com.jcabi.github.User;
 import com.jcabi.immutable.ArrayMap;
 import com.jcabi.log.VerboseCallable;
@@ -42,8 +43,6 @@ import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import javax.json.Json;
-import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -54,6 +53,14 @@ import org.junit.Test;
  * @version $Id$
  */
 public final class MkGithubTest {
+    /**
+     * Settings to use when creating temporary repos.
+     */
+    private static final Repos.RepoCreate NEW_REPO_SETTINGS =
+        new Repos.RepoCreate(
+            "test",
+            false
+        );
 
     /**
      * MkGithub can work.
@@ -61,7 +68,7 @@ public final class MkGithubTest {
      */
     @Test
     public void worksWithMockedData() throws Exception {
-        final Repo repo = new MkGithub().repos().create(MkGithubTest.json());
+        final Repo repo = new MkGithub().repos().create(NEW_REPO_SETTINGS);
         final Issue issue = repo.issues().create("hey", "how are you?");
         final Comment comment = issue.comments().post("hey, works?");
         MatcherAssert.assertThat(
@@ -89,7 +96,7 @@ public final class MkGithubTest {
     public void canRelogin() throws Exception {
         final String login = "mark";
         final MkGithub github = new MkGithub();
-        final Repo repo = github.repos().create(MkGithubTest.json());
+        final Repo repo = github.repos().create(NEW_REPO_SETTINGS);
         final Issue issue = repo.issues().create("title", "Found a bug");
         final Comment comment = github
             .relogin(login)
@@ -169,16 +176,5 @@ public final class MkGithubTest {
             repo.issues().iterate(new ArrayMap<String, String>()),
             Matchers.<Issue>iterableWithSize(threads)
         );
-    }
-
-    /**
-     * Create and return JsonObject to test.
-     * @return JsonObject
-     * @throws Exception If some problem inside
-     */
-    private static JsonObject json() throws Exception {
-        return Json.createObjectBuilder()
-            .add("name", "test")
-            .build();
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkHooksTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkHooksTest.java
@@ -32,8 +32,8 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Hook;
 import com.jcabi.github.Hooks;
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import java.util.Collections;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -142,7 +142,7 @@ public final class MkHooksTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkIssueEventsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssueEventsTest.java
@@ -32,8 +32,8 @@ package com.jcabi.github.mock;
 import com.google.common.base.Optional;
 import com.jcabi.aspects.Tv;
 import com.jcabi.github.Event;
+import com.jcabi.github.Repos;
 import java.util.Iterator;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -45,10 +45,6 @@ import org.junit.Test;
  * @since 0.23
  */
 public final class MkIssueEventsTest {
-    /**
-     * Name string used in various APIs.
-     */
-    private static final String NAME = "name";
     /**
      * Absent optional string.
      */
@@ -192,9 +188,7 @@ public final class MkIssueEventsTest {
     private MkIssueEvents issueEvents() throws Exception {
         return MkIssueEvents.class.cast(
             new MkGithub().repos().create(
-                Json.createObjectBuilder()
-                    .add(MkIssueEventsTest.NAME, "test")
-                    .build()
+                new Repos.RepoCreate("test", false)
             ).issueEvents()
         );
     }

--- a/src/test/java/com/jcabi/github/mock/MkIssueLabelsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssueLabelsTest.java
@@ -34,9 +34,9 @@ import com.jcabi.github.Issue;
 import com.jcabi.github.IssueLabels;
 import com.jcabi.github.Label;
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import java.util.Collections;
 import java.util.Iterator;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -47,11 +47,6 @@ import org.junit.Test;
  * @version $Id$
  */
 public final class MkIssueLabelsTest {
-    /**
-     * Name string constant.
-     */
-    private static final String NAME = "name";
-
     /**
      * Username of actor.
      */
@@ -170,7 +165,7 @@ public final class MkIssueLabelsTest {
      */
     private Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add(NAME, "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkIssueTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssueTest.java
@@ -35,9 +35,9 @@ import com.jcabi.github.Github;
 import com.jcabi.github.Issue;
 import com.jcabi.github.Label;
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import java.util.Collections;
 import java.util.Iterator;
-import javax.json.Json;
 import org.hamcrest.CustomMatcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -49,6 +49,7 @@ import org.mockito.Mockito;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle MultipleStringLiterals (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class MkIssueTest {
@@ -197,7 +198,7 @@ public final class MkIssueTest {
         final MkGithub first = new MkGithub("first");
         final Github second = first.relogin("second");
         final Repo repo = first.repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
         final int number = second.repos()
             .get(repo.coordinates())
@@ -308,7 +309,7 @@ public final class MkIssueTest {
      */
     private Issue issue() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         ).issues().create("hey", "how are you?");
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkIssuesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssuesTest.java
@@ -33,8 +33,8 @@ import com.jcabi.aspects.Tv;
 import com.jcabi.github.Github;
 import com.jcabi.github.Issue;
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import com.jcabi.immutable.ArrayMap;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -87,7 +87,7 @@ public final class MkIssuesTest {
     public void createsMultipleIssues() throws Exception {
         final Github github = new MkGithub("jeff");
         final Repo repo = github.repos().create(
-            Json.createObjectBuilder().add("name", "test-3").build()
+            new Repos.RepoCreate("test-3", false)
         );
         for (int idx = 1; idx < Tv.TEN; ++idx) {
             repo.issues().create("title", "body");
@@ -101,7 +101,7 @@ public final class MkIssuesTest {
      */
     private Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkLabelsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkLabelsTest.java
@@ -33,8 +33,8 @@ import com.jcabi.github.Issue;
 import com.jcabi.github.Label;
 import com.jcabi.github.Labels;
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import java.util.Collections;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -106,7 +106,7 @@ public final class MkLabelsTest {
      */
     private Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkMilestonesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkMilestonesTest.java
@@ -32,8 +32,8 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Milestone;
 import com.jcabi.github.Milestones;
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import com.jcabi.immutable.ArrayMap;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -124,7 +124,7 @@ public final class MkMilestonesTest {
      */
     private Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkPullCommentTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullCommentTest.java
@@ -30,6 +30,7 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.PullComment;
+import com.jcabi.github.Repos;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -80,7 +81,7 @@ public final class MkPullCommentTest {
     private static PullComment comment() throws Exception {
         return new MkGithub()
             .repos()
-            .create(Json.createObjectBuilder().add("name", "test").build())
+            .create(new Repos.RepoCreate("test", false))
             .pulls()
             .create("hello", "", "")
             .comments()

--- a/src/test/java/com/jcabi/github/mock/MkPullCommentsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullCommentsTest.java
@@ -32,10 +32,10 @@ package com.jcabi.github.mock;
 import com.jcabi.github.PullComment;
 import com.jcabi.github.PullComments;
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -208,7 +208,7 @@ public final class MkPullCommentsTest {
     private PullComments comments() throws IOException {
         return new MkGithub().repos().create(
             // @checkstyle MultipleStringLiteralsCheck (3 lines)
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         ).pulls().create("hello", "", "").comments();
     }
 
@@ -222,7 +222,7 @@ public final class MkPullCommentsTest {
         final MkStorage storage) throws IOException {
         final String login = "test";
         return new MkGithub(storage, login).repos().create(
-            Json.createObjectBuilder().add("name", login).build()
+            new Repos.RepoCreate(login, false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -32,6 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Pull;
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
@@ -181,7 +182,7 @@ public final class MkPullTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub(USERNAME).repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkPullsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullsTest.java
@@ -32,7 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Issue;
 import com.jcabi.github.Pull;
 import com.jcabi.github.Repo;
-import javax.json.Json;
+import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
@@ -92,7 +92,7 @@ public final class MkPullsTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkReferenceTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReferenceTest.java
@@ -31,6 +31,7 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Reference;
+import com.jcabi.github.Repos;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
@@ -111,7 +112,7 @@ public final class MkReferenceTest {
      */
     private Reference reference() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         ).git().references().create("refs/tags/hello", "testsha");
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkReferencesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReferencesTest.java
@@ -33,7 +33,7 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Reference;
 import com.jcabi.github.References;
 import com.jcabi.github.Repo;
-import javax.json.Json;
+import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -165,7 +165,7 @@ public final class MkReferencesTest {
      */
     private Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkReleaseAssetTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseAssetTest.java
@@ -32,6 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Release;
 import com.jcabi.github.ReleaseAsset;
 import com.jcabi.github.ReleaseAssets;
+import com.jcabi.github.Repos;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import javax.json.Json;
@@ -210,7 +211,7 @@ public final class MkReleaseAssetTest {
      */
     private static Release release() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         ).releases().create("v1.0");
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkReleaseAssetsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseAssetsTest.java
@@ -32,7 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Release;
 import com.jcabi.github.ReleaseAsset;
 import com.jcabi.github.ReleaseAssets;
-import javax.json.Json;
+import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -119,7 +119,7 @@ public final class MkReleaseAssetsTest {
      */
     private static Release release() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         ).releases().create("v1.0");
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkReleaseTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseTest.java
@@ -32,8 +32,8 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Github;
 import com.jcabi.github.Release;
 import com.jcabi.github.Releases;
+import com.jcabi.github.Repos;
 import java.io.IOException;
-import javax.json.Json;
 import javax.json.JsonString;
 import javax.json.JsonValue;
 import org.hamcrest.MatcherAssert;
@@ -48,12 +48,6 @@ import org.junit.Test;
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class MkReleaseTest {
-
-    /**
-     * NAME constant.
-     */
-    private static final String NAME = "name";
-
     /**
      * Check if a release can be deleted.
      * @throws Exception If any problems occur.
@@ -163,7 +157,7 @@ public final class MkReleaseTest {
         final Release.Smart smart = new Release.Smart(release);
         MatcherAssert.assertThat(
             smart.name(),
-            Matchers.equalTo(this.value(release, MkReleaseTest.NAME))
+            Matchers.equalTo(this.value(release, "name"))
         );
     }
 
@@ -246,7 +240,7 @@ public final class MkReleaseTest {
      */
     private static Releases releases() throws IOException {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add(MkReleaseTest.NAME, "test").build()
+            new Repos.RepoCreate("test", false)
         ).releases();
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkReleasesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleasesTest.java
@@ -32,7 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Release;
 import com.jcabi.github.Releases;
 import com.jcabi.github.Repo;
-import javax.json.Json;
+import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -159,7 +159,7 @@ public final class MkReleasesTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkRepoTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkRepoTest.java
@@ -37,7 +37,6 @@ import com.jcabi.github.Milestones;
 import com.jcabi.github.Repo;
 import com.jcabi.github.Repos;
 import java.io.IOException;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -58,7 +57,7 @@ public final class MkRepoTest {
     public void works() throws Exception {
         final Repos repos = new MkRepos(new MkStorage.InFile(), "jeff");
         final Repo repo = repos.create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
         MatcherAssert.assertThat(
             repo.coordinates(),
@@ -74,7 +73,7 @@ public final class MkRepoTest {
     public void returnsMkMilestones() throws Exception {
         final Repos repos = new MkRepos(new MkStorage.InFile(), "jeff");
         final Repo repo = repos.create(
-            Json.createObjectBuilder().add("name", "test1").build()
+            new Repos.RepoCreate("test1", false)
         );
         final Milestones milestones = repo.milestones();
         MatcherAssert.assertThat(milestones, Matchers.notNullValue());

--- a/src/test/java/com/jcabi/github/mock/MkReposTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReposTest.java
@@ -31,7 +31,6 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.Repo;
 import com.jcabi.github.Repos;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -126,10 +125,7 @@ public final class MkReposTest {
     private static Repo repo(final Repos repos, final String name,
         final String desc) throws Exception {
         return repos.create(
-            Json.createObjectBuilder()
-                .add("name", name)
-                .add("description", desc)
-                .build()
+            new Repos.RepoCreate(name, false).withDescription(desc)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkSearchTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkSearchTest.java
@@ -30,9 +30,9 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import com.jcabi.github.Search;
 import java.util.EnumMap;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -56,7 +56,7 @@ public final class MkSearchTest {
     public void canSearchForRepos() throws Exception {
         final MkGithub github = new MkGithub();
         github.repos().create(
-            Json.createObjectBuilder().add("name", "TestRepo").build()
+            new Repos.RepoCreate("TestRepo", false)
         );
         MatcherAssert.assertThat(
             github.search().repos("TestRepo", "updated", Search.Order.ASC),
@@ -73,7 +73,7 @@ public final class MkSearchTest {
     public void canSearchForIssues() throws Exception {
         final MkGithub github = new MkGithub();
         final Repo repo = github.repos().create(
-            Json.createObjectBuilder().add("name", "TestIssues").build()
+            new Repos.RepoCreate("TestIssues", false)
         );
         repo.issues().create("test issue", "TheTest");
         MatcherAssert.assertThat(
@@ -111,7 +111,7 @@ public final class MkSearchTest {
     public void canSearchForCodes() throws Exception {
         final MkGithub github = new MkGithub("jeff");
         github.repos().create(
-            Json.createObjectBuilder().add("name", "TestCode").build()
+            new Repos.RepoCreate("TestCode", false)
         );
         MatcherAssert.assertThat(
             github.search().codes("jeff", "repositories", Search.Order.DESC),

--- a/src/test/java/com/jcabi/github/mock/MkStarsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkStarsTest.java
@@ -31,8 +31,8 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import com.jcabi.github.Stars;
-import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -80,7 +80,7 @@ public class MkStarsTest {
      */
     private Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkTagTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkTagTest.java
@@ -30,6 +30,7 @@
 
 package com.jcabi.github.mock;
 
+import com.jcabi.github.Repos;
 import com.jcabi.github.Tag;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -67,7 +68,7 @@ public final class MkTagTest {
             .add("sha", "abcsha12").add("message", "test tag")
             .add("name", "v.0.1").build();
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         ).git().tags().create(json);
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkTagsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkTagsTest.java
@@ -31,6 +31,7 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
@@ -70,7 +71,7 @@ public final class MkTagsTest {
      */
     private Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkTreeTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkTreeTest.java
@@ -30,6 +30,7 @@
 
 package com.jcabi.github.mock;
 
+import com.jcabi.github.Repos;
 import com.jcabi.github.Tree;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -72,7 +73,7 @@ public final class MkTreeTest {
             )
         ).build();
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         ).git().trees().create(json);
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkTreesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkTreesTest.java
@@ -31,6 +31,7 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Repo;
+import com.jcabi.github.Repos;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
@@ -105,7 +106,7 @@ public final class MkTreesTest {
      */
     private Repo repo() throws Exception {
         return new MkGithub().repos().create(
-            Json.createObjectBuilder().add("name", "test").build()
+            new Repos.RepoCreate("test", false)
         );
     }
 


### PR DESCRIPTION
Fixes #1094 by adding a new parameter class (`NewRepoSettings`) and changing `Repo.create()` to accept an instance of this class as its argument rather than a raw `JsonObject`.

This requires updating a lot of test code since testcases create lots of temporary repos.