### PR TITLE
Refactor/consolidate temporary repo creation in tests

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkGithub.java
+++ b/src/main/java/com/jcabi/github/mock/MkGithub.java
@@ -227,7 +227,7 @@ public final class MkGithub implements Github {
     public Repo randomRepo() throws IOException {
         return this.repos().create(
             new Repos.RepoCreate(
-                RandomStringUtils.randomAlphanumeric(Tv.TEN),
+                RandomStringUtils.randomAlphanumeric(Tv.TWENTY),
                 true
             )
         );

--- a/src/test/java/com/jcabi/github/RepoRule.java
+++ b/src/test/java/com/jcabi/github/RepoRule.java
@@ -72,7 +72,7 @@ public final class RepoRule implements TestRule {
             try {
                 repo = repos.create(
                     settings.withName(
-                        RandomStringUtils.randomAlphanumeric(Tv.TEN)
+                        RandomStringUtils.randomAlphanumeric(Tv.TWENTY)
                     )
                 );
             } catch (final AssertionError exception) {

--- a/src/test/java/com/jcabi/github/RtAssigneesITCase.java
+++ b/src/test/java/com/jcabi/github/RtAssigneesITCase.java
@@ -67,12 +67,7 @@ public final class RtAssigneesITCase {
         Assume.assumeThat(key, Matchers.notNullValue());
         final Github github = new RtGithub(key);
         repos = github.repos();
-        repo = repos.create(
-            new Repos.RepoCreate(
-                RandomStringUtils.randomAlphanumeric(Tv.TEN),
-                false
-            ).withAutoInit(true)
-        );
+        repo = new RepoRule().repo(repos);
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtBranchTest.java
+++ b/src/test/java/com/jcabi/github/RtBranchTest.java
@@ -44,14 +44,6 @@ import org.junit.Test;
  */
 public final class RtBranchTest {
     /**
-     * Test username to own test repo.
-     */
-    private static final String REPO_USER = "jack";
-    /**
-     * Test repo name.
-     */
-    private static final String REPO_NAME = "project-42";
-    /**
      * Test branch name.
      */
     private static final String BRANCH_NAME = "topic";
@@ -67,11 +59,18 @@ public final class RtBranchTest {
      */
     @Test
     public void fetchesCommit() throws Exception {
-        final Commit commit = RtBranchTest.newBranch().commit();
+        final Repo repo = new MkGithub().randomRepo();
+        final Commit commit = RtBranchTest.newBranch(repo).commit();
         MatcherAssert.assertThat(commit.sha(), Matchers.equalTo(SHA));
         final Coordinates coords = commit.repo().coordinates();
-        MatcherAssert.assertThat(coords.user(), Matchers.equalTo(REPO_USER));
-        MatcherAssert.assertThat(coords.repo(), Matchers.equalTo(REPO_NAME));
+        MatcherAssert.assertThat(
+            coords.user(),
+            Matchers.equalTo(repo.coordinates().user())
+        );
+        MatcherAssert.assertThat(
+            coords.repo(),
+            Matchers.equalTo(repo.coordinates().repo())
+        );
     }
 
     /**
@@ -81,7 +80,7 @@ public final class RtBranchTest {
     @Test
     public void fetchesName() throws Exception {
         MatcherAssert.assertThat(
-            RtBranchTest.newBranch().name(),
+            RtBranchTest.newBranch(new MkGithub().randomRepo()).name(),
             Matchers.equalTo(BRANCH_NAME)
         );
     }
@@ -92,34 +91,31 @@ public final class RtBranchTest {
      */
     @Test
     public void fetchesRepo() throws Exception {
-        final Coordinates coords = RtBranchTest.newBranch()
+        final Repo repo = new MkGithub().randomRepo();
+        final Coordinates coords = RtBranchTest.newBranch(repo)
             .repo().coordinates();
-        MatcherAssert.assertThat(coords.user(), Matchers.equalTo(REPO_USER));
-        MatcherAssert.assertThat(coords.repo(), Matchers.equalTo(REPO_NAME));
-    }
-
-    /**
-     * RtBranch for testing.
-     * @return The RtBranch.
-     * @throws IOException If there is any I/O problem
-     */
-    private static Branch newBranch() throws IOException {
-        return new RtBranch(
-            new FakeRequest(),
-            RtBranchTest.repository(),
-            BRANCH_NAME,
-            SHA
+        MatcherAssert.assertThat(
+            coords.user(),
+            Matchers.equalTo(repo.coordinates().user())
+        );
+        MatcherAssert.assertThat(
+            coords.repo(),
+            Matchers.equalTo(repo.coordinates().repo())
         );
     }
 
     /**
-     * Mock repo for RtBranch creation.
-     * @return The mock repo.
+     * RtBranch for testing.
+     * @param repo Repository to create the branch in
+     * @return The RtBranch.
      * @throws IOException If there is any I/O problem
      */
-    private static Repo repository() throws IOException {
-        return new MkGithub(REPO_USER).repos().create(
-            new Repos.RepoCreate(REPO_NAME, false)
+    private static Branch newBranch(final Repo repo) throws IOException {
+        return new RtBranch(
+            new FakeRequest(),
+            repo,
+            BRANCH_NAME,
+            SHA
         );
     }
 }

--- a/src/test/java/com/jcabi/github/RtBranchesTest.java
+++ b/src/test/java/com/jcabi/github/RtBranchesTest.java
@@ -52,19 +52,6 @@ import org.junit.Test;
  */
 public final class RtBranchesTest {
     /**
-     * Name parameter.
-     */
-    private static final String NAME_PARAM = "name";
-    /**
-     * Name of test user to own test repository.
-     */
-    private static final String REPO_USER = "mary";
-    /**
-     * Name of test repository.
-     */
-    private static final String REPO_NAME = "epicness";
-
-    /**
      * RtBranches can iterate over all branches.
      * @throws Exception if there is any error
      */
@@ -87,7 +74,7 @@ public final class RtBranchesTest {
             .start();
         final RtBranches branches = new RtBranches(
             new JdkRequest(container.home()),
-            repository()
+            new MkGithub().randomRepo()
         );
         MatcherAssert.assertThat(
             branches.iterate(),
@@ -115,11 +102,17 @@ public final class RtBranchesTest {
      */
     @Test
     public void fetchesRepo() throws IOException {
-        final Repo repo = RtBranchesTest.repository();
+        final Repo repo = new MkGithub().randomRepo();
         final RtBranches branch = new RtBranches(new FakeRequest(), repo);
         final Coordinates coords = branch.repo().coordinates();
-        MatcherAssert.assertThat(coords.user(), Matchers.equalTo(REPO_USER));
-        MatcherAssert.assertThat(coords.repo(), Matchers.equalTo(REPO_NAME));
+        MatcherAssert.assertThat(
+            coords.user(),
+            Matchers.equalTo(repo.coordinates().user())
+        );
+        MatcherAssert.assertThat(
+            coords.repo(),
+            Matchers.equalTo(repo.coordinates().repo())
+        );
     }
 
     /**
@@ -132,7 +125,7 @@ public final class RtBranchesTest {
     private static JsonObject branch(final String name, final String sha)
         throws Exception {
         return Json.createObjectBuilder()
-            .add(NAME_PARAM, name)
+            .add("name", name)
             .add(
                 "commit",
                 Json.createObjectBuilder()
@@ -141,16 +134,5 @@ public final class RtBranchesTest {
                     .add("url", String.format("https://api.jcabi-github.invalid/repos/user/repo/commits/%s", sha))
             )
             .build();
-    }
-
-    /**
-     * Mock repo for RtBranch creation.
-     * @return The mock repo.
-     * @throws IOException If there is any I/O problem
-     */
-    private static Repo repository() throws IOException {
-        return new MkGithub(REPO_USER).repos().create(
-            new Repos.RepoCreate(REPO_NAME, false)
-        );
     }
 }

--- a/src/test/java/com/jcabi/github/RtCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtCommentTest.java
@@ -59,7 +59,7 @@ public final class RtCommentTest {
      */
     @Test
     public void canCompareInstances() throws Exception {
-        final Repo repo = repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("title", "body");
         final RtComment less = new RtComment(new FakeRequest(), issue, 1);
         final RtComment greater = new RtComment(new FakeRequest(), issue, 2);
@@ -77,7 +77,7 @@ public final class RtCommentTest {
      */
     @Test
     public void returnsItsIssue() throws Exception {
-        final Repo repo = repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("testing1", "issue1");
         final RtComment comment = new RtComment(new FakeRequest(), issue, 1);
         MatcherAssert.assertThat(comment.issue(), Matchers.is(issue));
@@ -89,7 +89,7 @@ public final class RtCommentTest {
      */
     @Test
     public void returnsItsNumber() throws Exception {
-        final Repo repo = repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("testing2", "issue2");
         final int num = 10;
         final RtComment comment = new RtComment(new FakeRequest(), issue, num);
@@ -105,7 +105,7 @@ public final class RtCommentTest {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
         ).start();
-        final Repo repo = repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("testing3", "issue3");
         final RtComment comment = new RtComment(
             new ApacheRequest(container.home()), issue, 10
@@ -132,7 +132,7 @@ public final class RtCommentTest {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body)
         ).start();
-        final Repo repo = repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("testing4", "issue4");
         final RtComment comment = new RtComment(
             new ApacheRequest(container.home()), issue, 10
@@ -157,7 +157,7 @@ public final class RtCommentTest {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
         ).start();
-        final Repo repo = repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("testing5", "issue5");
         final RtComment comment = new RtComment(
             new ApacheRequest(container.home()), issue, 10
@@ -184,7 +184,7 @@ public final class RtCommentTest {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
         ).start();
-        final Repo repo = repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("testing6", "issue6");
         final RtComment comment = new RtComment(
             new ApacheRequest(container.home()), issue, 10
@@ -198,16 +198,5 @@ public final class RtCommentTest {
         } finally {
             container.stop();
         }
-    }
-
-    /**
-     * This method returns a Repo for testing.
-     * @return Repo - a repo to be used for test.
-     * @throws Exception - if anything goes wrong.
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
     }
 }

--- a/src/test/java/com/jcabi/github/RtCommitsTest.java
+++ b/src/test/java/com/jcabi/github/RtCommitsTest.java
@@ -66,7 +66,7 @@ public class RtCommitsTest {
         ).start();
         final Commits commits = new RtCommits(
             new ApacheRequest(container.home()),
-            repo()
+            new MkGithub().randomRepo()
         );
         final JsonObject author = Json.createObjectBuilder()
             .add("name", "Scott").add("email", "scott@gmail.com")
@@ -91,17 +91,5 @@ public class RtCommitsTest {
         } finally {
             container.stop();
         }
-    }
-
-    /**
-     * This method returns a Repo for testing.
-     *
-     * @return Repo - a repo to be used for test.
-     * @throws Exception - if anything goes wrong.
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
     }
 }

--- a/src/test/java/com/jcabi/github/RtDeployKeysITCase.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeysITCase.java
@@ -29,12 +29,10 @@
  */
 package com.jcabi.github;
 
-import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.KeyPair;
 import java.io.ByteArrayOutputStream;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
@@ -71,12 +69,7 @@ public final class RtDeployKeysITCase {
         Assume.assumeThat(key, Matchers.notNullValue());
         final Github github = new RtGithub(key);
         repos = github.repos();
-        repo = repos.create(
-            new Repos.RepoCreate(
-                RandomStringUtils.randomAlphanumeric(Tv.TEN),
-                false
-            ).withAutoInit(true)
-        );
+        repo = new RepoRule().repo(repos);
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtIssueITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssueITCase.java
@@ -29,10 +29,8 @@
  */
 package com.jcabi.github;
 
-import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
 import com.jcabi.log.Logger;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
@@ -68,12 +66,7 @@ public final class RtIssueITCase {
         Assume.assumeThat(key, Matchers.notNullValue());
         final Github github = new RtGithub(key);
         repos = github.repos();
-        repo = repos.create(
-            new Repos.RepoCreate(
-                RandomStringUtils.randomAlphanumeric(Tv.TEN),
-                false
-            ).withAutoInit(true)
-        );
+        repo = new RepoRule().repo(repos);
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtIssueLabelsITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssueLabelsITCase.java
@@ -29,9 +29,7 @@
  */
 package com.jcabi.github;
 
-import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
@@ -68,12 +66,7 @@ public final class RtIssueLabelsITCase {
         Assume.assumeThat(key, Matchers.notNullValue());
         final Github github = new RtGithub(key);
         repos = github.repos();
-        repo = repos.create(
-            new Repos.RepoCreate(
-                RandomStringUtils.randomAlphanumeric(Tv.TEN),
-                false
-            ).withAutoInit(true)
-        );
+        repo = new RepoRule().repo(repos);
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtIssuesITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssuesITCase.java
@@ -29,14 +29,12 @@
  */
 package com.jcabi.github;
 
-import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
 import com.jcabi.immutable.ArrayMap;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Set;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
@@ -71,12 +69,7 @@ public final class RtIssuesITCase {
         Assume.assumeThat(key, Matchers.notNullValue());
         final Github github = new RtGithub(key);
         repos = github.repos();
-        repo = repos.create(
-            new Repos.RepoCreate(
-                RandomStringUtils.randomAlphanumeric(Tv.TEN),
-                false
-            ).withAutoInit(true)
-        );
+        repo = new RepoRule().repo(repos);
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtLabelsITCase.java
+++ b/src/test/java/com/jcabi/github/RtLabelsITCase.java
@@ -29,9 +29,7 @@
  */
 package com.jcabi.github;
 
-import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
@@ -68,12 +66,7 @@ public final class RtLabelsITCase {
         Assume.assumeThat(key, Matchers.notNullValue());
         final Github github = new RtGithub(key);
         repos = github.repos();
-        repo = repos.create(
-            new Repos.RepoCreate(
-                RandomStringUtils.randomAlphanumeric(Tv.TEN),
-                false
-            ).withAutoInit(true)
-        );
+        repo = new RepoRule().repo(repos);
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtMilestonesITCase.java
+++ b/src/test/java/com/jcabi/github/RtMilestonesITCase.java
@@ -72,12 +72,7 @@ public final class RtMilestonesITCase {
             new RtGithub(key).entry().through(RetryWire.class)
         );
         repos = github.repos();
-        repo = repos.create(
-            new Repos.RepoCreate(
-                RandomStringUtils.randomAlphanumeric(Tv.TEN),
-                false
-            ).withAutoInit(true)
-        );
+        repo = new RepoRule().repo(repos);
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtMilestonesITCase.java
+++ b/src/test/java/com/jcabi/github/RtMilestonesITCase.java
@@ -99,7 +99,7 @@ public final class RtMilestonesITCase {
     public void iteratesIssues() throws Exception {
         final Milestones milestones = repo.milestones();
         final Milestone milestone = milestones.create(
-            RandomStringUtils.randomAlphabetic(10)
+            RandomStringUtils.randomAlphabetic(Tv.TEN)
         );
         try {
             MatcherAssert.assertThat(
@@ -119,7 +119,7 @@ public final class RtMilestonesITCase {
     public void createsNewMilestone() throws Exception {
         final Milestones milestones = repo.milestones();
         final Milestone milestone = milestones.create(
-            RandomStringUtils.randomAlphabetic(10)
+            RandomStringUtils.randomAlphabetic(Tv.TEN)
         );
         try {
             MatcherAssert.assertThat(

--- a/src/test/java/com/jcabi/github/RtPullCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtPullCommentTest.java
@@ -61,7 +61,7 @@ public final class RtPullCommentTest {
     @Test
     public void canCompareInstances() throws Exception {
         final Pull pull = Mockito.mock(Pull.class);
-        Mockito.doReturn(repo()).when(pull).repo();
+        Mockito.doReturn(new MkGithub().randomRepo()).when(pull).repo();
         final RtPullComment less =
             new RtPullComment(new FakeRequest(), pull, 1);
         final RtPullComment greater =
@@ -99,7 +99,7 @@ public final class RtPullCommentTest {
             );
             MatcherAssert.assertThat(
                 container.take().uri().toString(),
-                Matchers.endsWith("/repos/joe/test/pulls/comments/1")
+                Matchers.endsWith("/repos/joe/blueharvest/pulls/comments/1")
             );
         } finally {
             container.stop();
@@ -133,7 +133,7 @@ public final class RtPullCommentTest {
             );
             MatcherAssert.assertThat(
                 query.uri().toString(),
-                Matchers.endsWith("/repos/joe/test/pulls/comments/2")
+                Matchers.endsWith("/repos/joe/blueharvest/pulls/comments/2")
             );
         } finally {
             container.stop();
@@ -147,7 +147,7 @@ public final class RtPullCommentTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub("joe").repos().create(
-            new Repos.RepoCreate("test", false)
+            new Repos.RepoCreate("blueharvest", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/RtPullCommentsTest.java
+++ b/src/test/java/com/jcabi/github/RtPullCommentsTest.java
@@ -231,7 +231,8 @@ public final class RtPullCommentsTest {
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
         ).start();
         final Pull pull = Mockito.mock(Pull.class);
-        Mockito.doReturn(repo()).when(pull).repo();
+        final Repo repository = repo();
+        Mockito.doReturn(repository).when(pull).repo();
         final RtPullComments comments =
             new RtPullComments(new ApacheRequest(container.home()), pull);
         try {
@@ -242,7 +243,12 @@ public final class RtPullCommentsTest {
             );
             MatcherAssert.assertThat(
                 query.uri().toString(),
-                Matchers.endsWith("/repos/johnny/test/pulls/0/comments/2")
+                Matchers.endsWith(
+                    String.format(
+                        "/repos/johnny/%s/pulls/0/comments/2",
+                        repository.coordinates().repo()
+                    )
+                )
             );
         } finally {
             container.stop();
@@ -255,9 +261,7 @@ public final class RtPullCommentsTest {
      * @throws Exception - if anything goes wrong.
      */
     private static Repo repo() throws Exception {
-        return new MkGithub("johnny").repos().create(
-            new Repos.RepoCreate("test", false)
-        );
+        return new MkGithub("johnny").randomRepo();
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtReferenceTest.java
+++ b/src/test/java/com/jcabi/github/RtReferenceTest.java
@@ -64,7 +64,9 @@ public final class RtReferenceTest {
             )
         ).start();
         final Reference reference = new RtReference(
-            new ApacheRequest(container.home()), repo(), "refs/heads/featureA"
+            new ApacheRequest(container.home()),
+            new MkGithub().randomRepo(),
+            "refs/heads/featureA"
         );
         try {
             reference.patch(
@@ -93,7 +95,9 @@ public final class RtReferenceTest {
             )
         ).start();
         final Reference reference = new RtReference(
-            new ApacheRequest(container.home()), repo(), "refs/heads/featureB"
+            new ApacheRequest(container.home()),
+            new MkGithub().randomRepo(),
+            "refs/heads/featureB"
         );
         try {
             MatcherAssert.assertThat(
@@ -118,7 +122,9 @@ public final class RtReferenceTest {
             )
         ).start();
         final Reference reference = new RtReference(
-            new ApacheRequest(container.home()), repo(), "refs/heads/featureC"
+            new ApacheRequest(container.home()),
+            new MkGithub().randomRepo(),
+            "refs/heads/featureC"
         );
         try {
             MatcherAssert.assertThat(
@@ -136,7 +142,7 @@ public final class RtReferenceTest {
      */
     @Test
     public void returnsOwner() throws Exception {
-        final Repo owner = repo();
+        final Repo owner = new MkGithub().randomRepo();
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(
                 HttpURLConnection.HTTP_OK,
@@ -155,16 +161,4 @@ public final class RtReferenceTest {
             container.stop();
         }
     }
-
-    /**
-     * This method returns a Repo for testing.
-     * @return Repo - a repo to be used for test.
-     * @throws Exception - if anything goes wrong.
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
 }

--- a/src/test/java/com/jcabi/github/RtReferencesTest.java
+++ b/src/test/java/com/jcabi/github/RtReferencesTest.java
@@ -62,7 +62,7 @@ public final class RtReferencesTest {
         ).start();
         final References refs = new RtReferences(
             new ApacheRequest(container.home()),
-            repo()
+            new MkGithub().randomRepo()
         );
         try {
             MatcherAssert.assertThat(
@@ -92,7 +92,7 @@ public final class RtReferencesTest {
         ).start();
         final References refs = new RtReferences(
             new ApacheRequest(container.home()),
-            repo()
+            new MkGithub().randomRepo()
         );
         try {
             MatcherAssert.assertThat(
@@ -115,7 +115,7 @@ public final class RtReferencesTest {
         ).start();
         final References refs = new RtReferences(
             new ApacheRequest(container.home()),
-            repo()
+            new MkGithub().randomRepo()
         );
         refs.remove("heads/feature-a");
         try {
@@ -142,7 +142,7 @@ public final class RtReferencesTest {
         ).start();
         final References refs = new RtReferences(
             new ApacheRequest(container.home()),
-            repo()
+            new MkGithub().randomRepo()
         );
         try {
             MatcherAssert.assertThat(
@@ -172,7 +172,7 @@ public final class RtReferencesTest {
         ).start();
         final References refs = new RtReferences(
             new ApacheRequest(container.home()),
-            repo()
+            new MkGithub().randomRepo()
         );
         try {
             MatcherAssert.assertThat(
@@ -186,16 +186,5 @@ public final class RtReferencesTest {
         } finally {
             container.stop();
         }
-    }
-
-    /**
-     * This method returns a Repo for testing.
-     * @return Repo - a repo to be used for test.
-     * @throws Exception - if anything goes wrong.
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
     }
 }

--- a/src/test/java/com/jcabi/github/RtReleaseAssetTest.java
+++ b/src/test/java/com/jcabi/github/RtReleaseAssetTest.java
@@ -119,7 +119,7 @@ public final class RtReleaseAssetTest {
             );
             MatcherAssert.assertThat(
                 query.uri().toString(),
-                Matchers.endsWith("/repos/john/test/releases/assets/2")
+                Matchers.endsWith("/repos/john/blueharvest/releases/assets/2")
             );
         } finally {
             container.stop();
@@ -189,7 +189,7 @@ public final class RtReleaseAssetTest {
     private static Release release() throws Exception {
         final Release release = Mockito.mock(Release.class);
         final Repo repo = new MkGithub("john").repos().create(
-            new Repos.RepoCreate("test", false)
+            new Repos.RepoCreate("blueharvest", false)
         );
         Mockito.doReturn(repo).when(release).repo();
         Mockito.doReturn(1).when(release).number();

--- a/src/test/java/com/jcabi/github/RtReleaseAssetsTest.java
+++ b/src/test/java/com/jcabi/github/RtReleaseAssetsTest.java
@@ -108,9 +108,7 @@ public final class RtReleaseAssetsTest {
      */
     private static Release release() throws Exception {
         final Release release = Mockito.mock(Release.class);
-        final Repo repo = new MkGithub("john").repos().create(
-            new Repos.RepoCreate("test", false)
-        );
+        final Repo repo = new MkGithub("john").randomRepo();
         Mockito.doReturn(repo).when(release).repo();
         Mockito.doReturn(1).when(release).number();
         return release;

--- a/src/test/java/com/jcabi/github/RtStatusesTest.java
+++ b/src/test/java/com/jcabi/github/RtStatusesTest.java
@@ -70,7 +70,12 @@ public class RtStatusesTest {
         ).start();
         final Request req = new ApacheRequest(container.home());
         final Statuses statuses = new RtStatuses(
-            req, new RtCommit(req, repo(), "0abcd89jcabitest")
+            req,
+            new RtCommit(
+                req,
+                new MkGithub().randomRepo(),
+                "0abcd89jcabitest"
+            )
         );
         try {
             statuses.create(
@@ -87,17 +92,5 @@ public class RtStatusesTest {
         } finally {
             container.stop();
         }
-    }
-
-    /**
-     * This method returns a Repo for testing.
-     *
-     * @return Repo - a repo to be used for test.
-     * @throws Exception - if anything goes wrong.
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
     }
 }

--- a/src/test/java/com/jcabi/github/RtTagTest.java
+++ b/src/test/java/com/jcabi/github/RtTagTest.java
@@ -61,7 +61,9 @@ public final class RtTagTest {
             )
         ).start();
         final Tag tag = new RtTag(
-            new ApacheRequest(container.home()), repo(), "abdes00test"
+            new ApacheRequest(container.home()),
+            new MkGithub().randomRepo(),
+            "abdes00test"
         );
         try {
             MatcherAssert.assertThat(
@@ -72,16 +74,4 @@ public final class RtTagTest {
             container.stop();
         }
     }
-
-    /**
-     * This method returns a Repo for testing.
-     * @return Repo - a repo to be used for test.
-     * @throws Exception - if anything goes wrong.
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
 }

--- a/src/test/java/com/jcabi/github/RtTagsTest.java
+++ b/src/test/java/com/jcabi/github/RtTagsTest.java
@@ -71,7 +71,7 @@ public final class RtTagsTest {
         ).start();
         final Tags tags = new RtTags(
             new ApacheRequest(container.home()),
-            repo()
+            new MkGithub().randomRepo()
         );
         final JsonObject tagger = Json.createObjectBuilder()
             .add("name", "Scott").add("email", "scott@gmail.com")
@@ -97,16 +97,4 @@ public final class RtTagsTest {
             container.stop();
         }
     }
-
-    /**
-     * This method returns a Repo for testing.
-     * @return Repo - a repo to be used for test.
-     * @throws Exception - if anything goes wrong.
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
 }

--- a/src/test/java/com/jcabi/github/mock/MkAssigneesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkAssigneesTest.java
@@ -30,7 +30,6 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import com.jcabi.github.User;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -89,8 +88,6 @@ public final class MkAssigneesTest {
      * @throws Exception If some problem inside
      */
     private static Repo repo() throws Exception {
-        return new MkGithub("Jonathan").repos().create(
-            new Repos.RepoCreate("test", false)
-        );
+        return new MkGithub("Jonathan").randomRepo();
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkBlobsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkBlobsTest.java
@@ -31,8 +31,6 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.Blob;
 import com.jcabi.github.Blobs;
-import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -51,7 +49,7 @@ public final class MkBlobsTest {
      */
     @Test
     public void canCreateBlob() throws Exception {
-        final Blobs blobs = repo().git().blobs();
+        final Blobs blobs = new MkGithub().randomRepo().git().blobs();
         final Blob blob = blobs.create("content1", "encoding1");
         MatcherAssert.assertThat(
             blobs.get(blob.sha()),
@@ -65,22 +63,11 @@ public final class MkBlobsTest {
      */
     @Test
     public void getBlob() throws Exception {
-        final Blobs blobs = repo().git().blobs();
+        final Blobs blobs = new MkGithub().randomRepo().git().blobs();
         final Blob created =  blobs.create("content", "base64");
         MatcherAssert.assertThat(
             blobs.get(created.sha()),
             Matchers.notNullValue()
-        );
-    }
-
-    /**
-     * Create a repo to work with.
-     * @return Repo
-     * @throws Exception If some problem inside
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub("Jonathan").repos().create(
-            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkBranchTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkBranchTest.java
@@ -31,7 +31,6 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -45,15 +44,6 @@ import org.junit.Test;
  */
 public final class MkBranchTest {
     /**
-     * Test user to own test repository.
-     */
-    private static final String REPO_USER = "jacqueline";
-    /**
-     * Test repository name.
-     */
-    private static final String REPO_NAME = "wonderful";
-
-    /**
      * MkBranch can fetch its name.
      * @throws IOException If an I/O problem occurs
      */
@@ -61,7 +51,7 @@ public final class MkBranchTest {
     public void fetchesName() throws IOException {
         final String name = "topic";
         MatcherAssert.assertThat(
-            MkBranchTest.branches()
+            MkBranchTest.branches(new MkGithub().randomRepo())
                 .create(name, "f8dfc75138a2b57859b65cfc45239978081b8de4")
                 .name(),
             Matchers.equalTo(name)
@@ -76,7 +66,7 @@ public final class MkBranchTest {
     public void fetchesCommit() throws IOException {
         final String sha = "ad1298cac285d601cd66b37ec8989836d7c6e651";
         MatcherAssert.assertThat(
-            MkBranchTest.branches()
+            MkBranchTest.branches(new MkGithub().randomRepo())
                 .create("feature-branch", sha).commit().sha(),
             Matchers.equalTo(sha)
         );
@@ -88,30 +78,27 @@ public final class MkBranchTest {
      */
     @Test
     public void fetchesRepo() throws IOException {
-        final Coordinates coords = MkBranchTest.branches()
+        final Repo repo = new MkGithub().randomRepo();
+        final Coordinates coords = MkBranchTest.branches(repo)
             .create("test", "sha")
             .repo().coordinates();
-        MatcherAssert.assertThat(coords.user(), Matchers.equalTo(REPO_USER));
-        MatcherAssert.assertThat(coords.repo(), Matchers.equalTo(REPO_NAME));
-    }
-
-    /**
-     * Mock repo for MkBranch creation.
-     * @return The mock repo.
-     * @throws IOException If there is any I/O problem
-     */
-    private static Repo repository() throws IOException {
-        return new MkGithub(REPO_USER).repos().create(
-            new Repos.RepoCreate(REPO_NAME, false)
+        MatcherAssert.assertThat(
+            coords.user(),
+            Matchers.equalTo(repo.coordinates().user())
+        );
+        MatcherAssert.assertThat(
+            coords.repo(),
+            Matchers.equalTo(repo.coordinates().repo())
         );
     }
 
     /**
      * MkBranches for MkBranch creation.
+     * @param repo Repository to get MkBranches of
      * @return MkBranches
      * @throws IOException If there is any I/O problem
      */
-    private static MkBranches branches() throws IOException {
-        return (MkBranches) (repository().branches());
+    private static MkBranches branches(final Repo repo) throws IOException {
+        return (MkBranches) (repo.branches());
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkBranchesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkBranchesTest.java
@@ -31,7 +31,7 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.Branch;
 import com.jcabi.github.Coordinates;
-import com.jcabi.github.Repos;
+import com.jcabi.github.Repo;
 import java.io.IOException;
 import java.util.Iterator;
 import org.hamcrest.MatcherAssert;
@@ -53,16 +53,23 @@ public final class MkBranchesTest {
     public void createsBranch() throws IOException {
         final String name = "my-new-feature";
         final String sha = "590e188e3d52a8da38cf51d3f9bf598bb46911af";
-        final String user = "johnson";
-        final String repo = "my-repo";
-        final Branch branch = ((MkBranches) (new MkGithub(user).repos().create(
-            new Repos.RepoCreate(repo, false)
-        ).branches())).create(name, sha);
+        final Repo repo = new MkGithub().randomRepo();
+        final Branch branch = ((MkBranches) (repo.branches()))
+            .create(name, sha);
         MatcherAssert.assertThat(branch.name(), Matchers.equalTo(name));
-        MatcherAssert.assertThat(branch.commit().sha(), Matchers.equalTo(sha));
+        MatcherAssert.assertThat(
+            branch.commit().sha(),
+            Matchers.equalTo(sha)
+        );
         final Coordinates coords = branch.commit().repo().coordinates();
-        MatcherAssert.assertThat(coords.user(), Matchers.equalTo(user));
-        MatcherAssert.assertThat(coords.repo(), Matchers.equalTo(repo));
+        MatcherAssert.assertThat(
+            coords.user(),
+            Matchers.equalTo(repo.coordinates().user())
+        );
+        MatcherAssert.assertThat(
+            coords.repo(),
+            Matchers.equalTo(repo.coordinates().repo())
+        );
     }
 
     /**
@@ -71,9 +78,8 @@ public final class MkBranchesTest {
      */
     @Test
     public void iteratesOverBranches() throws IOException {
-        final MkBranches branches = (MkBranches) (new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        ).branches());
+        final MkBranches branches = (MkBranches) (new MkGithub().randomRepo()
+            .branches());
         final String onename = "narf";
         final String onesha = "a86da33b875e8ecbaf75cefcf6d8957cbecb654e";
         branches.create(onename, onesha);
@@ -87,9 +93,15 @@ public final class MkBranchesTest {
         final Iterator<Branch> iter = branches.iterate().iterator();
         final Branch one = iter.next();
         MatcherAssert.assertThat(one.name(), Matchers.equalTo(onename));
-        MatcherAssert.assertThat(one.commit().sha(), Matchers.equalTo(onesha));
+        MatcherAssert.assertThat(
+            one.commit().sha(),
+            Matchers.equalTo(onesha)
+        );
         final Branch two = iter.next();
         MatcherAssert.assertThat(two.name(), Matchers.equalTo(twoname));
-        MatcherAssert.assertThat(two.commit().sha(), Matchers.equalTo(twosha));
+        MatcherAssert.assertThat(
+            two.commit().sha(),
+            Matchers.equalTo(twosha)
+        );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkCollaboratorsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCollaboratorsTest.java
@@ -30,7 +30,6 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Collaborators;
-import com.jcabi.github.Repos;
 import com.jcabi.github.User;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -93,8 +92,6 @@ public final class MkCollaboratorsTest {
      * @throws Exception If some problem inside
      */
     private Collaborators collaborators() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        ).collaborators();
+        return new MkGithub().randomRepo().collaborators();
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkCommentTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCommentTest.java
@@ -124,7 +124,7 @@ public final class MkCommentTest {
             Matchers.equalTo(
                 new URL(
                     // @checkstyle LineLength (1 line)
-                    "https://api.jcabi-github.invalid/repos/jeff/test/issues/comments/1"
+                    "https://api.jcabi-github.invalid/repos/jeff/blueharvest/issues/comments/1"
                 )
             )
         );
@@ -154,7 +154,7 @@ public final class MkCommentTest {
      */
     private Comment comment(final String text) throws Exception {
         return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
+            new Repos.RepoCreate("blueharvest", false)
         ).issues().create("hey", "how are you?").comments().post(text);
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkCommentsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCommentsTest.java
@@ -31,7 +31,6 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.Comment;
 import com.jcabi.github.Comments;
-import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -64,9 +63,8 @@ public final class MkCommentsTest {
      * @throws Exception If some problem inside
      */
     private Comments comments() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        ).issues().create("hey", "how are you?").comments();
+        return new MkGithub().randomRepo()
+            .issues().create("hey", "how are you?")
+            .comments();
     }
-
 }

--- a/src/test/java/com/jcabi/github/mock/MkCommitsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCommitsTest.java
@@ -31,8 +31,6 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Commit;
-import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
@@ -59,13 +57,14 @@ public class MkCommitsTest {
             .add("date", "2008-07-09T16:13:30+12:00").build();
         final JsonArray tree = Json.createArrayBuilder()
             .add("xyzsha12").build();
-        final Commit newCommit = this.repo().git().commits().create(
-            Json.createObjectBuilder().add("message", "my commit message")
-                .add("sha", "12ahscba")
-                .add("tree", "abcsha12")
-                .add("parents", tree)
-                .add("author", author).build()
-        );
+        final Commit newCommit = new MkGithub().randomRepo()
+            .git().commits().create(
+                Json.createObjectBuilder().add("message", "my commit message")
+                    .add("sha", "12ahscba")
+                    .add("tree", "abcsha12")
+                    .add("parents", tree)
+                    .add("author", author).build()
+            );
         MatcherAssert.assertThat(
             newCommit,
             Matchers.notNullValue()
@@ -73,17 +72,6 @@ public class MkCommitsTest {
         MatcherAssert.assertThat(
             newCommit.sha(),
             Matchers.equalTo("12ahscba")
-        );
-    }
-
-    /**
-     * Repo for testing.
-     * @return Repo
-     * @throws Exception - if something goes wrong.
-     */
-    private Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkContentTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkContentTest.java
@@ -32,7 +32,6 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Content;
 import com.jcabi.github.Contents;
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import javax.json.Json;
@@ -59,7 +58,7 @@ public final class MkContentTest {
      */
     @Test
     public void canGetOwnRepo() throws Exception {
-        final Repo repo = MkContentTest.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Contents contents = repo.contents();
         final Content content = contents.create(
             jsonContent("repo.txt", "for repo", "json repo")
@@ -77,7 +76,7 @@ public final class MkContentTest {
      */
     @Test
     public void canGetOwnPath() throws Exception {
-        final Contents contents = MkContentTest.repo().contents();
+        final Contents contents = new MkGithub().randomRepo().contents();
         final String path = "dummy.txt";
         final Content content = contents.create(
             jsonContent(path, "for path", "path test")
@@ -95,7 +94,7 @@ public final class MkContentTest {
      */
     @Test
     public void fetchesJsonRepresentation() throws Exception {
-        final Contents contents = MkContentTest.repo().contents();
+        final Contents contents = new MkGithub().randomRepo().contents();
         final String path = "fake.txt";
         final Content content = contents.create(
             jsonContent(path, "for json", "json test")
@@ -114,7 +113,7 @@ public final class MkContentTest {
      */
     @Test
     public void fetchesRawRepresentation() throws Exception {
-        final Contents contents = MkContentTest.repo().contents();
+        final Contents contents = new MkGithub().randomRepo().contents();
         final String raw = "raw test \u20ac\u0000";
         final InputStream stream = contents.create(
             jsonContent("raw.txt", "for raw", raw)
@@ -152,16 +151,5 @@ public final class MkContentTest {
                     content.getBytes(CharEncoding.UTF_8)
                 )
             ).build();
-    }
-
-    /**
-     * Create a repo to work with.
-     * @return Repo
-     * @throws Exception If some problem inside
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkContentsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkContentsTest.java
@@ -33,7 +33,6 @@ import com.jcabi.github.Content;
 import com.jcabi.github.Contents;
 import com.jcabi.github.Repo;
 import com.jcabi.github.RepoCommit;
-import com.jcabi.github.Repos;
 import com.jcabi.xml.XML;
 import java.io.IOException;
 import javax.json.Json;
@@ -58,7 +57,7 @@ public final class MkContentsTest {
      */
     @Test
     public void canFetchReadmeFile() throws Exception {
-        final Contents contents = MkContentsTest.repo().contents();
+        final Contents contents = new MkGithub().randomRepo().contents();
         final String body = "Readme On Master";
         // @checkstyle MultipleStringLiterals (6 lines)
         contents.create(
@@ -78,7 +77,7 @@ public final class MkContentsTest {
     @Test
     public void canFetchReadmeFromBranch() throws Exception {
         final String branch = "branch-1";
-        final Contents contents = MkContentsTest.repo().contents();
+        final Contents contents = new MkGithub().randomRepo().contents();
         final String body = "Readme On Branch";
         contents.create(
             content("README.md", "readme on branch", body)
@@ -100,7 +99,7 @@ public final class MkContentsTest {
     public void canCreateFile() throws Exception {
         final String path = "file.txt";
         final Content.Smart content = new Content.Smart(
-            this.createFile(MkContentsTest.repo(), path)
+            this.createFile(new MkGithub().randomRepo(), path)
         );
         MatcherAssert.assertThat(
             content.path(),
@@ -127,7 +126,7 @@ public final class MkContentsTest {
         final String branch = "branch-2";
         final String body = "some file";
         final Content.Smart content = new Content.Smart(
-            MkContentsTest.repo().contents().create(
+            new MkGithub().randomRepo().contents().create(
                 content(path, "some file", body)
                     .add("ref", branch)
                     .build()
@@ -158,7 +157,7 @@ public final class MkContentsTest {
      */
     @Test
     public void canRemoveFile() throws Exception {
-        final Repo repo = MkContentsTest.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final String path = "removeme.txt";
         this.createFile(repo, path);
         final JsonObject json = MkContentsTest
@@ -181,7 +180,7 @@ public final class MkContentsTest {
     @Test
     public void canRemoveFileFromBranch() throws Exception {
         final String branch = "branch-1";
-        final Repo repo = MkContentsTest.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final String path = "removeme.txt";
         this.createFile(repo, path);
         final JsonObject json = MkContentsTest
@@ -208,7 +207,7 @@ public final class MkContentsTest {
         final String initial = "initial text";
         final String updated = "updated text";
         final String cont = "content";
-        final Contents contents = MkContentsTest.repo().contents();
+        final Contents contents = new MkGithub().randomRepo().contents();
         MatcherAssert.assertThat(
             contents.create(
                 MkContentsTest.content(path, message, initial).build()
@@ -272,7 +271,7 @@ public final class MkContentsTest {
         final String initial = "Hello World!";
         final String updated = "update content";
         final String branch = "master";
-        final Contents contents = MkContentsTest.repo().contents();
+        final Contents contents = new MkGithub().randomRepo().contents();
         final JsonObject content = MkContentsTest
             .content(path, message, initial)
             .add("ref", branch)
@@ -299,7 +298,7 @@ public final class MkContentsTest {
     public void checkExists() throws Exception {
         final String path = "content-exist.txt";
         final String branch = "rel.08";
-        final Contents contents = MkContentsTest.repo().contents();
+        final Contents contents = new MkGithub().randomRepo().contents();
         contents.create(
             MkContentsTest.content(path, "commit", "content exists")
                 .add("ref", branch)
@@ -324,7 +323,7 @@ public final class MkContentsTest {
         final String path = "content-default-branch.txt";
         final String message = "content default branch created";
         final String text = "I'm content of default branch";
-        final Contents contents = MkContentsTest.repo().contents();
+        final Contents contents = new MkGithub().randomRepo().contents();
         final JsonObject content = MkContentsTest
             .content(path, message, text)
             .build();
@@ -438,17 +437,6 @@ public final class MkContentsTest {
     }
 
     /**
-     * Create a repo to work with.
-     * @return Repo
-     * @throws Exception If some problem inside
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
-    /**
      * Create a test repo with custom {@code MkStorage}.
      * @param storage The storage
      * @return Test repo
@@ -457,9 +445,7 @@ public final class MkContentsTest {
     private static Repo repo(
         final MkStorage storage) throws IOException {
         final String login = "test";
-        return new MkGithub(storage, login).repos().create(
-            new Repos.RepoCreate(login, false)
-        );
+        return new MkGithub(storage, login).randomRepo();
     }
 
 }

--- a/src/test/java/com/jcabi/github/mock/MkDeployKeysTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkDeployKeysTest.java
@@ -31,8 +31,6 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.DeployKey;
 import com.jcabi.github.DeployKeys;
-import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -50,7 +48,7 @@ public final class MkDeployKeysTest {
      */
     @Test
     public void canFetchEmptyListOfDeployKeys() throws Exception {
-        final DeployKeys deployKeys = MkDeployKeysTest.repo().keys();
+        final DeployKeys deployKeys = new MkGithub().randomRepo().keys();
         MatcherAssert.assertThat(
             deployKeys.iterate(),
             Matchers.emptyIterable()
@@ -63,7 +61,7 @@ public final class MkDeployKeysTest {
      */
     @Test
     public void canFetchSingleDeployKey() throws Exception {
-        final DeployKeys keys = MkDeployKeysTest.repo().keys();
+        final DeployKeys keys = new MkGithub().randomRepo().keys();
         final DeployKey key = keys.create("Title", "Key");
         MatcherAssert.assertThat(keys.get(key.number()), Matchers.equalTo(key));
     }
@@ -74,7 +72,7 @@ public final class MkDeployKeysTest {
      */
     @Test
     public void canCreateDeployKey() throws Exception {
-        final DeployKeys keys = MkDeployKeysTest.repo().keys();
+        final DeployKeys keys = new MkGithub().randomRepo().keys();
         final DeployKey key = keys.create("Title1", "Key1");
         MatcherAssert.assertThat(key, Matchers.equalTo(keys.get(key.number())));
     }
@@ -86,7 +84,7 @@ public final class MkDeployKeysTest {
      */
     @Test
     public void canCreateDistinctDeployKeys() throws Exception {
-        final DeployKeys keys = MkDeployKeysTest.repo().keys();
+        final DeployKeys keys = new MkGithub().randomRepo().keys();
         final DeployKey first = keys.create("Title2", "Key2");
         final DeployKey second = keys.create("Title3", "Key3");
         MatcherAssert.assertThat(
@@ -106,7 +104,7 @@ public final class MkDeployKeysTest {
      */
     @Test
     public void canRepresentAsJson() throws Exception {
-        final DeployKeys keys = MkDeployKeysTest.repo().keys();
+        final DeployKeys keys = new MkGithub().randomRepo().keys();
         final DeployKey first = keys.create("Title4", "Key4");
         MatcherAssert.assertThat(
             first.json().toString(),
@@ -114,17 +112,6 @@ public final class MkDeployKeysTest {
                 Matchers.containsString("\"title\":\"Title4\""),
                 Matchers.containsString("\"key\":\"Key4\"")
             )
-        );
-    }
-
-    /**
-     * Create a repo to work with.
-     * @return Repo
-     * @throws Exception If some problem inside
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkEventTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkEventTest.java
@@ -52,9 +52,7 @@ public final class MkEventTest {
     public void canGetCreatedAt() throws Exception {
         final MkStorage storage = new MkStorage.InFile();
         final String user = "test_user";
-        final Repo repo = new MkGithub(storage, user).repos().create(
-            new Repos.RepoCreate("test", false)
-        );
+        final Repo repo = new MkGithub(storage, user).randomRepo();
         final MkIssueEvents events = (MkIssueEvents) (repo.issueEvents());
         final int eventnum = events.create(
             "test_type",

--- a/src/test/java/com/jcabi/github/mock/MkForkTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkForkTest.java
@@ -30,8 +30,6 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Fork;
-import com.jcabi.github.Forks;
-import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -50,21 +48,10 @@ public final class MkForkTest {
      */
     @Test
     public void fetchAsJson() throws Exception {
-        final Fork fork = forks().create("fork");
+        final Fork fork = new MkGithub().randomRepo().forks().create("fork");
         MatcherAssert.assertThat(
             fork.json().toString(),
             Matchers.containsString("{")
         );
-    }
-
-    /**
-     * Create and return forks to test.
-     * @return Forks
-     * @throws Exception if any problem inside
-     */
-    private static Forks forks() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        ).forks();
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkForksTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkForksTest.java
@@ -32,7 +32,6 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Fork;
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
@@ -70,7 +69,7 @@ public final class MkForksTest {
      */
     @Test
     public void iteratesForks() throws Exception {
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Fork fork = repo.forks().create("Organization");
         final Iterable<Fork> iterate = repo.forks().iterate("Order");
         MatcherAssert.assertThat(
@@ -82,17 +81,4 @@ public final class MkForksTest {
             Matchers.hasItem(fork)
         );
     }
-
-    /**
-     * Create a repo to work with.
-     *
-     * @return Repo
-     * @throws Exception if a problem occurs.
-     */
-    private Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
 }

--- a/src/test/java/com/jcabi/github/mock/MkGitTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkGitTest.java
@@ -30,7 +30,6 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -51,7 +50,7 @@ public final class MkGitTest {
      */
     @Test
     public void canFetchOwnRepo() throws Exception {
-        final Repo repo = repo();
+        final Repo repo = new MkGithub().randomRepo();
         MatcherAssert.assertThat(
             repo.git().repo(),
             Matchers.equalTo(repo)
@@ -65,19 +64,8 @@ public final class MkGitTest {
     @Test
     public void givesReferences() throws Exception {
         MatcherAssert.assertThat(
-            repo().git().references(), Matchers.notNullValue()
+            new MkGithub().randomRepo().git().references(),
+            Matchers.notNullValue()
         );
     }
-
-    /**
-     * Create a repo to work with.
-     * @return Repo
-     * @throws Exception If some problem inside
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
 }

--- a/src/test/java/com/jcabi/github/mock/MkIssueEventsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssueEventsTest.java
@@ -32,7 +32,6 @@ package com.jcabi.github.mock;
 import com.google.common.base.Optional;
 import com.jcabi.aspects.Tv;
 import com.jcabi.github.Event;
-import com.jcabi.github.Repos;
 import java.util.Iterator;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -79,8 +78,13 @@ public final class MkIssueEventsTest {
         );
         MatcherAssert.assertThat(
             event.url().toString(),
-            // @checkstyle LineLength (1 line)
-            Matchers.equalTo("https://api.jcabi-github.invalid/repos/jeff/test/issues/events/1")
+            Matchers.equalTo(
+                String.format(
+                    // @checkstyle LineLength (1 line)
+                    "https://api.jcabi-github.invalid/repos/jeff/%s/issues/events/1",
+                    events.repo().coordinates().repo()
+                )
+            )
         );
         MatcherAssert.assertThat(
             event.createdAt().getTime(),
@@ -187,9 +191,7 @@ public final class MkIssueEventsTest {
      */
     private MkIssueEvents issueEvents() throws Exception {
         return MkIssueEvents.class.cast(
-            new MkGithub().repos().create(
-                new Repos.RepoCreate("test", false)
-            ).issueEvents()
+            new MkGithub().randomRepo().issueEvents()
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkIssueLabelsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssueLabelsTest.java
@@ -34,7 +34,6 @@ import com.jcabi.github.Issue;
 import com.jcabi.github.IssueLabels;
 import com.jcabi.github.Label;
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import java.util.Collections;
 import java.util.Iterator;
 import org.hamcrest.MatcherAssert;
@@ -58,7 +57,7 @@ public final class MkIssueLabelsTest {
      */
     @Test
     public void iteratesIssues() throws Exception {
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final String name = "bug";
         repo.labels().create(name, "c0c0c0");
         final Issue issue = repo.issues().create("title", "body");
@@ -75,7 +74,7 @@ public final class MkIssueLabelsTest {
      */
     @Test
     public void createsLabelsThroughDecorator() throws Exception {
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("how are you?", "");
         final String name = "task";
         new IssueLabels.Smart(issue.labels()).addIfAbsent(name, "f0f0f0");
@@ -91,7 +90,7 @@ public final class MkIssueLabelsTest {
      */
     @Test
     public void addingLabelGeneratesEvent() throws Exception {
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final String name = "confirmed";
         repo.labels().create(name, "663399");
         final Issue issue = repo.issues().create("Titular", "Corpus");
@@ -127,7 +126,7 @@ public final class MkIssueLabelsTest {
      */
     @Test
     public void removingLabelGeneratesEvent() throws Exception {
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final String name = "invalid";
         repo.labels().create(name, "ee82ee");
         final Issue issue = repo.issues().create("Rewrite", "Sound good?");
@@ -155,17 +154,6 @@ public final class MkIssueLabelsTest {
         MatcherAssert.assertThat(
             unlabeled.label().get().name(),
             Matchers.equalTo(name)
-        );
-    }
-
-    /**
-     * Create an repo to work with.
-     * @return Repo
-     * @throws Exception If some problem inside
-     */
-    private Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkIssueTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssueTest.java
@@ -35,7 +35,6 @@ import com.jcabi.github.Github;
 import com.jcabi.github.Issue;
 import com.jcabi.github.Label;
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import java.util.Collections;
 import java.util.Iterator;
 import org.hamcrest.CustomMatcher;
@@ -197,9 +196,7 @@ public final class MkIssueTest {
     public void canRememberItsAuthor() throws Exception {
         final MkGithub first = new MkGithub("first");
         final Github second = first.relogin("second");
-        final Repo repo = first.repos().create(
-            new Repos.RepoCreate("test", false)
-        );
+        final Repo repo = first.randomRepo();
         final int number = second.repos()
             .get(repo.coordinates())
             .issues()
@@ -308,9 +305,8 @@ public final class MkIssueTest {
      * @throws Exception If some problem inside
      */
     private Issue issue() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        ).issues().create("hey", "how are you?");
+        return new MkGithub().randomRepo()
+            .issues().create("hey", "how are you?");
     }
 
 }

--- a/src/test/java/com/jcabi/github/mock/MkIssuesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkIssuesTest.java
@@ -53,7 +53,7 @@ public final class MkIssuesTest {
      */
     @Test
     public void iteratesIssues() throws Exception {
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         repo.issues().create("hey, you", "body of issue");
         repo.issues().create("hey", "body of 2nd issue");
         repo.issues().create("hey again", "body of 3rd issue");
@@ -69,7 +69,7 @@ public final class MkIssuesTest {
      */
     @Test
     public void createsNewIssueWithCorrectAuthor() throws Exception {
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Issue.Smart issue = new Issue.Smart(
             repo.issues().create("hello", "the body")
         );
@@ -93,16 +93,4 @@ public final class MkIssuesTest {
             repo.issues().create("title", "body");
         }
     }
-
-    /**
-     * Create an repo to work with.
-     * @return Repo
-     * @throws Exception If some problem inside
-     */
-    private Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
 }

--- a/src/test/java/com/jcabi/github/mock/MkLabelsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkLabelsTest.java
@@ -33,7 +33,6 @@ import com.jcabi.github.Issue;
 import com.jcabi.github.Label;
 import com.jcabi.github.Labels;
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -52,7 +51,7 @@ public final class MkLabelsTest {
      */
     @Test
     public void iteratesLabels() throws Exception {
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         repo.labels().create("bug", "e0e0e0");
         MatcherAssert.assertThat(
             repo.labels().iterate(),
@@ -66,7 +65,7 @@ public final class MkLabelsTest {
      */
     @Test
     public void deletesLabels() throws Exception {
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Labels labels = repo.labels();
         final String name = "label-0";
         labels.create(name, "e1e1e1");
@@ -89,7 +88,7 @@ public final class MkLabelsTest {
      */
     @Test
     public void setsLabelColor() throws Exception {
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final String color = "f0f0f0";
         final String name = "task";
         repo.labels().create(name, color);
@@ -98,16 +97,4 @@ public final class MkLabelsTest {
             Matchers.equalTo(color)
         );
     }
-
-    /**
-     * Create an repo to work with.
-     * @return Repo
-     * @throws Exception If some problem inside
-     */
-    private Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
 }

--- a/src/test/java/com/jcabi/github/mock/MkMilestonesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkMilestonesTest.java
@@ -32,7 +32,6 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Milestone;
 import com.jcabi.github.Milestones;
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import com.jcabi.immutable.ArrayMap;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -52,7 +51,7 @@ public final class MkMilestonesTest {
      */
     @Test
     public void returnsRepo() throws Exception {
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Repo owner = repo.milestones().repo();
         MatcherAssert.assertThat(repo, Matchers.is(owner));
     }
@@ -63,7 +62,8 @@ public final class MkMilestonesTest {
      */
     @Test
     public void createsMilestone() throws Exception {
-        final Milestones milestones = this.repo().milestones();
+        final Milestones milestones = new MkGithub().randomRepo()
+            .milestones();
         final Milestone milestone = milestones.create("test milestone");
         MatcherAssert.assertThat(milestone, Matchers.notNullValue());
         MatcherAssert.assertThat(
@@ -78,7 +78,8 @@ public final class MkMilestonesTest {
      */
     @Test
     public void getsMilestone() throws Exception {
-        final Milestones milestones = this.repo().milestones();
+        final Milestones milestones = new MkGithub().randomRepo()
+            .milestones();
         final Milestone created = milestones.create("test");
         MatcherAssert.assertThat(
             milestones.get(created.number()),
@@ -91,7 +92,8 @@ public final class MkMilestonesTest {
      */
     @Test
     public void removesMilestone() throws Exception {
-        final Milestones milestones = this.repo().milestones();
+        final Milestones milestones = new MkGithub().randomRepo()
+            .milestones();
         final Milestone created = milestones.create("testTitle");
         MatcherAssert.assertThat(
             milestones.iterate(new ArrayMap<String, String>()),
@@ -110,21 +112,12 @@ public final class MkMilestonesTest {
      */
     @Test
     public void iteratesMilestones() throws Exception {
-        final Milestones milestones = this.repo().milestones();
+        final Milestones milestones = new MkGithub().randomRepo()
+            .milestones();
         milestones.create("testMilestone");
         MatcherAssert.assertThat(
             milestones.iterate(new ArrayMap<String, String>()),
             Matchers.<Milestone>iterableWithSize(1)
-        );
-    }
-    /**
-     * Repo for testing.
-     * @return Repo
-     * @throws Exception - if something goes wrong.
-     */
-    private Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkPullCommentTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullCommentTest.java
@@ -30,7 +30,6 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.PullComment;
-import com.jcabi.github.Repos;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -80,8 +79,7 @@ public final class MkPullCommentTest {
      */
     private static PullComment comment() throws Exception {
         return new MkGithub()
-            .repos()
-            .create(new Repos.RepoCreate("test", false))
+            .randomRepo()
             .pulls()
             .create("hello", "", "")
             .comments()

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -32,7 +32,6 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Pull;
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
@@ -181,8 +180,6 @@ public final class MkPullTest {
      * @throws Exception If some problem inside
      */
     private static Repo repo() throws Exception {
-        return new MkGithub(USERNAME).repos().create(
-            new Repos.RepoCreate("test", false)
-        );
+        return new MkGithub(USERNAME).randomRepo();
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkPullsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullsTest.java
@@ -32,7 +32,6 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Issue;
 import com.jcabi.github.Pull;
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
@@ -54,7 +53,7 @@ public final class MkPullsTest {
      */
     @Test
     public void canCreateAPull() throws Exception {
-        final Repo repo = MkPullsTest.repo();
+        final Repo repo = new MkGithub().randomRepo();
         final Pull pull = repo.pulls().create("hello", "", "");
         final Issue.Smart issue = new Issue.Smart(
             repo.issues().get(pull.number())
@@ -83,16 +82,5 @@ public final class MkPullsTest {
     @Ignore
     public void canFetchSinglePull() throws Exception {
         // to be implemented
-    }
-
-    /**
-     * Create a repo to work with.
-     * @return Repo
-     * @throws Exception If some problem inside
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkReferenceTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReferenceTest.java
@@ -31,7 +31,6 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Reference;
-import com.jcabi.github.Repos;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
@@ -111,8 +110,7 @@ public final class MkReferenceTest {
      * @throws Exception - if something goes wrong.
      */
     private Reference reference() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        ).git().references().create("refs/tags/hello", "testsha");
+        return new MkGithub().randomRepo().git()
+            .references().create("refs/tags/hello", "testsha");
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkReferencesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReferencesTest.java
@@ -33,7 +33,6 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Reference;
 import com.jcabi.github.References;
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -52,7 +51,8 @@ public final class MkReferencesTest {
      */
     @Test
     public void createsMkReference() throws Exception {
-        final References refs = this.repo().git().references();
+        final References refs = new MkGithub().randomRepo()
+            .git().references();
         MatcherAssert.assertThat(
             refs.create("refs/heads/branch1", "abcderf122"),
             Matchers.notNullValue()
@@ -65,7 +65,8 @@ public final class MkReferencesTest {
      */
     @Test
     public void returnsRepo() throws Exception {
-        final References refs = this.repo().git().references();
+        final References refs = new MkGithub().randomRepo()
+            .git().references();
         MatcherAssert.assertThat(
             refs.repo(),
             Matchers.notNullValue()
@@ -78,7 +79,7 @@ public final class MkReferencesTest {
      */
     @Test
     public void iteratesReferences() throws Exception {
-        final Repo owner = this.repo();
+        final Repo owner = new MkGithub().randomRepo();
         final References refs = owner.git().references();
         refs.create("refs/heads/br", "qweqwe");
         refs.create("refs/tags/t1", "111t222");
@@ -94,7 +95,7 @@ public final class MkReferencesTest {
      */
     @Test
     public void iteratesReferencesInSubNamespace() throws Exception {
-        final Repo owner = this.repo();
+        final Repo owner = new MkGithub().randomRepo();
         final References refs = owner.git().references();
         refs.create("refs/heads/br", "qweqwe");
         refs.create("refs/tags/t1", "111t222");
@@ -114,7 +115,7 @@ public final class MkReferencesTest {
      */
     @Test
     public void iteratesTags() throws Exception {
-        final Repo owner = this.repo();
+        final Repo owner = new MkGithub().randomRepo();
         final References refs = owner.git().references();
         refs.create("refs/tags/t2", "2322f34");
         MatcherAssert.assertThat(
@@ -129,7 +130,7 @@ public final class MkReferencesTest {
      */
     @Test
     public void iteratesHeads() throws Exception {
-        final Repo owner = this.repo();
+        final Repo owner = new MkGithub().randomRepo();
         final References refs = owner.git().references();
         refs.create("refs/heads/branch2", "blahblah");
         MatcherAssert.assertThat(
@@ -144,7 +145,7 @@ public final class MkReferencesTest {
      */
     @Test
     public void removesReference() throws Exception {
-        final Repo owner = this.repo();
+        final Repo owner = new MkGithub().randomRepo();
         final References refs = owner.git().references();
         refs.create("refs/heads/testbr", "qweqwe22");
         refs.create("refs/tags/t2", "111teee");
@@ -158,15 +159,4 @@ public final class MkReferencesTest {
             Matchers.<Reference>iterableWithSize(1)
         );
     }
-    /**
-     * Repo for testing.
-     * @return Repo
-     * @throws Exception - if something goes wrong.
-     */
-    private Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
 }

--- a/src/test/java/com/jcabi/github/mock/MkReleaseAssetTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseAssetTest.java
@@ -32,7 +32,6 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Release;
 import com.jcabi.github.ReleaseAsset;
 import com.jcabi.github.ReleaseAssets;
-import com.jcabi.github.Repos;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import javax.json.Json;
@@ -210,8 +209,6 @@ public final class MkReleaseAssetTest {
      * @throws Exception If some problem inside
      */
     private static Release release() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        ).releases().create("v1.0");
+        return new MkGithub().randomRepo().releases().create("v1.0");
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkReleaseAssetsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseAssetsTest.java
@@ -32,7 +32,6 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Release;
 import com.jcabi.github.ReleaseAsset;
 import com.jcabi.github.ReleaseAssets;
-import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -118,8 +117,6 @@ public final class MkReleaseAssetsTest {
      * @throws Exception If some problem inside
      */
     private static Release release() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        ).releases().create("v1.0");
+        return new MkGithub().randomRepo().releases().create("v1.0");
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkReleaseTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseTest.java
@@ -32,7 +32,6 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Github;
 import com.jcabi.github.Release;
 import com.jcabi.github.Releases;
-import com.jcabi.github.Repos;
 import java.io.IOException;
 import javax.json.JsonString;
 import javax.json.JsonValue;
@@ -239,8 +238,6 @@ public final class MkReleaseTest {
      * @throws IOException if any I/O problems occur.
      */
     private static Releases releases() throws IOException {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        ).releases();
+        return new MkGithub().randomRepo().releases();
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkReleaseTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseTest.java
@@ -196,7 +196,7 @@ public final class MkReleaseTest {
      * @throws Exception If some problem inside
      */
     @Test
-    public void canGetPublichedAt() throws Exception {
+    public void canGetPublishedAt() throws Exception {
         final Release release = MkReleaseTest.release();
         final Release.Smart smart = new Release.Smart(release);
         MatcherAssert.assertThat(

--- a/src/test/java/com/jcabi/github/mock/MkReleasesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleasesTest.java
@@ -31,8 +31,6 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.Release;
 import com.jcabi.github.Releases;
-import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -50,7 +48,7 @@ public final class MkReleasesTest {
      */
     @Test
     public void canFetchEmptyListOfReleases() throws Exception {
-        final Releases releases = MkReleasesTest.repo().releases();
+        final Releases releases = new MkGithub().randomRepo().releases();
         MatcherAssert.assertThat(
             releases.iterate(),
             Matchers.emptyIterable()
@@ -63,7 +61,7 @@ public final class MkReleasesTest {
      */
     @Test
     public void canFetchNonEmptyListOfReleases() throws Exception {
-        final Releases releases = MkReleasesTest.repo().releases();
+        final Releases releases = new MkGithub().randomRepo().releases();
         final String tag = "v1.0";
         releases.create(tag);
         MatcherAssert.assertThat(
@@ -79,7 +77,7 @@ public final class MkReleasesTest {
      */
     @Test
     public void canFetchSingleRelease() throws Exception {
-        final Releases releases = MkReleasesTest.repo().releases();
+        final Releases releases = new MkGithub().randomRepo().releases();
         MatcherAssert.assertThat(releases.get(1), Matchers.notNullValue());
     }
 
@@ -89,7 +87,7 @@ public final class MkReleasesTest {
      */
     @Test
     public void canCreateRelease() throws Exception {
-        final Releases releases = MkReleasesTest.repo().releases();
+        final Releases releases = new MkGithub().randomRepo().releases();
         final String tag = "v1.0.0";
         final Release release = releases.create(tag);
         MatcherAssert.assertThat(
@@ -104,7 +102,7 @@ public final class MkReleasesTest {
      */
     @Test
     public void iteratesReleases() throws Exception {
-        final Releases releases = repo().releases();
+        final Releases releases = new MkGithub().randomRepo().releases();
         releases.create("v1.0.1");
         releases.create("v1.0.2");
         MatcherAssert.assertThat(
@@ -119,7 +117,7 @@ public final class MkReleasesTest {
      */
     @Test
     public void canRemoveRelease() throws Exception {
-        final Releases releases = repo().releases();
+        final Releases releases = new MkGithub().randomRepo().releases();
         releases.create("v1.1.1");
         releases.create("v1.1.2");
         MatcherAssert.assertThat(
@@ -139,7 +137,7 @@ public final class MkReleasesTest {
      */
     @Test
     public void findsReleaseByTag() throws Exception {
-        final Releases releases = MkReleasesTest.repo().releases();
+        final Releases releases = new MkGithub().randomRepo().releases();
         final String tag = "v5.0";
         releases.create(tag);
         MatcherAssert.assertThat(
@@ -149,17 +147,6 @@ public final class MkReleasesTest {
         MatcherAssert.assertThat(
             new Release.Smart(new Releases.Smart(releases).find(tag)).tag(),
             Matchers.equalTo(tag)
-        );
-    }
-
-    /**
-     * Create a repo to work with.
-     * @return Repo
-     * @throws Exception If some problem inside
-     */
-    private static Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkRepoTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkRepoTest.java
@@ -57,11 +57,11 @@ public final class MkRepoTest {
     public void works() throws Exception {
         final Repos repos = new MkRepos(new MkStorage.InFile(), "jeff");
         final Repo repo = repos.create(
-            new Repos.RepoCreate("test", false)
+            new Repos.RepoCreate("test5", false)
         );
         MatcherAssert.assertThat(
             repo.coordinates(),
-            Matchers.hasToString("jeff/test")
+            Matchers.hasToString("jeff/test5")
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkStarsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkStarsTest.java
@@ -30,8 +30,6 @@
 
 package com.jcabi.github.mock;
 
-import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import com.jcabi.github.Stars;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -50,7 +48,7 @@ public class MkStarsTest {
      */
     @Test
     public final void starsRepository() throws Exception {
-        final Stars stars = this.repo().stars();
+        final Stars stars = new MkGithub().randomRepo().stars();
         stars.star();
         MatcherAssert.assertThat(
             stars.starred(),
@@ -64,7 +62,7 @@ public class MkStarsTest {
      */
     @Test
     public final void unstarsRepository() throws Exception {
-        final Stars stars = this.repo().stars();
+        final Stars stars = new MkGithub().randomRepo().stars();
         stars.star();
         stars.unstar();
         MatcherAssert.assertThat(
@@ -72,16 +70,4 @@ public class MkStarsTest {
             Matchers.is(false)
         );
     }
-
-    /**
-     * Create an repo to work with.
-     * @return Repo
-     * @throws Exception If some problem inside
-     */
-    private Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
 }

--- a/src/test/java/com/jcabi/github/mock/MkTagTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkTagTest.java
@@ -30,7 +30,6 @@
 
 package com.jcabi.github.mock;
 
-import com.jcabi.github.Repos;
 import com.jcabi.github.Tag;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -67,9 +66,7 @@ public final class MkTagTest {
         final JsonObject json = Json.createObjectBuilder()
             .add("sha", "abcsha12").add("message", "test tag")
             .add("name", "v.0.1").build();
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        ).git().tags().create(json);
+        return new MkGithub().randomRepo().git().tags().create(json);
     }
 
 }

--- a/src/test/java/com/jcabi/github/mock/MkTagsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkTagsTest.java
@@ -30,8 +30,6 @@
 
 package com.jcabi.github.mock;
 
-import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
@@ -55,7 +53,7 @@ public final class MkTagsTest {
         final JsonObject tagger = Json.createObjectBuilder()
             .add("name", "Scott").add("email", "Scott@gmail.com").build();
         MatcherAssert.assertThat(
-            this.repo().git().tags().create(
+            new MkGithub().randomRepo().git().tags().create(
                 Json.createObjectBuilder().add("name", "v.0.1")
                     .add("message", "test tag").add("sha", "abcsha12")
                     .add("tagger", tagger).build()
@@ -63,16 +61,4 @@ public final class MkTagsTest {
             Matchers.notNullValue()
         );
     }
-
-    /**
-     * Repo for testing.
-     * @return Repo
-     * @throws Exception - if something goes wrong.
-     */
-    private Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
 }

--- a/src/test/java/com/jcabi/github/mock/MkTreeTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkTreeTest.java
@@ -30,7 +30,6 @@
 
 package com.jcabi.github.mock;
 
-import com.jcabi.github.Repos;
 import com.jcabi.github.Tree;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -72,9 +71,7 @@ public final class MkTreeTest {
                     .add("name", "v.0.1").build()
             )
         ).build();
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        ).git().trees().create(json);
+        return new MkGithub().randomRepo().git().trees().create(json);
     }
 
 }

--- a/src/test/java/com/jcabi/github/mock/MkTreesTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkTreesTest.java
@@ -31,7 +31,6 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Repo;
-import com.jcabi.github.Repos;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
@@ -66,7 +65,7 @@ public final class MkTreesTest {
                 )
             ).build();
         MatcherAssert.assertThat(
-            this.repo().git().trees().create(tree),
+            new MkGithub().randomRepo().git().trees().create(tree),
             Matchers.notNullValue()
         );
     }
@@ -91,23 +90,11 @@ public final class MkTreesTest {
                     .build()
             ).build()
         ).build();
-        final Repo repo = this.repo();
+        final Repo repo = new MkGithub().randomRepo();
         repo.git().trees().create(json);
         MatcherAssert.assertThat(
             repo.git().trees().getRec(sha).json().getString("sha"),
             Matchers.containsString(sha)
         );
     }
-
-    /**
-     * Repo for testing.
-     * @return Repo
-     * @throws Exception - if something goes wrong.
-     */
-    private Repo repo() throws Exception {
-        return new MkGithub().repos().create(
-            new Repos.RepoCreate("test", false)
-        );
-    }
-
 }


### PR DESCRIPTION
Fixes #1096 by refactoring existing tests to, wherever feasible, use `RepoRule.repo()` and `MkGithub.randomRepo()` for temporary test repo creation, instead of reimplementing such logic across many testcase classes. Much duplicate code is thus eliminated.