### PR TITLE
Make CommitsComparison.files() return typed objects instead of raw JSON

### DIFF
--- a/src/main/java/com/jcabi/github/CommitsComparison.java
+++ b/src/main/java/com/jcabi/github/CommitsComparison.java
@@ -58,6 +58,15 @@ public interface CommitsComparison extends JsonReadable {
     Repo repo();
 
     /**
+     * Iterate over the file changes between the two commits being
+     * compared.
+     * @return Iterable of file changes
+     * @throws IOException If there is any I/O problem
+     */
+    @NotNull(message = "files is never NULL")
+    Iterable<FileChange> files() throws IOException;
+
+    /**
      * Smart commits comparison with extra features.
      */
     @Immutable
@@ -102,14 +111,10 @@ public interface CommitsComparison extends JsonReadable {
             return commits;
         }
 
-        /**
-         * Get a JSON-array of objects with information about files.
-         * @return JSON-array
-         * @throws IOException If there is any I/O problem
-         */
-        @NotNull(message = "json array is never NULL")
-        public JsonArray files() throws IOException {
-            return this.comparison.json().getJsonArray("files");
+        @Override
+        @NotNull(message = "files is never NULL")
+        public Iterable<FileChange> files() throws IOException {
+            return this.comparison.files();
         }
 
         @Override

--- a/src/main/java/com/jcabi/github/FileChange.java
+++ b/src/main/java/com/jcabi/github/FileChange.java
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.google.common.base.Optional;
+import com.jcabi.aspects.Immutable;
+import com.jcabi.aspects.Loggable;
+import java.io.IOException;
+import java.util.Locale;
+import javax.json.JsonObject;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * File change.
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.24
+ * @see <a href="http://developer.github.com/v3/repos/commits/#compare-two-commits">Compare two commits</a>
+ */
+@Immutable
+@SuppressWarnings("PMD.TooManyMethods")
+public interface FileChange extends JsonReadable {
+    enum Status implements StringEnum {
+        /**
+         * File was added.
+         */
+        ADDED("added"),
+        /**
+         * File's content was modified.
+         */
+        MODIFIED("modified"),
+        /**
+         * File was removed.
+         */
+        REMOVED("removed"),
+        /**
+         * File was renamed.
+         */
+        RENAMED("renamed");
+
+        /**
+         * File status string.
+         */
+        private final transient String status;
+
+        /**
+         * Ctor.
+         * @param stat File status string.
+         */
+        Status(@NotNull(message = "stat can't be NULL") final String stat) {
+            this.status = stat;
+        }
+
+        @Override
+        @NotNull(message = "identifier is never NULL")
+        public String identifier() {
+            return this.status;
+        }
+
+        /**
+         * Get file change status corresponding to the given status string.
+         * @param name Status string
+         * @return Status enum value
+         */
+        public static FileChange.Status forValue(final String name) {
+            return Status.valueOf(name.toUpperCase(Locale.ENGLISH));
+        }
+    }
+
+    /**
+     * Smart file change with extra features.
+     */
+    @Immutable
+    @ToString
+    @Loggable(Loggable.DEBUG)
+    @EqualsAndHashCode(of = { "change", "jsn" })
+    @SuppressWarnings("PMD.TooManyMethods")
+    final class Smart implements FileChange {
+        /**
+         * Encapsulated file change.
+         */
+        private final transient FileChange change;
+        /**
+         * SmartJson object for convenient JSON parsing.
+         */
+        private final transient SmartJson jsn;
+
+        /**
+         * Public ctor.
+         * @param chng File change
+         */
+        public Smart(
+            @NotNull(message = "chng can't be NULL")
+            final FileChange chng
+        ) {
+            this.change = chng;
+            this.jsn = new SmartJson(chng);
+        }
+
+        /**
+         * File's commit SHA.
+         * @return SHA
+         * @throws IOException If there is any I/O problem
+         */
+        @NotNull(message = "commit SHA is never NULL")
+        public String sha() throws IOException {
+            return this.jsn.text("sha");
+        }
+
+        /**
+         * File's name. Includes the path to the file from the
+         * root directory of the repository. Does not start with a
+         * forward slash. Example: "foo/bar/baz.txt"
+         * @return Filename
+         * @throws IOException If there is any I/O problem
+         */
+        @NotNull(message = "filename is never NULL")
+        public String filename() throws IOException {
+            return this.jsn.text("filename");
+        }
+
+        /**
+         * Status of the file in this change.
+         * @return File status
+         * @throws IOException If there is any I/O problem
+         */
+        @NotNull(message = "status is never NULL")
+        public FileChange.Status status() throws IOException {
+            return FileChange.Status.forValue(this.jsn.text("status"));
+        }
+
+        /**
+         * Number of lines added, or 0 if the file is binary.
+         * @return Number of lines added
+         * @throws IOException If there is any I/O problem
+         */
+        public int additions() throws IOException {
+            return this.jsn.number("additions");
+        }
+
+        /**
+         * Number of lines deleted, or 0 if the file is binary.
+         * @return Number of lines deleted
+         * @throws IOException If there is any I/O problem
+         */
+        public int deletions() throws IOException {
+            return this.jsn.number("deletions");
+        }
+
+        /**
+         * Number of lines modified, which is equal to the sum of
+         * {@link Smart#additions()} and {@link Smart#deletions()}.
+         * @return Number of lines modified
+         * @throws IOException If there is any I/O problem
+         */
+        public int changes() throws IOException {
+            return this.jsn.number("changes");
+        }
+
+        /**
+         * Diff string of the changes to the file. Only available if
+         * the file is text (as opposed to binary).
+         * @return Diff string
+         * @throws IOException If there is any I/O problem
+         */
+        @NotNull(message = "optional itself is never NULL")
+        public Optional<String> patch() throws IOException {
+            return Optional.fromNullable(this.json().getString("patch", null));
+        }
+
+        /**
+         * URL for the raw contents of the file.
+         * @return URL
+         * @throws IOException If there is any I/O problem
+         */
+        @NotNull(message = "raw url is never NULL")
+        public String rawUrl() throws IOException {
+            return this.jsn.text("raw_url");
+        }
+
+        /**
+         * URL for the file's git blob.
+         * @return URL
+         * @throws IOException If there is any I/O problem
+         */
+        @NotNull(message = "blob url is never NULL")
+        public String blobUrl() throws IOException {
+            return this.jsn.text("blob_url");
+        }
+
+        /**
+         * Repo contents URL for the file.
+         * @return URL
+         * @throws IOException If there is any I/O problem
+         */
+        @NotNull(message = "contents url is never NULL")
+        public String contentsUrl() throws IOException {
+            return this.jsn.text("contents_url");
+        }
+
+        @Override
+        @NotNull(message = "json is never NULL")
+        public JsonObject json() throws IOException {
+            return this.change.json();
+        }
+    }
+}

--- a/src/main/java/com/jcabi/github/RtFileChange.java
+++ b/src/main/java/com/jcabi/github/RtFileChange.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.aspects.Loggable;
+import java.io.IOException;
+import javax.json.JsonObject;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * File change.
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.24
+ */
+@Loggable(Loggable.DEBUG)
+@EqualsAndHashCode(of = { "jsn" })
+@ToString
+final class RtFileChange implements FileChange {
+    /**
+     * Encapsulated JSON object.
+     */
+    private final transient JsonObject jsn;
+
+    /**
+     * Public ctor.
+     * @param obj File change JSON object
+     */
+    public RtFileChange(
+        @NotNull(message = "JSON object can't be NULL")
+        final JsonObject obj
+    ) {
+        this.jsn = obj;
+    }
+
+    @Override
+    @NotNull(message = "JSON is never NULL")
+    public JsonObject json() throws IOException {
+        return this.jsn;
+    }
+}

--- a/src/main/java/com/jcabi/github/mock/MkCommitsComparison.java
+++ b/src/main/java/com/jcabi/github/mock/MkCommitsComparison.java
@@ -29,10 +29,12 @@
  */
 package com.jcabi.github.mock;
 
+import com.google.common.collect.ImmutableList;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.github.CommitsComparison;
 import com.jcabi.github.Coordinates;
+import com.jcabi.github.FileChange;
 import com.jcabi.github.Repo;
 import java.io.IOException;
 import javax.json.Json;
@@ -49,6 +51,15 @@ import lombok.ToString;
 @Loggable(Loggable.DEBUG)
 @ToString
 final class MkCommitsComparison implements CommitsComparison {
+    /**
+     * File change JSON object.
+     */
+    private static final JsonObject FILE_JSON = Json.createObjectBuilder()
+        .add("sha", "bbcd538c8e72b8c175046e27cc8f907076331401")
+        .add("filename", "test-file")
+        // @checkstyle MultipleStringLiterals (1 lines)
+        .add("status", "modified")
+        .build();
 
     /**
      * Storage.
@@ -104,14 +115,19 @@ final class MkCommitsComparison implements CommitsComparison {
             )
             .add(
                 "files",
-                Json.createObjectBuilder()
-                    .add("sha", "bbcd538c8e72b8c175046e27cc8f907076331401")
-                    .add("filename", "test-file")
-                        // @checkstyle MultipleStringLiterals (1 lines)
-                    .add("status", "test")
+                Json.createArrayBuilder()
+                    .add(MkCommitsComparison.FILE_JSON)
                     .build()
             )
-            .add("commits", Json.createArrayBuilder())
+            .add("commits", Json.createArrayBuilder().build())
             .build();
+    }
+
+    @Override
+    @NotNull(message = "files is never NULL")
+    public Iterable<FileChange> files() {
+        return ImmutableList.<FileChange>of(
+            new MkFileChange(MkCommitsComparison.FILE_JSON)
+        );
     }
 }

--- a/src/main/java/com/jcabi/github/mock/MkFileChange.java
+++ b/src/main/java/com/jcabi/github/mock/MkFileChange.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github.mock;
+
+import com.jcabi.aspects.Loggable;
+import com.jcabi.github.FileChange;
+import javax.json.JsonObject;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * Mock file change.
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.24
+ */
+@Loggable(Loggable.DEBUG)
+@EqualsAndHashCode(of = "jsn")
+@ToString
+public final class MkFileChange implements FileChange {
+    /**
+     * Encapsulated file change JSON object.
+     */
+    private final transient JsonObject jsn;
+
+    /**
+     * Public ctor.
+     * @param obj File change JSON object
+     */
+    public MkFileChange(
+        @NotNull(message = "JSON obj can't be NULL")
+        final JsonObject obj
+    ) {
+        this.jsn = obj;
+    }
+
+    @Override
+    @NotNull(message = "json is never NULL")
+    public JsonObject json() {
+        return this.jsn;
+    }
+}

--- a/src/test/java/com/jcabi/github/CommitsComparisonTest.java
+++ b/src/test/java/com/jcabi/github/CommitsComparisonTest.java
@@ -101,7 +101,9 @@ public final class CommitsComparisonTest {
             )
         );
         MatcherAssert.assertThat(
-            comparison.files().getJsonObject(0).getString("filename"),
+            new FileChange.Smart(
+                comparison.files().iterator().next()
+            ).filename(),
             Matchers.equalTo(filename)
         );
     }

--- a/src/test/java/com/jcabi/github/FileChangeTest.java
+++ b/src/test/java/com/jcabi/github/FileChangeTest.java
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.google.common.base.Optional;
+import com.jcabi.github.mock.MkFileChange;
+import java.io.IOException;
+import javax.json.Json;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link FileChange}.
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.24
+ */
+public final class FileChangeTest {
+    /**
+     * FileChange.Smart can get the status of the file.
+     * @throws IOException If an I/O problem occurs
+     */
+    @Test
+    public void getsStatus() throws IOException {
+        final String status = "status";
+        MatcherAssert.assertThat(
+            FileChangeTest.stringFileChange(status, "added").status(),
+            Matchers.equalTo(FileChange.Status.ADDED)
+        );
+        MatcherAssert.assertThat(
+            FileChangeTest.stringFileChange(status, "modified").status(),
+            Matchers.equalTo(FileChange.Status.MODIFIED)
+        );
+        MatcherAssert.assertThat(
+            FileChangeTest.stringFileChange(status, "removed").status(),
+            Matchers.equalTo(FileChange.Status.REMOVED)
+        );
+        MatcherAssert.assertThat(
+            FileChangeTest.stringFileChange(status, "renamed").status(),
+            Matchers.equalTo(FileChange.Status.RENAMED)
+        );
+    }
+
+    /**
+     * FileChange.Smart can get the filename of the file.
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void getsFilename() throws IOException {
+        final String filename = "foo/bar.txt";
+        MatcherAssert.assertThat(
+            FileChangeTest.stringFileChange("filename", filename).filename(),
+            Matchers.equalTo(filename)
+        );
+    }
+
+    /**
+     * FileChange.Smart can get the commit SHA of the file.
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void getsSha() throws IOException {
+        final String sha = "6dcb09b5b57875f334f61aebed695e2e4193db51";
+        MatcherAssert.assertThat(
+            FileChangeTest.stringFileChange("sha", sha).sha(),
+            Matchers.equalTo(sha)
+        );
+    }
+
+    /**
+     * FileChange.Smart can get the file's count of lines added.
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void getsAdditions() throws IOException {
+        // @checkstyle MagicNumberCheck (1 line)
+        final int adds = 42;
+        MatcherAssert.assertThat(
+            FileChangeTest.intFileChange("additions", adds).additions(),
+            Matchers.equalTo(adds)
+        );
+    }
+
+    /**
+     * FileChange.Smart can get the file's count of lines deleted.
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void getsDeletions() throws IOException {
+        // @checkstyle MagicNumberCheck (1 line)
+        final int deletions = 97;
+        MatcherAssert.assertThat(
+            FileChangeTest.intFileChange("deletions", deletions).deletions(),
+            Matchers.equalTo(deletions)
+        );
+    }
+
+    /**
+     * FileChange.Smart can get the file's count of lines changed.
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void getsChanges() throws IOException {
+        // @checkstyle MagicNumberCheck (1 line)
+        final int changes = 11;
+        MatcherAssert.assertThat(
+            FileChangeTest.intFileChange("changes", changes).changes(),
+            Matchers.equalTo(changes)
+        );
+    }
+
+    /**
+     * FileChange.Smart does not fail when attempting to get the
+     * it is absent (which is normally the case for binary files).
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void getsAbsentPatch() throws IOException {
+        MatcherAssert.assertThat(
+            new FileChange.Smart(
+                new MkFileChange(
+                    Json.createObjectBuilder().build()
+                )
+            ).patch(),
+            Matchers.equalTo(Optional.<String>absent())
+        );
+    }
+
+    /**
+     * FileChange.Smart can get the file's diff patch string when
+     * it is present (which is normally the case for text files).
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void getsPresentPatch() throws IOException {
+        // @checkstyle LineLength (1 line)
+        final String patch = "@@ -120,7 +120,7 @@ class Test1 @@ -1000,7 +1000,7 @@ class Test1";
+        MatcherAssert.assertThat(
+            stringFileChange(
+                "patch",
+                patch
+            ).patch(),
+            Matchers.equalTo(Optional.of(patch))
+        );
+    }
+
+    /**
+     * FileChange.Smart can get the URL for the file's raw content.
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void getsRawUrl() throws IOException {
+        // @checkstyle LineLength (1 line)
+        final String url = "https://api.jcabi-github.invalid/octocat/Hello-World/raw/6dcb09b5b57875f334f61aebed695e2e4193db51/foo/bar.txt";
+        MatcherAssert.assertThat(
+            stringFileChange(
+                "raw_url",
+                url
+            ).rawUrl(),
+            Matchers.equalTo(url)
+        );
+    }
+
+    /**
+     * FileChange.Smart can get the URL of the file's blob.
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void getsBlobUrl() throws IOException {
+        // @checkstyle LineLength (1 line)
+        final String url = "https://api.jcabi-github.invalid/octocat/Hello-World/blob/6dcb09b5b57875f334f61aebed695e2e4193db51/foo/bar.txt";
+        MatcherAssert.assertThat(
+            stringFileChange(
+                "blob_url",
+                url
+            ).blobUrl(),
+            Matchers.equalTo(url)
+        );
+    }
+
+    /**
+     * FileChange.Smart can get the contents URL of the file.
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void getsContentsUrl() throws IOException {
+        // @checkstyle LineLength (1 line)
+        final String url = "https://api.jcabi-github.invalid/repos/octocat/Hello-World/contents/foo/bar.txt?ref=6dcb09b5b57875f334f61aebed695e2e4193db51";
+        MatcherAssert.assertThat(
+            FileChangeTest.stringFileChange("contents_url", url)
+                .contentsUrl(),
+            Matchers.equalTo(url)
+        );
+    }
+
+    /**
+     * Make a new smart file change backed by a JSON object consisting of a
+     * single key-value pair, where the value is a string.
+     * @param key Key string
+     * @param value Value string
+     * @return FileChange.Smart
+     */
+    private static FileChange.Smart stringFileChange(
+        final String key,
+        final String value
+    ) {
+        return new FileChange.Smart(
+            new MkFileChange(
+                Json.createObjectBuilder()
+                    .add(key, value)
+                    .build()
+            )
+        );
+    }
+
+    /**
+     * Make a new smart file change backed by a JSON object consisting of a
+     * single key-value pair, where the value is an integer.
+     * @param key Key string
+     * @param value Value integer
+     * @return FileChange.Smart
+     */
+    private static FileChange.Smart intFileChange(
+        final String key,
+        final int value
+    ) {
+        return new FileChange.Smart(
+            new MkFileChange(
+                Json.createObjectBuilder()
+                    .add(key, value)
+                    .build()
+            )
+        );
+    }
+}

