### PR TITLE
Fix status name passing

### DIFF
--- a/src/main/java/com/jcabi/github/RtStatuses.java
+++ b/src/main/java/com/jcabi/github/RtStatuses.java
@@ -34,6 +34,7 @@ import com.jcabi.http.response.JsonResponse;
 import com.jcabi.http.response.RestResponse;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Locale;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonStructure;
@@ -106,7 +107,7 @@ public class RtStatuses implements Statuses {
         @NotNull(message = "status can't be NULL") final Status status
     ) throws IOException {
         final JsonStructure json = Json.createObjectBuilder()
-            .add("state", status.state().name())
+            .add("state", status.state().name().toLowerCase(Locale.getDefault()))
             .add("target_url", status.targetUrl())
             .add("description", status.description())
             .add("context", status.context())

--- a/src/main/java/com/jcabi/github/RtStatuses.java
+++ b/src/main/java/com/jcabi/github/RtStatuses.java
@@ -107,7 +107,7 @@ public class RtStatuses implements Statuses {
         @NotNull(message = "status can't be NULL") final Status status
     ) throws IOException {
         final JsonStructure json = Json.createObjectBuilder()
-            .add("state", status.state().name().toLowerCase(Locale.getDefault()))
+            .add("state", status.state().name().toLowerCase(Locale.ENGLISH))
             .add("target_url", status.targetUrl())
             .add("description", status.description())
             .add("context", status.context())


### PR DESCRIPTION
With changing enum names to camel-cased there creeped an error - Github API only accepts lower case statuses.