### PR TITLE
Don't bother generating docs when installing pdd

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -2,7 +2,7 @@ architect:
 - yegor256
 - dmarkov
 install:
-- sudo gem install pdd
+- sudo gem install -N pdd
 assets:
   secring.gpg: yegor256/home#assets/secring.gpg
   settings.xml: yegor256/home#assets/jcabi/settings.xml


### PR DESCRIPTION
This should speed up the build a little bit and avoid some unnecessary console output.