--- a/src/test/java/com/jcabi/github/RtCommitsComparisonITCase.java
+++ b/src/test/java/com/jcabi/github/RtCommitsComparisonITCase.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.google.common.base.Optional;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assume;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RtCommitsComparison}.
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.24
+ */
+public final class RtCommitsComparisonITCase {
+    /**
+     * RtCommitsComparison can read the file changes in the comparison.
+     * @throws Exception If some problem inside
+     * @see <a href="https://api.github.com/repos/jcabi/jcabi-github/compare/fec537c74da115b01a5c27b225d22a3976545acf...3ebe52aaf7bf7681fa30a19fcbbbb246db7ad8b4">The relevant commit comparison</a>
+     */
+    @Test
+    public void readsFiles() throws Exception {
+        final String headsha = "3ebe52aaf7bf7681fa30a19fcbbbb246db7ad8b4";
+        final Iterable<FileChange> files = RtCommitsComparisonITCase.github()
+            .repos()
+            .get(new Coordinates.Simple("jcabi/jcabi-github"))
+            .commits()
+            .compare("fec537c74da115b01a5c27b225d22a3976545acf", headsha)
+            .files();
+        MatcherAssert.assertThat(
+            files,
+            Matchers.<FileChange>iterableWithSize(1)
+        );
+        final FileChange.Smart file = new FileChange.Smart(
+            files.iterator().next()
+        );
+        MatcherAssert.assertThat(
+            file.additions(),
+            Matchers.equalTo(2)
+        );
+        MatcherAssert.assertThat(
+            file.blobUrl(),
+            Matchers.equalTo(
+                // @checkstyle LineLength (1 line)
+                "https://github.com/jcabi/jcabi-github/blob/3ebe52aaf7bf7681fa30a19fcbbbb246db7ad8b4/.rultor.yml"
+            )
+        );
+        MatcherAssert.assertThat(
+            file.changes(),
+            // @checkstyle MagicNumberCheck (1 line)
+            Matchers.equalTo(4)
+        );
+        MatcherAssert.assertThat(
+            file.contentsUrl(),
+            Matchers.equalTo(
+                // @checkstyle LineLength (1 line)
+                "https://api.github.com/repos/jcabi/jcabi-github/contents/.rultor.yml?ref=3ebe52aaf7bf7681fa30a19fcbbbb246db7ad8b4"
+            )
+        );
+        MatcherAssert.assertThat(
+            file.deletions(),
+            Matchers.equalTo(2)
+        );
+        MatcherAssert.assertThat(
+            file.filename(),
+            Matchers.equalTo(".rultor.yml")
+        );
+        MatcherAssert.assertThat(
+            file.patch(),
+            Matchers.equalTo(
+                Optional.of(
+                    // @checkstyle LineLength (1 line)
+                    "@@ -2,7 +2,7 @@ architect:\n - yegor256\n - dmarkov\n install:\n-- sudo gem install -N pdd\n+- sudo gem install --no-rdoc --no-ri pdd\n assets:\n   secring.gpg: yegor256/home#assets/secring.gpg\n   settings.xml: yegor256/home#assets/jcabi/settings.xml\n@@ -37,4 +37,4 @@ release:\n     git commit -am \"${tag}\"\n     mvn clean deploy -Pqulice -Psonatype -Pjcabi --errors --settings ../settings.xml\n     mvn clean site-deploy -Psite --errors --settings ../settings.xml\n-  commanders: []\n\\ No newline at end of file\n+  commanders: []"
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            file.rawUrl(),
+            Matchers.equalTo(
+                // @checkstyle LineLength (1 line)
+                "https://github.com/jcabi/jcabi-github/raw/3ebe52aaf7bf7681fa30a19fcbbbb246db7ad8b4/.rultor.yml"
+            )
+        );
+        MatcherAssert.assertThat(
+            file.sha(),
+            Matchers.equalTo("daaa16ef7a19c2071ce80a6545077c11880daac3")
+        );
+        MatcherAssert.assertThat(
+            file.status(),
+            Matchers.equalTo(FileChange.Status.MODIFIED)
+        );
+    }
+
+    /**
+     * Create and return github to test.
+     *
+     * @return Repo
+     * @throws Exception If some problem inside
+     */
+    private static Github github() throws Exception {
+        final String key = System.getProperty("failsafe.github.key");
+        Assume.assumeThat(key, Matchers.notNullValue());
+        return new RtGithub(key);
+    }
+}

--- a/src/test/java/com/jcabi/github/RtCommitsComparisonTest.java
+++ b/src/test/java/com/jcabi/github/RtCommitsComparisonTest.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.google.common.base.Optional;
 import com.jcabi.http.request.FakeRequest;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -46,16 +47,46 @@ public final class RtCommitsComparisonTest {
     /**
      * RtCommitsComparison can fetch JSON.
      * @throws Exception If some problem inside
-     * @checkstyle MultipleStringLiterals (25 lines)
+     * @checkstyle MultipleStringLiterals (75 lines)
+     * @checkstyle ExecutableStatementCountCheck (75 lines)
      */
     @Test
     public void fetchesJson() throws Exception {
+        final String sha = "fffffffffffffffffffffffffffffffffffffffe";
+        final String filename = "bar/quux.txt";
+        // @checkstyle MagicNumberCheck (3 lines)
+        final int additions = 7;
+        final int deletions = 2;
+        final int changes = 9;
+        final String patch = "some diff here";
+        // @checkstyle LineLength (3 lines)
+        final String bloburl = "https://api.jcabi-github.invalid/johndoe/my-repo/blob/fffffffffffffffffffffffffffffffffffffffe/bar/quux.txt";
+        final String rawurl = "https://api.jcabi-github.invalid/johndoe/my-repo/raw/fffffffffffffffffffffffffffffffffffffffe/bar/quux.txt";
+        final String contentsurl = "https://api.github.invalid/repos/johndoe/my-repo/contents/bar/quux.txt?ref=fffffffffffffffffffffffffffffffffffffffe";
         final CommitsComparison comparison = new RtCommitsComparison(
             new FakeRequest().withBody(
                 Json.createObjectBuilder()
                     .add("base_commit", Json.createObjectBuilder())
                     .add("commits", Json.createArrayBuilder())
-                    .add("files", Json.createArrayBuilder())
+                    .add(
+                        "files",
+                        Json.createArrayBuilder()
+                            .add(
+                                Json.createObjectBuilder()
+                                    .add("sha", sha)
+                                    .add("filename", filename)
+                                    .add("status", "added")
+                                    .add("additions", additions)
+                                    .add("deletions", deletions)
+                                    .add("changes", changes)
+                                    .add("patch", patch)
+                                    .add("blob_url", bloburl)
+                                    .add("raw_url", rawurl)
+                                    .add("contents_url", contentsurl)
+                                    .build()
+                            )
+                            .build()
+                    )
                     .build().toString()
             ),
             RtCommitsComparisonTest.repo(),
@@ -70,7 +101,24 @@ public final class RtCommitsComparisonTest {
             json.getJsonArray("commits"), Matchers.notNullValue()
         );
         MatcherAssert.assertThat(
-            json.getJsonArray("files"), Matchers.notNullValue()
+            comparison.files(),
+            Matchers.<FileChange>iterableWithSize(1)
+        );
+        final FileChange.Smart file = new FileChange.Smart(
+            comparison.files().iterator().next()
+        );
+        MatcherAssert.assertThat(file.sha(), Matchers.equalTo(sha));
+        MatcherAssert.assertThat(file.filename(), Matchers.equalTo(filename));
+        MatcherAssert.assertThat(file.additions(), Matchers.equalTo(additions));
+        MatcherAssert.assertThat(file.deletions(), Matchers.equalTo(deletions));
+        MatcherAssert.assertThat(file.changes(), Matchers.equalTo(changes));
+        MatcherAssert.assertThat(
+            file.status(),
+            Matchers.equalTo(FileChange.Status.ADDED)
+        );
+        MatcherAssert.assertThat(
+            file.patch(),
+            Matchers.equalTo(Optional.of(patch))
         );
     }
 


### PR DESCRIPTION
Fixes #1082 by adding a `FileChange` interface and having `CommitsComparison.files()` return an `Iterator<FileChange>` instead of a raw `JsonArray`.