### PR TITLE
Fix Rultor build by using --no-rdoc --no-ri instead of -N

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -2,7 +2,7 @@ architect:
 - yegor256
 - dmarkov
 install:
-- sudo gem install -N pdd
+- sudo gem install --no-rdoc --no-ri pdd
 assets:
   secring.gpg: yegor256/home#assets/secring.gpg
   settings.xml: yegor256/home#assets/jcabi/settings.xml


### PR DESCRIPTION
See https://github.com/jcabi/jcabi-github/pull/1100#issuecomment-110250596
Refs #1103.