### PR TITLE
Separate "user X's orgs" from "all orgs and my orgs"

### DIFF
--- a/src/main/java/com/jcabi/github/Github.java
+++ b/src/main/java/com/jcabi/github/Github.java
@@ -120,6 +120,14 @@ public interface Github {
     Users users();
 
     /**
+     * Get Organizations API entry point.
+     * @return Organizations API entry point
+     * @since 0.24
+     */
+    @NotNull(message = "organizations is never NULL")
+    Organizations organizations();
+
+    /**
      * Get Markdown API entry point.
      * @return Markdown API entry point
      * @since 0.6

--- a/src/main/java/com/jcabi/github/Organizations.java
+++ b/src/main/java/com/jcabi/github/Organizations.java
@@ -35,6 +35,7 @@ import javax.validation.constraints.NotNull;
 /**
  * Github organizations.
  * @author Paul Polishchuk (ppol@ua.fm)
+ * @author Chris Rebert (github@chrisrebert.com)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
  * @since 0.24

--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -74,6 +74,7 @@ import org.apache.commons.io.Charsets;
 @Loggable(Loggable.DEBUG)
 @ToString
 @EqualsAndHashCode(of = "request")
+@SuppressWarnings("PMD.TooManyMethods")
 public final class RtGithub implements Github {
 
     /**
@@ -177,6 +178,12 @@ public final class RtGithub implements Github {
     @NotNull(message = "users are never NULL")
     public Users users() {
         return new RtUsers(this, this.request);
+    }
+
+    @Override
+    @NotNull(message = "organizations is never NULL")
+    public Organizations organizations() {
+        return new RtOrganizations(this, this.request);
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/RtOrganizations.java
+++ b/src/main/java/com/jcabi/github/RtOrganizations.java
@@ -41,23 +41,16 @@ import lombok.EqualsAndHashCode;
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
- * @since 0.7
- * @checkstyle MultipleStringLiterals (500 lines)
+ * @since 0.24
  */
 @Immutable
 @Loggable(Loggable.DEBUG)
-@EqualsAndHashCode(of = { "entry", "ghub", "request", "owner" })
+@EqualsAndHashCode(of = { "entry", "ghub", "request" })
 final class RtOrganizations implements Organizations {
-
     /**
      * API entry point.
      */
     private final transient Request entry;
-
-    /**
-     * Github.
-     */
-    private final transient Github ghub;
 
     /**
      * RESTful request.
@@ -65,33 +58,19 @@ final class RtOrganizations implements Organizations {
     private final transient Request request;
 
     /**
-     * User we're in.
+     * Github.
      */
-    private final transient User owner;
+    private final transient Github ghub;
 
     /**
      * Public ctor.
      * @param github Github
      * @param req Request
-     * @param user User
      */
-    RtOrganizations(final Github github, final Request req, final User user) {
+    RtOrganizations(final Github github, final Request req) {
         this.entry = req;
-        this.ghub = github;
-        this.owner = user;
         this.request = this.entry.uri().path("/user").path("/orgs").back();
-    }
-
-    @Override
-    @NotNull(message = "Github is never NULL")
-    public Github github() {
-        return this.ghub;
-    }
-
-    @Override
-    @NotNull(message = "user is never NULL")
-    public User user() {
-        return this.owner;
+        this.ghub = github;
     }
 
     @Override
@@ -107,22 +86,6 @@ final class RtOrganizations implements Organizations {
     public Iterable<Organization> iterate() {
         return new RtPagination<Organization>(
             this.request,
-            new RtValuePagination.Mapping<Organization, JsonObject>() {
-                @Override
-                public Organization map(final JsonObject object) {
-                    return RtOrganizations.this.get(object.getString("login"));
-                }
-            }
-        );
-    }
-
-    @Override
-    @NotNull(message = "Iterable of orgs is never NULL")
-    public Iterable<Organization> iterate(
-        @NotNull(message = "username can't be NULL") final String username
-    ) {
-        return new RtPagination<Organization>(
-            this.entry.uri().path("/users").path(username).path("/orgs").back(),
             new RtValuePagination.Mapping<Organization, JsonObject>() {
                 @Override
                 public Organization map(final JsonObject object) {

--- a/src/main/java/com/jcabi/github/RtUser.java
+++ b/src/main/java/com/jcabi/github/RtUser.java
@@ -130,8 +130,8 @@ final class RtUser implements User {
 
     @Override
     @NotNull(message = "organizations is never NULL")
-    public Organizations organizations() {
-        return new RtOrganizations(this.ghub, this.ghub.entry(), this);
+    public UserOrganizations organizations() {
+        return new RtUserOrganizations(this.ghub, this.ghub.entry(), this);
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/RtUserOrganizations.java
+++ b/src/main/java/com/jcabi/github/RtUserOrganizations.java
@@ -40,6 +40,7 @@ import lombok.EqualsAndHashCode;
 /**
  * Github user organizations.
  * @author Paul Polishchuk (ppol@ua.fm)
+ * @author Chris Rebert (github@chrisrebert.com)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
  * @since 0.24

--- a/src/main/java/com/jcabi/github/User.java
+++ b/src/main/java/com/jcabi/github/User.java
@@ -72,10 +72,10 @@ public interface User extends JsonReadable, JsonPatchable {
 
     /**
      * Get his organizations.
-     * @return Organizations organizations
+     * @return UserOrganizations organizations
      */
     @NotNull(message = "organizations is never NULL")
-    Organizations organizations();
+    UserOrganizations organizations();
 
     /**
      * Get his keys.
@@ -244,7 +244,7 @@ public interface User extends JsonReadable, JsonPatchable {
 
         @Override
         @NotNull(message = "Organizations is never NULL")
-        public Organizations organizations() {
+        public UserOrganizations organizations() {
             return this.user.organizations();
         }
 

--- a/src/main/java/com/jcabi/github/UserOrganizations.java
+++ b/src/main/java/com/jcabi/github/UserOrganizations.java
@@ -36,6 +36,7 @@ import javax.validation.constraints.NotNull;
 /**
  * Organizations of a Github user.
  * @author Paul Polishchuk (ppol@ua.fm)
+ * @author Chris Rebert (github@chrisrebert.com)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
  * @since 0.24

--- a/src/main/java/com/jcabi/github/UserOrganizations.java
+++ b/src/main/java/com/jcabi/github/UserOrganizations.java
@@ -30,31 +30,42 @@
 package com.jcabi.github;
 
 import com.jcabi.aspects.Immutable;
+import java.io.IOException;
 import javax.validation.constraints.NotNull;
 
 /**
- * Github organizations.
+ * Organizations of a Github user.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
  * @since 0.24
  */
 @Immutable
-public interface Organizations {
-    /**
-     * Get specific organization by name.
-     * @param login Login name of the organization.
-     * @return Organization
-     * @see <a href="http://developer.github.com/v3/orgs/#get-an-organization">Get a Single Organization</a>
-     */
-    @NotNull(message = "organization is never NULL")
-    Organization get(@NotNull(message = "login is never NULL") String login);
+public interface UserOrganizations {
 
     /**
-     * Iterate over organizations of the currently logged-in user.
+     * Github we're in.
+     * @return Github
+     */
+    @NotNull(message = "Github is never NULL")
+    Github github();
+
+    /**
+     * Get its owner.
+     * @return User
+     */
+    @NotNull(message = "user is never NULL")
+    User user();
+
+    /**
+     * Iterate organizations of particular user.
+     * All public organizations for an unauthenticated user or
+     * private and public organizations for authenticated users
      * @return Iterator of Organizations
-     * @see <a href="https://developer.github.com/v3/orgs/#list-your-organizations">List Your Organizations</a>
+     * @throws IOException If there is an I/O problem
+     * @see <a href="http://developer.github.com/v3/orgs/#list-user-organizations">List User Organizations</a>
+     * @since 0.24
      */
     @NotNull(message = "iterable is never NULL")
-    Iterable<Organization> iterate();
+    Iterable<Organization> iterate() throws IOException;
 }

--- a/src/main/java/com/jcabi/github/mock/MkGithub.java
+++ b/src/main/java/com/jcabi/github/mock/MkGithub.java
@@ -37,6 +37,7 @@ import com.jcabi.github.Github;
 import com.jcabi.github.Gitignores;
 import com.jcabi.github.Limits;
 import com.jcabi.github.Markdown;
+import com.jcabi.github.Organizations;
 import com.jcabi.github.Repo;
 import com.jcabi.github.Repos;
 import com.jcabi.github.Search;
@@ -158,6 +159,16 @@ public final class MkGithub implements Github {
     public Users users() {
         try {
             return new MkUsers(this.storage, this.self);
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @Override
+    @NotNull(message = "organizations is never NULL")
+    public Organizations organizations() {
+        try {
+            return new MkOrganizations(this.storage);
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);
         }

--- a/src/main/java/com/jcabi/github/mock/MkUser.java
+++ b/src/main/java/com/jcabi/github/mock/MkUser.java
@@ -33,10 +33,10 @@ import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Github;
 import com.jcabi.github.Notification;
-import com.jcabi.github.Organizations;
 import com.jcabi.github.PublicKeys;
 import com.jcabi.github.User;
 import com.jcabi.github.UserEmails;
+import com.jcabi.github.UserOrganizations;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
@@ -106,9 +106,9 @@ final class MkUser implements User {
 
     @Override
     @NotNull(message = "orgs is never NULL")
-    public Organizations organizations() {
+    public UserOrganizations organizations() {
         try {
-            return new MkOrganizations(this.storage, this.self);
+            return new MkUserOrganizations(this.storage, this.self);
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);
         }

--- a/src/main/java/com/jcabi/github/mock/MkUserOrganizations.java
+++ b/src/main/java/com/jcabi/github/mock/MkUserOrganizations.java
@@ -46,6 +46,7 @@ import org.xembly.Directives;
 /**
  * Github user organizations.
  * @author Paul Polishchuk (ppol@ua.fm)
+ * @author Chris Rebert (github@chrisrebert.com)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
  * @since 0.24

--- a/src/test/java/com/jcabi/github/RtOrganizationsITCase.java
+++ b/src/test/java/com/jcabi/github/RtOrganizationsITCase.java
@@ -36,7 +36,7 @@ import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtOrganizations}.
+ * Test case for {@link RtUserOrganizations}.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
@@ -45,7 +45,7 @@ import org.junit.Test;
 @OAuthScope(Scope.READ_ORG)
 public final class RtOrganizationsITCase {
     /**
-     * RtOrganizations can get an organization.
+     * RtUserOrganizations can get an organization.
      * @throws Exception if any problem inside
      */
     @Test
@@ -57,12 +57,12 @@ public final class RtOrganizationsITCase {
     }
 
     /**
-     * RtOrganizations can iterate all organizations.
+     * RtUserOrganizations can iterate all organizations.
      * @throws Exception if any problem inside
      */
     @Test
     public void iterateOrganizations() throws Exception {
-        final Organizations orgs = github().users().self().organizations();
+        final UserOrganizations orgs = github().users().self().organizations();
         MatcherAssert.assertThat(
             orgs.iterate("yegor256").iterator().next(),
             Matchers.notNullValue()

--- a/src/test/java/com/jcabi/github/RtOrganizationsTest.java
+++ b/src/test/java/com/jcabi/github/RtOrganizationsTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
  * Test case for {@link RtOrganizations}.
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
+ * @author Chris Rebert (github@chrisrebert.com)
  * @version $Id$
  */
 public final class RtOrganizationsTest {

--- a/src/test/java/com/jcabi/github/RtPublicMembersITCase.java
+++ b/src/test/java/com/jcabi/github/RtPublicMembersITCase.java
@@ -71,7 +71,7 @@ public final class RtPublicMembersITCase {
         Assume.assumeThat(key, Matchers.notNullValue());
         final Github github = new RtGithub(key);
         final Users users = github.users();
-        org = users.get(ORG_NAME).organizations().get(ORG_NAME);
+        org = github.organizations().get(ORG_NAME);
         member = users.get("yegor256");
         nonMember = users.get("charset");
     }

--- a/src/test/java/com/jcabi/github/RtUserOrganizationsITCase.java
+++ b/src/test/java/com/jcabi/github/RtUserOrganizationsITCase.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 /**
  * Test case for {@link RtUserOrganizations}.
  * @author Paul Polishchuk (ppol@ua.fm)
+ * @author Chris Rebert (github@chrisrebert.com)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
  * @since 0.24

--- a/src/test/java/com/jcabi/github/RtUserOrganizationsITCase.java
+++ b/src/test/java/com/jcabi/github/RtUserOrganizationsITCase.java
@@ -29,29 +29,33 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.OAuthScope.Scope;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
 import org.junit.Test;
 
 /**
- * Test case for {@link RtOrganizations}.
+ * Test case for {@link RtUserOrganizations}.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
  * @since 0.24
  */
-public final class RtOrganizationsITCase {
+@OAuthScope(Scope.READ_ORG)
+public final class RtUserOrganizationsITCase {
     /**
-     * RtOrganizations can get an organization.
+     * RtUserOrganizations can iterate all organizations of a user.
      * @throws Exception if any problem inside
      */
     @Test
-    public void getOrganization() throws Exception {
-        final String login = "github";
-        final Organization org = github()
-            .organizations().get(login);
-        MatcherAssert.assertThat(org.login(), Matchers.equalTo(login));
+    public void iterateOrganizations() throws Exception {
+        final UserOrganizations orgs = github().users().get("yegor256")
+            .organizations();
+        MatcherAssert.assertThat(
+            orgs.iterate().iterator().next(),
+            Matchers.notNullValue()
+        );
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtUserOrganizationsTest.java
+++ b/src/test/java/com/jcabi/github/RtUserOrganizationsTest.java
@@ -44,15 +44,15 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 /**
- * Test case for {@link RtOrganizations}.
+ * Test case for {@link RtUserOrganizations}.
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  */
-public final class RtOrganizationsTest {
+public final class RtUserOrganizationsTest {
 
     /**
-     * RtOrganizations should be able to iterate its organizations.
+     * RtUserOrganizations should be able to iterate its organizations.
      *
      * @throws Exception If a problem occurs
      * @checkstyle MagicNumberCheck (25 lines)
@@ -70,7 +70,7 @@ public final class RtOrganizationsTest {
             )
         ).start();
         try {
-            final Organizations orgs = new RtOrganizations(
+            final UserOrganizations orgs = new RtUserOrganizations(
                 new MkGithub(),
                 new ApacheRequest(container.home()),
                 Mockito.mock(User.class)
@@ -89,7 +89,7 @@ public final class RtOrganizationsTest {
     }
 
     /**
-     * RtOrganizations can iterate organizations for an unauthenticated user.
+     * RtUserOrganizations can iterate organizations for an unauthenticated user.
      *
      * @throws Exception If a problem occurs
      */
@@ -106,7 +106,7 @@ public final class RtOrganizationsTest {
             )
         ).start();
         try {
-            final Organizations orgs = new RtOrganizations(
+            final UserOrganizations orgs = new RtUserOrganizations(
                 new MkGithub(),
                 new ApacheRequest(container.home()),
                 Mockito.mock(User.class)
@@ -126,7 +126,7 @@ public final class RtOrganizationsTest {
     }
 
     /**
-     * RtOrganizations should be able to get a single organization.
+     * RtUserOrganizations should be able to get a single organization.
      *
      * @throws Exception if a problem occurs
      */
@@ -136,7 +136,7 @@ public final class RtOrganizationsTest {
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
         ).start();
         try {
-            final Organizations orgs = new RtOrganizations(
+            final UserOrganizations orgs = new RtUserOrganizations(
                 new MkGithub(),
                 new ApacheRequest(container.home()),
                 Mockito.mock(User.class)

--- a/src/test/java/com/jcabi/github/RtUserOrganizationsTest.java
+++ b/src/test/java/com/jcabi/github/RtUserOrganizationsTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
  * Test case for {@link RtUserOrganizations}.
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
+ * @author Chris Rebert (github@chrisrebert.com)
  * @version $Id$
  */
 public final class RtUserOrganizationsTest {

--- a/src/test/java/com/jcabi/github/mock/MkOrganizationsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkOrganizationsTest.java
@@ -30,33 +30,76 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Github;
-import com.jcabi.github.UserOrganizations;
+import com.jcabi.github.Organizations;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Github user organizations.
+ * Github organizations.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
  * @since 0.24
- * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
-public final class MkUserOrganizationsTest {
+public final class MkOrganizationsTest {
     /**
-     * MkUserOrganizations can list user organizations.
+     * MkOrganizations can get specific organization.
      * @throws Exception If some problem inside
      */
     @Test
-    public void iteratesUserOrganizations() throws Exception {
-        final String login = "orgTestIterate";
-        final Github github = new MkGithub(login);
-        final UserOrganizations userOrgs = github.users().get(login)
-            .organizations();
-        github.organizations().get(login);
+    public void getSingleOrganization() throws Exception {
+        final String login = "orgTestGet";
+        final MkOrganizations orgs = new MkOrganizations(
+            new MkStorage.InFile()
+        );
         MatcherAssert.assertThat(
-            userOrgs.iterate(),
+            orgs.get(login),
+            Matchers.notNullValue()
+        );
+        MatcherAssert.assertThat(
+            orgs.get(login).json().getString("login"),
+            Matchers.equalTo(login)
+        );
+    }
+
+    /**
+     * Organization created_at field should be variable.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void testCreatedAt() throws Exception {
+        final String name = "testCreatedAt";
+        final MkOrganizations orgs = new MkOrganizations(
+            new MkStorage.InFile()
+        );
+        final String created = "created_at";
+        final Date early = new Github.Time(
+            orgs.get(name)
+                .json()
+                .getString(created)
+        ).date();
+        TimeUnit.SECONDS.sleep(1L);
+        final Date later = new Github.Time(
+            orgs.get(name)
+                .json()
+                .getString(created)
+        ).date();
+        MatcherAssert.assertThat(later, Matchers.greaterThanOrEqualTo(early));
+    }
+
+    /**
+     * MkOrganizations can list the logged-in user's organizations.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void iteratesCurrentUserOrganizations() throws Exception {
+        final Organizations orgs = new MkGithub().organizations();
+        orgs.get("orgTestIterate");
+        MatcherAssert.assertThat(
+            orgs.iterate(),
             Matchers.not(Matchers.emptyIterable())
         );
     }

--- a/src/test/java/com/jcabi/github/mock/MkPublicMembersTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPublicMembersTest.java
@@ -158,7 +158,7 @@ public final class MkPublicMembersTest {
      * @throws IOException If there is an I/O problem
      */
     private static MkOrganization organization() throws IOException {
-        return (MkOrganization) new MkOrganizations(
+        return (MkOrganization) new MkUserOrganizations(
             new MkStorage.InFile(),
             "maxwell"
         ).get(RandomStringUtils.randomAlphanumeric(Tv.TWENTY));

--- a/src/test/java/com/jcabi/github/mock/MkPublicMembersTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPublicMembersTest.java
@@ -158,9 +158,8 @@ public final class MkPublicMembersTest {
      * @throws IOException If there is an I/O problem
      */
     private static MkOrganization organization() throws IOException {
-        return (MkOrganization) new MkUserOrganizations(
-            new MkStorage.InFile(),
-            "maxwell"
+        return (MkOrganization) new MkOrganizations(
+            new MkStorage.InFile()
         ).get(RandomStringUtils.randomAlphanumeric(Tv.TWENTY));
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkUserOrganizationsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkUserOrganizationsTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 /**
  * Github user organizations.
  * @author Paul Polishchuk (ppol@ua.fm)
+ * @author Chris Rebert (github@chrisrebert.com)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/orgs/">Organizations API</a>
  * @since 0.24

--- a/src/test/java/com/jcabi/github/mock/MkUserOrganizationsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkUserOrganizationsTest.java
@@ -45,15 +45,15 @@ import org.junit.Test;
  * @since 0.7
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
-public final class MkOrganizationsTest {
+public final class MkUserOrganizationsTest {
 
     /**
-     * MkOrganizations can list organizations.
+     * MkUserOrganizations can list organizations.
      * @throws Exception If some problem inside
      */
     @Test
     public void iteratesOrganizations() throws Exception {
-        final MkOrganizations orgs = new MkOrganizations(
+        final MkUserOrganizations orgs = new MkUserOrganizations(
             new MkStorage.InFile(),
             "orgTestIterate"
         );
@@ -65,13 +65,13 @@ public final class MkOrganizationsTest {
     }
 
     /**
-     * MkOrganizations can list user organizations.
+     * MkUserOrganizations can list user organizations.
      * @throws Exception If some problem inside
      */
     @Test
     public void iteratesUserOrganizations() throws Exception {
         final String login = "orgTestIterate";
-        final MkOrganizations orgs = new MkOrganizations(
+        final MkUserOrganizations orgs = new MkUserOrganizations(
             new MkStorage.InFile(),
             login
         );
@@ -83,13 +83,13 @@ public final class MkOrganizationsTest {
     }
 
     /**
-     * MkOrganizations can get specific organization.
+     * MkUserOrganizations can get specific organization.
      * @throws Exception If some problem inside
      */
     @Test
     public void getSingleOrganization() throws Exception {
         final String login = "orgTestGet";
-        final MkOrganizations orgs = new MkOrganizations(
+        final MkUserOrganizations orgs = new MkUserOrganizations(
             new MkStorage.InFile(),
             login
         );
@@ -109,7 +109,7 @@ public final class MkOrganizationsTest {
      */
     @Test
     public void testCreatedAt() throws Exception {
-        final MkOrganizations orgs = new MkOrganizations(
+        final MkUserOrganizations orgs = new MkUserOrganizations(
             new MkStorage.InFile(), "testCreatedAt"
         );
         final String created = "created_at";

--- a/src/test/java/com/jcabi/github/mock/MkUserTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkUserTest.java
@@ -29,7 +29,7 @@
  */
 package com.jcabi.github.mock;
 
-import com.jcabi.github.Organizations;
+import com.jcabi.github.UserOrganizations;
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -54,7 +54,7 @@ public final class MkUserTest {
             new MkStorage.InFile(),
             "orgTestIterate"
         );
-        final Organizations orgs = user.organizations();
+        final UserOrganizations orgs = user.organizations();
         MatcherAssert.assertThat(
             orgs,
             Matchers.notNullValue()


### PR DESCRIPTION
Fixes #1109.
* `Organizations` is renamed to `UserOrganizations` for clarity. It represents the organizations of which a particular user is a member.
* A new `Organizations` class is added, which represents all GitHub organizations in existence
  * `UserOrganizations`'s "get org named X" and "iterate the logged-in user's orgs" methods are moved to the new `Organizations` class, since they don't depend at all on the user whose organizations the `UserOrganizations` represents
* `User.organizations()` now returns `UserOrganizations`
* `Github.organizations()` is added; it returns the new `Organizations`