### PR TITLE
Add missing MkGrizzlyContainer stoppages in tests

### DIFF
--- a/src/test/java/com/jcabi/github/RtMilestonesTest.java
+++ b/src/test/java/com/jcabi/github/RtMilestonesTest.java
@@ -56,15 +56,19 @@ public final class RtMilestonesTest {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
         ).start();
-        final RtMilestones milestones = new RtMilestones(
-            new ApacheRequest(container.home()),
-            repo()
-        );
-        milestones.remove(1);
-        MatcherAssert.assertThat(
-            container.take().method(),
-            Matchers.equalTo(Request.DELETE)
-        );
+        try {
+            final RtMilestones milestones = new RtMilestones(
+                new ApacheRequest(container.home()),
+                repo()
+            );
+            milestones.remove(1);
+            MatcherAssert.assertThat(
+                container.take().method(),
+                Matchers.equalTo(Request.DELETE)
+            );
+        } finally {
+            container.stop();
+        }
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtRepoTest.java
+++ b/src/test/java/com/jcabi/github/RtRepoTest.java
@@ -330,10 +330,14 @@ public final class RtRepoTest {
                     .build().toString()
             )
         ).start();
-        final Repo repo = RtRepoTest.repo(
-            new ApacheRequest(container.home())
-        );
-        MatcherAssert.assertThat(repo.languages(), Matchers.notNullValue());
+        try {
+            final Repo repo = RtRepoTest.repo(
+                new ApacheRequest(container.home())
+            );
+            MatcherAssert.assertThat(repo.languages(), Matchers.notNullValue());
+        } finally {
+            container.stop();
+        }
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtStarsTest.java
+++ b/src/test/java/com/jcabi/github/RtStarsTest.java
@@ -61,20 +61,24 @@ public final class RtStarsTest {
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT)
         ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_NOT_FOUND))
             .start();
-        final Stars starred = new RtStars(
-            new ApacheRequest(container.home()),
-            RtStarsTest.repo("someuser", "starredrepo")
-        );
-        MatcherAssert.assertThat(
-            starred.starred(), Matchers.is(true)
-        );
-        final Stars unstarred = new RtStars(
-            new ApacheRequest(container.home()),
-            RtStarsTest.repo("otheruser", "notstarredrepo")
-        );
-        MatcherAssert.assertThat(
-            unstarred.starred(), Matchers.is(false)
-        );
+        try {
+            final Stars starred = new RtStars(
+                new ApacheRequest(container.home()),
+                RtStarsTest.repo("someuser", "starredrepo")
+            );
+            MatcherAssert.assertThat(
+                starred.starred(), Matchers.is(true)
+            );
+            final Stars unstarred = new RtStars(
+                new ApacheRequest(container.home()),
+                RtStarsTest.repo("otheruser", "notstarredrepo")
+            );
+            MatcherAssert.assertThat(
+                unstarred.starred(), Matchers.is(false)
+            );
+        } finally {
+            container.stop();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #1116.
After auditing the test logs, I found some tests that use `MkGrizzlyContainer` but never call `.stop()` anywhere, thus leaking open ports.
Also filed https://github.com/jcabi/jcabi-http/issues/96 which would make it possible to largely prevent this in the future.