### PR TITLE
Add Pull.head/base, which return (newly-added) PullRef

### DIFF
--- a/src/main/java/com/jcabi/github/Pull.java
+++ b/src/main/java/com/jcabi/github/Pull.java
@@ -69,6 +69,22 @@ public interface Pull extends Comparable<Pull>, JsonReadable, JsonPatchable {
     int number();
 
     /**
+     * Get its base ref.
+     * @return Base ref
+     * @throws IOException If there is any I/O problem
+     */
+    @NotNull(message = "base is never NULL")
+    PullRef base() throws IOException;
+
+    /**
+     * Get its head ref.
+     * @return Head ref
+     * @throws IOException If there is any I/O problem
+     */
+    @NotNull(message = "head is never NULL")
+    PullRef head() throws IOException;
+
+    /**
      * Get all commits of the pull request.
      * @return Commits
      * @throws IOException If there is any I/O problem
@@ -378,6 +394,17 @@ public interface Pull extends Comparable<Pull>, JsonReadable, JsonPatchable {
         ) {
             return this.pull.compareTo(obj);
         }
-    }
 
+        @Override
+        @NotNull(message = "base is never NULL")
+        public PullRef base() throws IOException {
+            return this.pull.base();
+        }
+
+        @Override
+        @NotNull(message = "head is never NULL")
+        public PullRef head() throws IOException {
+            return this.pull.head();
+        }
+    }
 }

--- a/src/main/java/com/jcabi/github/PullRef.java
+++ b/src/main/java/com/jcabi/github/PullRef.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.aspects.Immutable;
+import com.jcabi.aspects.Loggable;
+import java.io.IOException;
+import javax.json.JsonObject;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * GitHub pull request ref.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ * @see <a href="https://developer.github.com/v3/pulls/#get-a-single-pull-request">Get a single pull request API</a>
+ *
+ */
+@Immutable
+public interface PullRef extends JsonReadable {
+    /**
+     * Get the repository which its commit is in.
+     * @return Repo
+     */
+    @NotNull(message = "repo is never NULL")
+    Repo repo();
+
+    /**
+     * Get its ref.
+     * @return Ref
+     * @throws IOException If there is any I/O problem
+     */
+    @NotNull(message = "ref is never NULL")
+    String ref() throws IOException;
+
+    /**
+     * Get its commit SHA.
+     * @return Commit SHA
+     * @throws IOException If there is any I/O problem
+     */
+    @NotNull(message = "sha is never NULL")
+    String sha() throws IOException;
+
+    /**
+     * Smart pull request ref with extra features.
+     */
+    @Immutable
+    @ToString
+    @Loggable(Loggable.DEBUG)
+    @EqualsAndHashCode(of = { "pullref", "jsn" })
+    final class Smart implements PullRef {
+        /**
+         * Encapsulated pull request ref.
+         */
+        private final transient PullRef pullref;
+        /**
+         * SmartJson object for convenient JSON parsing.
+         */
+        private final transient SmartJson jsn;
+
+        /**
+         * Public ctor.
+         * @param pref Pull request ref
+         */
+        public Smart(
+            @NotNull(message = "pull request ref can't be NULL")
+            final PullRef pref
+        ) {
+            this.pullref = pref;
+            this.jsn = new SmartJson(pref);
+        }
+
+        @Override
+        @NotNull(message = "repo is never NULL")
+        public Repo repo() {
+            return this.pullref.repo();
+        }
+
+        @Override
+        @NotNull(message = "ref is never NULL")
+        public String ref() throws IOException {
+            return this.pullref.ref();
+        }
+
+        @Override
+        @NotNull(message = "sha is never NULL")
+        public String sha() throws IOException {
+            return this.pullref.sha();
+        }
+
+        /**
+         * Gets the user who owns the repository which its commit is in.
+         * @return User
+         * @throws IOException If there is any I/O problem
+         */
+        @NotNull(message = "user is never NULL")
+        public User user() throws IOException {
+            return this.pullref.repo().github().users().get(
+                this.jsn.value("user", JsonObject.class).getString("login")
+            );
+        }
+
+        /**
+         * Get its label. Normally of the form "user:branch".
+         * @return Label string
+         * @throws IOException If there is any I/O problem
+         */
+        @NotNull(message = "label is never NULL")
+        public String label() throws IOException {
+            return this.jsn.text("label");
+        }
+
+        /**
+         * Get its commit.
+         * @return Commit
+         * @throws IOException If there is any I/O problem
+         */
+        @NotNull(message = "commit is never NULL")
+        public Commit commit() throws IOException {
+            return this.repo().git().commits().get(this.sha());
+        }
+
+        @Override
+        @NotNull(message = "JSON is never NULL")
+        public JsonObject json() throws IOException {
+            return this.pullref.json();
+        }
+    }
+}

--- a/src/main/java/com/jcabi/github/RtPull.java
+++ b/src/main/java/com/jcabi/github/RtPull.java
@@ -190,6 +190,24 @@ final class RtPull implements Pull {
     }
 
     @Override
+    @NotNull(message = "base is never NULL")
+    public PullRef base() throws IOException {
+        return new RtPullRef(
+            this.owner.github(),
+            this.json().getJsonObject("base")
+        );
+    }
+
+    @Override
+    @NotNull(message = "head is never NULL")
+    public PullRef head() throws IOException {
+        return new RtPullRef(
+            this.owner.github(),
+            this.json().getJsonObject("head")
+        );
+    }
+
+    @Override
     @NotNull(message = "JSON is never NULL")
     public JsonObject json() throws IOException {
         return new RtJson(this.request).fetch();

--- a/src/main/java/com/jcabi/github/RtPullRef.java
+++ b/src/main/java/com/jcabi/github/RtPullRef.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.aspects.Loggable;
+import javax.json.JsonObject;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+
+/**
+ * GitHub pull request ref.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ */
+@Loggable(Loggable.DEBUG)
+@EqualsAndHashCode(of = { "github", "jsn" })
+final class RtPullRef implements PullRef {
+    /**
+     * API entry point.
+     */
+    private final transient Github github;
+    /**
+     * JSON of the pull request ref.
+     */
+    private final transient JsonObject jsn;
+
+    /**
+     * Public ctor.
+     * @param gthb Github
+     * @param json Pull request ref JSON object
+     */
+    RtPullRef(final Github gthb, final JsonObject json) {
+        this.github = gthb;
+        this.jsn = json;
+    }
+
+    @Override
+    @NotNull(message = "JSON is never NULL")
+    public JsonObject json() {
+        return this.jsn;
+    }
+
+    @Override
+    @NotNull(message = "ref is never NULL")
+    public String ref() {
+        return this.jsn.getString("ref");
+    }
+
+    @Override
+    @NotNull(message = "sha is never NULL")
+    public String sha() {
+        return this.jsn.getString("sha");
+    }
+
+    @Override
+    @NotNull(message = "sha is never NULL")
+    public Repo repo() {
+        return this.github.repos().get(
+            new Coordinates.Simple(
+                this.jsn.getJsonObject("repo").getString("full_name")
+            )
+        );
+    }
+}

--- a/src/main/java/com/jcabi/github/mock/MkBranches.java
+++ b/src/main/java/com/jcabi/github/mock/MkBranches.java
@@ -119,7 +119,7 @@ public final class MkBranches implements Branches {
                         MkBranches.this.self,
                         MkBranches.this.coords,
                         xml.xpath("@name").get(0),
-                        xml.xpath(XPATH_TO_SHA).get(0)
+                        xml.xpath(MkBranches.XPATH_TO_SHA).get(0)
                     );
                 }
             }
@@ -172,7 +172,7 @@ public final class MkBranches implements Branches {
                     )
                 )
                 .get(0)
-                .xpath(XPATH_TO_SHA)
+                .xpath(MkBranches.XPATH_TO_SHA)
                 .get(0)
         );
     }

--- a/src/main/java/com/jcabi/github/mock/MkBranches.java
+++ b/src/main/java/com/jcabi/github/mock/MkBranches.java
@@ -55,6 +55,11 @@ import org.xembly.Directives;
 @EqualsAndHashCode(of = { "storage", "self", "coords" })
 public final class MkBranches implements Branches {
     /**
+     * XPath from a given branch to its commit SHA string.
+     */
+    private static final String XPATH_TO_SHA = "sha/text()";
+
+    /**
      * Storage.
      */
     private final transient MkStorage storage;
@@ -114,7 +119,7 @@ public final class MkBranches implements Branches {
                         MkBranches.this.self,
                         MkBranches.this.coords,
                         xml.xpath("@name").get(0),
-                        xml.xpath("sha/text()").get(0)
+                        xml.xpath(XPATH_TO_SHA).get(0)
                     );
                 }
             }
@@ -140,6 +145,36 @@ public final class MkBranches implements Branches {
             .add("sha").set(sha).up();
         this.storage.apply(directives);
         return new MkBranch(this.storage, this.self, this.coords, name, sha);
+    }
+
+    /**
+     * Gets a branch by name.
+     * @param name Name of branch.
+     * @return The branch with the given name
+     * @throws IOException If there is an I/O problem
+     */
+    @NotNull(message = "branch is never NULL")
+    public Branch get(
+        @NotNull(message = "name cannot be NULL")
+        final String name
+    ) throws IOException {
+        return new MkBranch(
+            this.storage,
+            this.self,
+            this.coords,
+            name,
+            this.storage.xml()
+                .nodes(
+                    String.format(
+                        "%s/branch[@name='%s']",
+                        this.xpath(),
+                        name
+                    )
+                )
+                .get(0)
+                .xpath(XPATH_TO_SHA)
+                .get(0)
+        );
     }
 
     /**

--- a/src/main/java/com/jcabi/github/mock/MkPull.java
+++ b/src/main/java/com/jcabi/github/mock/MkPull.java
@@ -217,9 +217,9 @@ final class MkPull implements Pull {
     @NotNull(message = "JSON is never NULL")
     public JsonObject json() throws IOException {
         final XML xml = this.storage.xml().nodes(this.xpath()).get(0);
-        final String basebranch = xml.xpath("base/text()").get(0);
+        final String branch = xml.xpath("base/text()").get(0);
         final String head = xml.xpath("head/text()").get(0);
-        final String[] headparts = head.split(MkPull.USER_BRANCH_SEP, 2);
+        final String[] parts = head.split(MkPull.USER_BRANCH_SEP, 2);
         final List<String> patches = xml.xpath("patch/text()");
         final String patch;
         if (patches.isEmpty()) {
@@ -242,20 +242,20 @@ final class MkPull implements Pull {
             .add(
                 "head",
                 Json.createObjectBuilder()
-                    .add(REF_PROP, headparts[1])
-                    .add(LABEL_PROP, head)
+                    .add(MkPull.REF_PROP, parts[1])
+                    .add(MkPull.LABEL_PROP, head)
                     .build()
             )
             .add(
                 "base",
                 Json.createObjectBuilder()
-                    .add(REF_PROP, basebranch)
+                    .add(MkPull.REF_PROP, branch)
                     .add(
-                        LABEL_PROP,
+                        MkPull.LABEL_PROP,
                         String.format(
                             "%s:%s",
                             this.coords.user(),
-                            basebranch
+                            branch
                         )
                     )
                     .build()

--- a/src/main/java/com/jcabi/github/mock/MkPull.java
+++ b/src/main/java/com/jcabi/github/mock/MkPull.java
@@ -36,6 +36,7 @@ import com.jcabi.github.Coordinates;
 import com.jcabi.github.MergeState;
 import com.jcabi.github.Pull;
 import com.jcabi.github.PullComments;
+import com.jcabi.github.PullRef;
 import com.jcabi.github.Repo;
 import com.jcabi.xml.XML;
 import java.io.IOException;
@@ -121,6 +122,48 @@ final class MkPull implements Pull {
     @Override
     public int number() {
         return this.num;
+    }
+
+    @Override
+    @NotNull(message = "base is never NULL")
+    public PullRef base() throws IOException {
+        return new MkPullRef(
+            this.storage,
+            new MkBranches(
+                this.storage,
+                this.self,
+                this.coords
+            ).get(
+                this.storage.xml().xpath(
+                    String.format("%s/base/text()", this.xpath())
+                ).get(0)
+            )
+        );
+    }
+
+    @Override
+    @NotNull(message = "head is never NULL")
+    public PullRef head() throws IOException {
+        final String userbranch = this.storage.xml()
+            .xpath(String.format("%s/head/text()", this.xpath()))
+            .get(0);
+        final String[] parts = userbranch.split(MkPull.USER_BRANCH_SEP, 2);
+        if (parts.length != 2) {
+            throw new IllegalStateException("Invalid MkPull head");
+        }
+        final String user = parts[0];
+        final String branch = parts[1];
+        return new MkPullRef(
+            this.storage,
+            new MkBranches(
+                this.storage,
+                this.self,
+                new Coordinates.Simple(
+                    user,
+                    this.coords.repo()
+                )
+            ).get(branch)
+        );
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/mock/MkPull.java
+++ b/src/main/java/com/jcabi/github/mock/MkPull.java
@@ -245,8 +245,7 @@ final class MkPull implements Pull {
                     .add(MkPull.REF_PROP, parts[1])
                     .add(MkPull.LABEL_PROP, head)
                     .build()
-            )
-            .add(
+            ).add(
                 "base",
                 Json.createObjectBuilder()
                     .add(MkPull.REF_PROP, branch)
@@ -257,14 +256,11 @@ final class MkPull implements Pull {
                             this.coords.user(),
                             branch
                         )
-                    )
-                    .build()
-            )
-            .add(
+                    ).build()
+            ).add(
                 "comments",
                 this.storage.xml().nodes(this.comment()).size()
-            )
-            .build();
+            ).build();
     }
 
     /**

--- a/src/main/java/com/jcabi/github/mock/MkPullRef.java
+++ b/src/main/java/com/jcabi/github/mock/MkPullRef.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github.mock;
+
+import com.jcabi.aspects.Immutable;
+import com.jcabi.aspects.Loggable;
+import com.jcabi.github.Branch;
+import com.jcabi.github.PullRef;
+import com.jcabi.github.Repo;
+import java.io.IOException;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * Mock GitHub pull request ref.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ */
+@Immutable
+@Loggable(Loggable.DEBUG)
+@ToString
+@EqualsAndHashCode(of = { "storage", "branch" })
+final class MkPullRef implements PullRef {
+    /**
+     * Storage.
+     */
+    private final transient MkStorage storage;
+
+    /**
+     * Branch.
+     */
+    private final transient Branch branch;
+
+    /**
+     * Public ctor.
+     * @param stg Storage
+     * @param brnch Branch
+     */
+    MkPullRef(
+        @NotNull(message = "stg can't be NULL") final MkStorage stg,
+        @NotNull(message = "branch can't be NULL") final Branch brnch
+    ) {
+        this.storage = stg;
+        this.branch = brnch;
+    }
+
+    @Override
+    @NotNull(message = "repo is never NULL")
+    public Repo repo() {
+        return this.branch.repo();
+    }
+
+    @Override
+    @NotNull(message = "ref is never NULL")
+    public String ref() {
+        return this.branch.name();
+    }
+
+    @Override
+    @NotNull(message = "sha is never NULL")
+    public String sha() {
+        return this.branch.commit().sha();
+    }
+
+    @Override
+    @NotNull(message = "JSON is never NULL")
+    public JsonObject json() throws IOException {
+        final String user = this.repo().coordinates().user();
+        return Json.createObjectBuilder()
+            .add("ref", this.ref())
+            .add("sha", this.sha())
+            .add("label", String.format("%s:%s", user, this.ref()))
+            .add("user", new MkUser(this.storage, user).json())
+            .add("repo", this.repo().json())
+            .build();
+    }
+}

--- a/src/main/java/com/jcabi/github/mock/MkPulls.java
+++ b/src/main/java/com/jcabi/github/mock/MkPulls.java
@@ -56,6 +56,12 @@ import org.xembly.Directives;
 @ToString
 @EqualsAndHashCode(of = { "storage", "self", "coords" })
 final class MkPulls implements Pulls {
+    /**
+     * The separator between the username and
+     * the branch name in the base/head parameters
+     * when creating a pull request.
+     */
+    private static final String USER_BRANCH_SEP = ":";
 
     /**
      * Storage.
@@ -122,6 +128,12 @@ final class MkPulls implements Pulls {
         if (base.isEmpty()) {
             throw new IllegalArgumentException("base cannot be empty!");
         }
+        final String canonicalHead;
+        if (head.contains(USER_BRANCH_SEP)) {
+            canonicalHead = head;
+        } else {
+            canonicalHead = this.coords.user() + USER_BRANCH_SEP + head;
+        }
         this.storage.lock();
         final int number;
         try {
@@ -130,7 +142,7 @@ final class MkPulls implements Pulls {
             this.storage.apply(
                 new Directives().xpath(this.xpath()).add("pull")
                     .add("number").set(Integer.toString(number)).up()
-                    .add("head").set(head).up()
+                    .add("head").set(canonicalHead).up()
                     .add("base").set(base).up()
                     .add("user")
                     .add("login").set(this.self)

--- a/src/main/java/com/jcabi/github/mock/MkPulls.java
+++ b/src/main/java/com/jcabi/github/mock/MkPulls.java
@@ -128,11 +128,16 @@ final class MkPulls implements Pulls {
         if (base.isEmpty()) {
             throw new IllegalArgumentException("base cannot be empty!");
         }
-        final String canonicalHead;
-        if (head.contains(USER_BRANCH_SEP)) {
-            canonicalHead = head;
+        final String canonical;
+        if (head.contains(MkPulls.USER_BRANCH_SEP)) {
+            canonical = head;
         } else {
-            canonicalHead = this.coords.user() + USER_BRANCH_SEP + head;
+            canonical = String.format(
+                "%s%s%s",
+                this.coords.user(),
+                MkPulls.USER_BRANCH_SEP,
+                head
+            );
         }
         this.storage.lock();
         final int number;
@@ -142,7 +147,7 @@ final class MkPulls implements Pulls {
             this.storage.apply(
                 new Directives().xpath(this.xpath()).add("pull")
                     .add("number").set(Integer.toString(number)).up()
-                    .add("head").set(canonicalHead).up()
+                    .add("head").set(canonical).up()
                     .add("base").set(base).up()
                     .add("user")
                     .add("login").set(this.self)

--- a/src/main/java/com/jcabi/github/mock/MkPulls.java
+++ b/src/main/java/com/jcabi/github/mock/MkPulls.java
@@ -116,6 +116,12 @@ final class MkPulls implements Pulls {
         @NotNull(message = "head can't be NULL") final String head,
         @NotNull(message = "base can't be NULL") final String base
     ) throws IOException {
+        if (head.isEmpty()) {
+            throw new IllegalArgumentException("head cannot be empty!");
+        }
+        if (base.isEmpty()) {
+            throw new IllegalArgumentException("base cannot be empty!");
+        }
         this.storage.lock();
         final int number;
         try {

--- a/src/test/java/com/jcabi/github/PullRefTest.java
+++ b/src/test/java/com/jcabi/github/PullRefTest.java
@@ -67,7 +67,7 @@ public final class PullRefTest {
     public void fetchesRepo() throws IOException {
         final Repo repo = new MkGithub().randomRepo();
         MatcherAssert.assertThat(
-            pullRef(repo).repo().coordinates(),
+            PullRefTest.pullRef(repo).repo().coordinates(),
             Matchers.equalTo(repo.coordinates())
         );
     }
@@ -79,8 +79,8 @@ public final class PullRefTest {
     @Test
     public void fetchesRef() throws IOException {
         MatcherAssert.assertThat(
-            pullRef().ref(),
-            Matchers.equalTo(REF)
+            PullRefTest.pullRef().ref(),
+            Matchers.equalTo(PullRefTest.REF)
         );
     }
 
@@ -91,8 +91,8 @@ public final class PullRefTest {
     @Test
     public void fetchesSha() throws IOException {
         MatcherAssert.assertThat(
-            pullRef().sha(),
-            Matchers.equalTo(SHA)
+            PullRefTest.pullRef().sha(),
+            Matchers.equalTo(PullRefTest.SHA)
         );
     }
 
@@ -103,8 +103,8 @@ public final class PullRefTest {
     @Test
     public void fetchesLabel() throws IOException {
         MatcherAssert.assertThat(
-            pullRef().label(),
-            Matchers.equalTo(LABEL)
+            PullRefTest.pullRef().label(),
+            Matchers.equalTo(PullRefTest.LABEL)
         );
     }
 
@@ -115,14 +115,14 @@ public final class PullRefTest {
     @Test
     public void fetchesCommit() throws IOException {
         final Repo repo = new MkGithub().randomRepo();
-        final Commit commit = pullRef(repo).commit();
+        final Commit commit = PullRefTest.pullRef(repo).commit();
         MatcherAssert.assertThat(
             commit.repo().coordinates(),
             Matchers.equalTo(repo.coordinates())
         );
         MatcherAssert.assertThat(
             commit.sha(),
-            Matchers.equalTo(SHA)
+            Matchers.equalTo(PullRefTest.SHA)
         );
     }
 
@@ -134,7 +134,7 @@ public final class PullRefTest {
     public void fetchesUser() throws IOException {
         final Repo repo = new MkGithub().randomRepo();
         MatcherAssert.assertThat(
-            pullRef(repo).user().login(),
+            PullRefTest.pullRef(repo).user().login(),
             Matchers.equalTo(repo.coordinates().user())
         );
     }
@@ -154,9 +154,9 @@ public final class PullRefTest {
             new RtPullRef(
                 repo.github(),
                 Json.createObjectBuilder()
-                    .add("label", LABEL)
-                    .add("ref", REF)
-                    .add("sha", SHA)
+                    .add("label", PullRefTest.LABEL)
+                    .add("ref", PullRefTest.REF)
+                    .add("sha", PullRefTest.SHA)
                     .add("user", user)
                     .add(
                         "repo",
@@ -177,6 +177,6 @@ public final class PullRefTest {
      * @throws IOException If there is an I/O problem.
      */
     private static PullRef.Smart pullRef() throws IOException {
-        return pullRef(new MkGithub().randomRepo());
+        return PullRefTest.pullRef(new MkGithub().randomRepo());
     }
 }

--- a/src/test/java/com/jcabi/github/PullRefTest.java
+++ b/src/test/java/com/jcabi/github/PullRefTest.java
@@ -165,8 +165,7 @@ public final class PullRefTest {
                             .add("full_name", coords.toString())
                             .add("owner", user)
                             .build()
-                    )
-                    .build()
+                    ).build()
             )
         );
     }

--- a/src/test/java/com/jcabi/github/PullRefTest.java
+++ b/src/test/java/com/jcabi/github/PullRefTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.github.mock.MkGithub;
+import java.io.IOException;
+import javax.json.Json;
+import javax.json.JsonObject;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link PullRef}.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ */
+public final class PullRefTest {
+    /**
+     * Test ref.
+     */
+    private static final String REF = "the-ref";
+    /**
+     * Test commit SHA.
+     * @checkstyle LineLength (2 lines)
+     */
+    private static final String SHA = "7a1f68e743e8a81e158136c8661011fb55abd703";
+    /**
+     * Test pull request ref label.
+     */
+    private static final String LABEL = "pr-ref-label";
+
+    /**
+     * PullRef.Smart can fetch its repo.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesRepo() throws IOException {
+        final Repo repo = new MkGithub().randomRepo();
+        MatcherAssert.assertThat(
+            pullRef(repo).repo().coordinates(),
+            Matchers.equalTo(repo.coordinates())
+        );
+    }
+
+    /**
+     * PullRef.Smart can fetch its ref name.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesRef() throws IOException {
+        MatcherAssert.assertThat(
+            pullRef().ref(),
+            Matchers.equalTo(REF)
+        );
+    }
+
+    /**
+     * PullRef.Smart can fetch its commit sha.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesSha() throws IOException {
+        MatcherAssert.assertThat(
+            pullRef().sha(),
+            Matchers.equalTo(SHA)
+        );
+    }
+
+    /**
+     * PullRef.Smart can fetch its label.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesLabel() throws IOException {
+        MatcherAssert.assertThat(
+            pullRef().label(),
+            Matchers.equalTo(LABEL)
+        );
+    }
+
+    /**
+     * PullRef.Smart can fetch its commit.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesCommit() throws IOException {
+        final Repo repo = new MkGithub().randomRepo();
+        final Commit commit = pullRef(repo).commit();
+        MatcherAssert.assertThat(
+            commit.repo().coordinates(),
+            Matchers.equalTo(repo.coordinates())
+        );
+        MatcherAssert.assertThat(
+            commit.sha(),
+            Matchers.equalTo(SHA)
+        );
+    }
+
+    /**
+     * PullRef.Smart can fetch its user.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesUser() throws IOException {
+        final Repo repo = new MkGithub().randomRepo();
+        MatcherAssert.assertThat(
+            pullRef(repo).user().login(),
+            Matchers.equalTo(repo.coordinates().user())
+        );
+    }
+
+    /**
+     * Returns a smart pull request ref in the given repo for testing.
+     * @param repo Repo to create the pull request ref in
+     * @return PullRef.Smart
+     * @throws IOException If there is an I/O problem.
+     */
+    private static PullRef.Smart pullRef(final Repo repo) throws IOException {
+        final Coordinates coords = repo.coordinates();
+        final JsonObject user = Json.createObjectBuilder()
+            .add("login", coords.user())
+            .build();
+        return new PullRef.Smart(
+            new RtPullRef(
+                repo.github(),
+                Json.createObjectBuilder()
+                    .add("label", LABEL)
+                    .add("ref", REF)
+                    .add("sha", SHA)
+                    .add("user", user)
+                    .add(
+                        "repo",
+                        Json.createObjectBuilder()
+                            .add("name", coords.repo())
+                            .add("full_name", coords.toString())
+                            .add("owner", user)
+                            .build()
+                    )
+                    .build()
+            )
+        );
+    }
+
+    /**
+     * Returns a smart pull request ref for testing.
+     * @return PullRef.Smart
+     * @throws IOException If there is an I/O problem.
+     */
+    private static PullRef.Smart pullRef() throws IOException {
+        return pullRef(new MkGithub().randomRepo());
+    }
+}

--- a/src/test/java/com/jcabi/github/RtPullRefITCase.java
+++ b/src/test/java/com/jcabi/github/RtPullRefITCase.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+/**
+ * Test case for {@link RtPullRef}.
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @todo #1125:30min Implement this integration test for RtPullRef and
+ *  PullRef.Smart to check that they work with actual JSON from GitHub.
+ */
+public final class RtPullRefITCase {
+}

--- a/src/test/java/com/jcabi/github/RtPullRefTest.java
+++ b/src/test/java/com/jcabi/github/RtPullRefTest.java
@@ -47,9 +47,9 @@ import org.junit.Test;
 public final class RtPullRefTest {
     /**
      * Test commit SHA.
-     * @checkstyle LineLength (2 lines)
      */
-    private static final String SHA = "7a1f68e743e8a81e158136c8661011fb55abd703";
+    private static final String SHA =
+        "7a1f68e743e8a81e158136c8661011fb55abd703";
     /**
      * Test ref.
      */

--- a/src/test/java/com/jcabi/github/RtPullRefTest.java
+++ b/src/test/java/com/jcabi/github/RtPullRefTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.github.mock.MkGithub;
+import java.io.IOException;
+import javax.json.Json;
+import javax.json.JsonObject;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RtPullRef}.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ */
+public final class RtPullRefTest {
+    /**
+     * Test commit SHA.
+     * @checkstyle LineLength (2 lines)
+     */
+    private static final String SHA = "7a1f68e743e8a81e158136c8661011fb55abd703";
+    /**
+     * Test ref.
+     */
+    private static final String REF = "some-branch";
+
+    /**
+     * RtPullRef can fetch its repo.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesRepo() throws IOException {
+        final Repo repo = new MkGithub().randomRepo();
+        MatcherAssert.assertThat(
+            RtPullRefTest.pullRef(repo).repo().coordinates(),
+            Matchers.equalTo(repo.coordinates())
+        );
+    }
+
+    /**
+     * RtPullRef can fetch its ref.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesRef() throws IOException {
+        MatcherAssert.assertThat(
+            RtPullRefTest.pullRef().ref(),
+            Matchers.equalTo(REF)
+        );
+    }
+
+    /**
+     * RtPullRef can fetch its commit SHA.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesSha() throws IOException {
+        MatcherAssert.assertThat(
+            RtPullRefTest.pullRef().sha(),
+            Matchers.equalTo(SHA)
+        );
+    }
+
+    /**
+     * Returns an RtPullRef for testing.
+     * @return Test RtPullRef
+     * @throws IOException If there is an I/O problem.
+     */
+    private static PullRef pullRef() throws IOException {
+        return RtPullRefTest.pullRef(new MkGithub().randomRepo());
+    }
+
+    /**
+     * Returns an RtPullRef in the given repo for testing.
+     * @param repo Repo to create the pull request ref in
+     * @return Test RtPullRef
+     */
+    private static PullRef pullRef(final Repo repo) {
+        final Coordinates coords = repo.coordinates();
+        final JsonObject user = Json.createObjectBuilder()
+            .add("login", coords.user())
+            .build();
+        return new RtPullRef(
+            repo.github(),
+            Json.createObjectBuilder()
+                .add("ref", REF)
+                .add("sha", SHA)
+                .add("user", user)
+                .add(
+                    "repo",
+                    Json.createObjectBuilder()
+                        .add("owner", user)
+                        .add("name", coords.repo())
+                        .add("full_name", coords.toString())
+                        .build()
+                )
+                .build()
+        );
+    }
+}

--- a/src/test/java/com/jcabi/github/RtPullRefTest.java
+++ b/src/test/java/com/jcabi/github/RtPullRefTest.java
@@ -124,8 +124,7 @@ public final class RtPullRefTest {
                         .add("name", coords.repo())
                         .add("full_name", coords.toString())
                         .build()
-                )
-                .build()
+                ).build()
         );
     }
 }

--- a/src/test/java/com/jcabi/github/RtPullTest.java
+++ b/src/test/java/com/jcabi/github/RtPullTest.java
@@ -132,8 +132,8 @@ public final class RtPullTest {
                     .add(
                         "base",
                         Json.createObjectBuilder()
-                            .add(REF_PROP, ref)
-                            .add(SHA_PROP, sha)
+                            .add(RtPullTest.REF_PROP, ref)
+                            .add(RtPullTest.SHA_PROP, sha)
                             .build()
                     )
                     .build()
@@ -179,8 +179,8 @@ public final class RtPullTest {
                     .add(
                         "head",
                         Json.createObjectBuilder()
-                            .add(REF_PROP, ref)
-                            .add(SHA_PROP, sha)
+                            .add(RtPullTest.REF_PROP, ref)
+                            .add(RtPullTest.SHA_PROP, sha)
                             .build()
                     )
                     .build()

--- a/src/test/java/com/jcabi/github/RtPullTest.java
+++ b/src/test/java/com/jcabi/github/RtPullTest.java
@@ -36,7 +36,9 @@ import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.mock.MkQuery;
 import com.jcabi.http.request.ApacheRequest;
 import com.jcabi.http.request.FakeRequest;
+import java.io.IOException;
 import java.net.HttpURLConnection;
+import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
@@ -50,6 +52,14 @@ import org.mockito.Mockito;
  * @version $Id$
  */
 public final class RtPullTest {
+    /**
+     * Property name for ref name in pull request ref JSON object.
+     */
+    private static final String REF_PROP = "ref";
+    /**
+     * Property name for commit SHA in pull request ref JSON object.
+     */
+    private static final String SHA_PROP = "sha";
 
     /**
      * RtPull should be able to retrieve commits.
@@ -101,6 +111,100 @@ public final class RtPullTest {
             MatcherAssert.assertThat(
                 pull.files().iterator().next().getString("file1"),
                 Matchers.equalTo("testFile")
+            );
+        } finally {
+            container.stop();
+        }
+    }
+
+    /**
+     * RtPull can fetch its base ref.
+     * @throws IOException If some I/O problem occurs
+     */
+    @Test
+    public void fetchesBase() throws IOException {
+        final String ref = "sweet-feature-branch";
+        final String sha = "e93c6a2216c69daa574abc16e7c14767fce44ad6";
+        final MkContainer container = new MkGrizzlyContainer().next(
+            new MkAnswer.Simple(
+                HttpURLConnection.HTTP_OK,
+                Json.createObjectBuilder()
+                    .add(
+                        "base",
+                        Json.createObjectBuilder()
+                            .add(REF_PROP, ref)
+                            .add(SHA_PROP, sha)
+                            .build()
+                    )
+                    .build()
+                    .toString()
+            )
+        ).start();
+        final RtPull pull = new RtPull(
+            new ApacheRequest(container.home()),
+            this.repo(),
+            1
+        );
+        try {
+            final PullRef base = pull.base();
+            MatcherAssert.assertThat(
+                base,
+                Matchers.notNullValue()
+            );
+            MatcherAssert.assertThat(
+                base.ref(),
+                Matchers.equalTo(ref)
+            );
+            MatcherAssert.assertThat(
+                base.sha(),
+                Matchers.equalTo(sha)
+            );
+        } finally {
+            container.stop();
+        }
+    }
+
+    /**
+     * RtPull can fetch its head ref.
+     * @throws IOException If some I/O problem occurs
+     */
+    @Test
+    public void fetchesHead() throws IOException {
+        final String ref = "neat-other-branch";
+        final String sha = "9c717b4716e4fc4d917f546e8e6b562e810e3922";
+        final MkContainer container = new MkGrizzlyContainer().next(
+            new MkAnswer.Simple(
+                HttpURLConnection.HTTP_OK,
+                Json.createObjectBuilder()
+                    .add(
+                        "head",
+                        Json.createObjectBuilder()
+                            .add(REF_PROP, ref)
+                            .add(SHA_PROP, sha)
+                            .build()
+                    )
+                    .build()
+                    .toString()
+            )
+        ).start();
+        final RtPull pull = new RtPull(
+            new ApacheRequest(container.home()),
+            this.repo(),
+            1
+        );
+        try {
+            final PullRef head = pull.head();
+            MatcherAssert.assertThat(
+                head,
+                Matchers.notNullValue()
+            );
+            MatcherAssert.assertThat(
+                head.ref(),
+                Matchers.equalTo(ref)
+            );
+            MatcherAssert.assertThat(
+                head.sha(),
+                Matchers.equalTo(sha)
             );
         } finally {
             container.stop();

--- a/src/test/java/com/jcabi/github/mock/MkPullCommentTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullCommentTest.java
@@ -81,7 +81,7 @@ public final class MkPullCommentTest {
         return new MkGithub()
             .randomRepo()
             .pulls()
-            .create("hello", "", "")
+            .create("hello", "head", "base")
             .comments()
             .post("comment", "commit", "/", 1);
     }

--- a/src/test/java/com/jcabi/github/mock/MkPullCommentsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullCommentsTest.java
@@ -75,7 +75,7 @@ public final class MkPullCommentsTest {
         comments.pull()
             .repo()
             .pulls()
-            .create("new", "", "")
+            .create("new", "head-branch", "base-branch")
             .comments()
             .post("new pull comment", "new commit", "/p", 1);
         comments.post("test 1", "tesst 1", "/test1", 1);
@@ -220,7 +220,8 @@ public final class MkPullCommentsTest {
      */
     private PullComments comments() throws IOException {
         // @checkstyle MultipleStringLiteralsCheck (1 line)
-        return new MkGithub().randomRepo().pulls().create("hello", "", "")
+        return new MkGithub().randomRepo().pulls()
+            .create("hello", "awesome-head", "awesome-base")
             .comments();
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkPullRefTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullRefTest.java
@@ -50,9 +50,9 @@ public final class MkPullRefTest {
     private static final String REF = "awesome-branch";
     /**
      * Test commit SHA.
-     * @checkstyle LineLength (2 lines)
      */
-    private static final String SHA = "361bb23ed4c028914d45d53c3727c48b035ee643";
+    private static final String SHA =
+        "361bb23ed4c028914d45d53c3727c48b035ee643";
     /**
      * Test username.
      */
@@ -65,9 +65,10 @@ public final class MkPullRefTest {
     @Test
     public void fetchesRepo() throws IOException {
         final MkStorage storage = new MkStorage.InFile();
-        final Repo repo = new MkGithub(storage, USERNAME).randomRepo();
+        final Repo repo = new MkGithub(storage, MkPullRefTest.USERNAME)
+            .randomRepo();
         MatcherAssert.assertThat(
-            pullRef(storage, repo).repo().coordinates(),
+            MkPullRefTest.pullRef(storage, repo).repo().coordinates(),
             Matchers.equalTo(repo.coordinates())
         );
     }
@@ -80,7 +81,7 @@ public final class MkPullRefTest {
     public void fetchesRef() throws IOException {
         MatcherAssert.assertThat(
             pullRef().ref(),
-            Matchers.equalTo(REF)
+            Matchers.equalTo(MkPullRefTest.REF)
         );
     }
 
@@ -92,7 +93,7 @@ public final class MkPullRefTest {
     public void fetchesSha() throws IOException {
         MatcherAssert.assertThat(
             pullRef().sha(),
-            Matchers.equalTo(SHA)
+            Matchers.equalTo(MkPullRefTest.SHA)
         );
     }
 
@@ -105,10 +106,10 @@ public final class MkPullRefTest {
         final MkStorage storage = new MkStorage.InFile();
         return new MkPullRef(
             storage,
-            ((MkBranches) (new MkGithub(storage, USERNAME)
+            ((MkBranches) (new MkGithub(storage, MkPullRefTest.USERNAME)
                 .randomRepo()
                 .branches()
-            )).create(REF, SHA)
+            )).create(MkPullRefTest.REF, MkPullRefTest.SHA)
         );
     }
 
@@ -125,7 +126,8 @@ public final class MkPullRefTest {
     ) throws IOException {
         return new MkPullRef(
             storage,
-            ((MkBranches) (repo.branches())).create(REF, SHA)
+            ((MkBranches) (repo.branches()))
+                .create(MkPullRefTest.REF, MkPullRefTest.SHA)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkPullRefTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullRefTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github.mock;
+
+import com.jcabi.github.PullRef;
+import com.jcabi.github.Repo;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link MkPullRef}.
+ *
+ * @author Chris Rebert (github@rebertia.com)
+ * @version $Id$
+ * @since 0.24
+ */
+public final class MkPullRefTest {
+    /**
+     * Test ref.
+     */
+    private static final String REF = "awesome-branch";
+    /**
+     * Test commit SHA.
+     * @checkstyle LineLength (2 lines)
+     */
+    private static final String SHA = "361bb23ed4c028914d45d53c3727c48b035ee643";
+    /**
+     * Test username.
+     */
+    private static final String USERNAME = "myrtle";
+
+    /**
+     * MkPullRef can fetch its repo.
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void fetchesRepo() throws IOException {
+        final MkStorage storage = new MkStorage.InFile();
+        final Repo repo = new MkGithub(storage, USERNAME).randomRepo();
+        MatcherAssert.assertThat(
+            pullRef(storage, repo).repo().coordinates(),
+            Matchers.equalTo(repo.coordinates())
+        );
+    }
+
+    /**
+     * MkPullRef can fetch its ref name.
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void fetchesRef() throws IOException {
+        MatcherAssert.assertThat(
+            pullRef().ref(),
+            Matchers.equalTo(REF)
+        );
+    }
+
+    /**
+     * MkPullRef can fetch its commit sha.
+     * @throws IOException If there is an I/O problem
+     */
+    @Test
+    public void fetchesSha() throws IOException {
+        MatcherAssert.assertThat(
+            pullRef().sha(),
+            Matchers.equalTo(SHA)
+        );
+    }
+
+    /**
+     * Returns an MkPullRef for testing.
+     * @return MkPullRef for testing
+     * @throws IOException If there is an I/O problem
+     */
+    private static PullRef pullRef() throws IOException {
+        final MkStorage storage = new MkStorage.InFile();
+        return new MkPullRef(
+            storage,
+            ((MkBranches) (new MkGithub(storage, USERNAME)
+                .randomRepo()
+                .branches()
+            )).create(REF, SHA)
+        );
+    }
+
+    /**
+     * Returns a pull request ref for testing.
+     * @param storage Storage
+     * @param repo Repo to create the pull request ref in
+     * @return PullRef for testing
+     * @throws IOException If there is an I/O problem
+     */
+    private static PullRef pullRef(
+        final MkStorage storage,
+        final Repo repo
+    ) throws IOException {
+        return new MkPullRef(
+            storage,
+            ((MkBranches) (repo.branches())).create(REF, SHA)
+        );
+    }
+}

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -140,7 +140,7 @@ public final class MkPullTest {
      */
     @Test
     public void canGetBase() throws Exception {
-        final PullRef base = pullRequest().base();
+        final PullRef base = MkPullTest.pullRequest().base();
         MatcherAssert.assertThat(base, Matchers.notNullValue());
         MatcherAssert.assertThat(base.ref(), Matchers.equalTo(BASE));
     }
@@ -151,7 +151,7 @@ public final class MkPullTest {
      */
     @Test
     public void canGetHead() throws Exception {
-        final PullRef head = pullRequest().head();
+        final PullRef head = MkPullTest.pullRequest().head();
         MatcherAssert.assertThat(head, Matchers.notNullValue());
         MatcherAssert.assertThat(head.ref(), Matchers.equalTo(HEAD));
     }

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -145,16 +145,16 @@ public final class MkPullTest {
         final Pull pull = repo().pulls().create("Test Pull Json", head, base);
         final JsonObject json = pull.json();
         MatcherAssert.assertThat(
-            json.getString("number"),
-            Matchers.equalTo("1")
+            json.getInt("number"),
+            Matchers.equalTo(1)
         );
         MatcherAssert.assertThat(
-            json.getString("head"),
-            Matchers.equalTo(head)
+            json.getJsonObject("head").getString("label"),
+            Matchers.equalTo(String.format("%s:%s", USERNAME, head))
         );
         MatcherAssert.assertThat(
-            json.getString("base"),
-            Matchers.equalTo(base)
+            json.getJsonObject("base").getString("label"),
+            Matchers.equalTo(String.format("%s:%s", USERNAME, base))
         );
         MatcherAssert.assertThat(
             json.getJsonObject("user").getString("login"),

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -31,6 +31,7 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Pull;
+import com.jcabi.github.PullRef;
 import com.jcabi.github.Repo;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -131,6 +132,28 @@ public final class MkPullTest {
             pull.comments(),
             Matchers.notNullValue()
         );
+    }
+
+    /**
+     * MkPull can get its base ref.
+     * @throws Exception If a problem occurs.
+     */
+    @Test
+    public void canGetBase() throws Exception {
+        final PullRef base = pullRequest().base();
+        MatcherAssert.assertThat(base, Matchers.notNullValue());
+        MatcherAssert.assertThat(base.ref(), Matchers.equalTo(BASE));
+    }
+
+    /**
+     * MkPull can get its head ref.
+     * @throws Exception If a problem occurs.
+     */
+    @Test
+    public void canGetHead() throws Exception {
+        final PullRef head = pullRequest().head();
+        MatcherAssert.assertThat(head, Matchers.notNullValue());
+        MatcherAssert.assertThat(head.ref(), Matchers.equalTo(HEAD));
     }
 
     /**

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -51,6 +51,14 @@ public final class MkPullTest {
      * Login of test user.
      */
     private static final String USERNAME = "patrick";
+    /**
+     * Base branch name.
+     */
+    private static final String BASE = "my-base-branch";
+    /**
+     * Head branch name.
+     */
+    private static final String HEAD = "my-head-branch";
 
     /**
      * MkPull should be able to compare different instances.
@@ -88,7 +96,7 @@ public final class MkPullTest {
      */
     @Test
     public void canGetCommentsNumberIfZero() throws Exception {
-        final Pull pull = MkPullTest.repo().pulls().create("", "", "");
+        final Pull pull = MkPullTest.pullRequest();
         MatcherAssert.assertThat(
             pull.json().getInt("comments"),
             Matchers.is(0)
@@ -102,8 +110,7 @@ public final class MkPullTest {
      */
     @Test
     public void canGetCommentsNumberIfNonZero() throws Exception {
-        final Repo repo =  MkPullTest.repo();
-        final Pull pull = repo.pulls().create("", "", "");
+        final Pull pull = MkPullTest.pullRequest();
         pull.comments().post("comment1", "path1", "how are you?", 1);
         pull.comments().post("comment2", "path2", "how are you2?", 2);
         MatcherAssert.assertThat(
@@ -119,8 +126,7 @@ public final class MkPullTest {
      */
     @Test
     public void canGetComments() throws Exception {
-        final Repo repo =  MkPullTest.repo();
-        final Pull pull = repo.pulls().create("", "", "");
+        final Pull pull = MkPullTest.pullRequest();
         MatcherAssert.assertThat(
             pull.comments(),
             Matchers.notNullValue()
@@ -181,5 +187,18 @@ public final class MkPullTest {
      */
     private static Repo repo() throws Exception {
         return new MkGithub(USERNAME).randomRepo();
+    }
+
+    /**
+     * Create a pull request to work with.
+     * @return Repo
+     * @throws Exception If some problem inside
+     */
+    private static Pull pullRequest() throws Exception {
+        final Repo rpo = MkPullTest.repo();
+        final MkBranches branches = (MkBranches) (rpo.branches());
+        branches.create(BASE, "e11f7ffa797f8422f016576cb7c2f5bb6f66aa51");
+        branches.create(HEAD, "5a8d0143b3fa9de883a5672d4a1f44d472657a8a");
+        return rpo.pulls().create("Test PR", HEAD, BASE);
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -142,7 +142,10 @@ public final class MkPullTest {
     public void canGetBase() throws Exception {
         final PullRef base = MkPullTest.pullRequest().base();
         MatcherAssert.assertThat(base, Matchers.notNullValue());
-        MatcherAssert.assertThat(base.ref(), Matchers.equalTo(BASE));
+        MatcherAssert.assertThat(
+            base.ref(),
+            Matchers.equalTo(MkPullTest.BASE)
+        );
     }
 
     /**
@@ -153,7 +156,10 @@ public final class MkPullTest {
     public void canGetHead() throws Exception {
         final PullRef head = MkPullTest.pullRequest().head();
         MatcherAssert.assertThat(head, Matchers.notNullValue());
-        MatcherAssert.assertThat(head.ref(), Matchers.equalTo(HEAD));
+        MatcherAssert.assertThat(
+            head.ref(),
+            Matchers.equalTo(MkPullTest.HEAD)
+        );
     }
 
     /**
@@ -165,7 +171,8 @@ public final class MkPullTest {
     public void canRetrieveAsJson() throws Exception {
         final String head = "blah";
         final String base = "aaa";
-        final Pull pull = repo().pulls().create("Test Pull Json", head, base);
+        final Pull pull = MkPullTest.repo().pulls()
+            .create("Test Pull Json", head, base);
         final JsonObject json = pull.json();
         MatcherAssert.assertThat(
             json.getInt("number"),
@@ -173,15 +180,27 @@ public final class MkPullTest {
         );
         MatcherAssert.assertThat(
             json.getJsonObject("head").getString("label"),
-            Matchers.equalTo(String.format("%s:%s", USERNAME, head))
+            Matchers.equalTo(
+                String.format(
+                    "%s:%s",
+                    MkPullTest.USERNAME,
+                    head
+                )
+            )
         );
         MatcherAssert.assertThat(
             json.getJsonObject("base").getString("label"),
-            Matchers.equalTo(String.format("%s:%s", USERNAME, base))
+            Matchers.equalTo(
+                String.format(
+                    "%s:%s",
+                    MkPullTest.USERNAME,
+                    base
+                )
+            )
         );
         MatcherAssert.assertThat(
             json.getJsonObject("user").getString("login"),
-            Matchers.equalTo(USERNAME)
+            Matchers.equalTo(MkPullTest.USERNAME)
         );
     }
 
@@ -192,7 +211,8 @@ public final class MkPullTest {
      */
     @Test
     public void canPatchJson() throws Exception {
-        final Pull pull = repo().pulls().create("Test Patch", "def", "abc");
+        final Pull pull = MkPullTest.repo().pulls()
+            .create("Test Patch", "def", "abc");
         final String value = "someValue";
         pull.patch(
             Json.createObjectBuilder().add("patch", value).build()
@@ -209,7 +229,7 @@ public final class MkPullTest {
      * @throws Exception If some problem inside
      */
     private static Repo repo() throws Exception {
-        return new MkGithub(USERNAME).randomRepo();
+        return new MkGithub(MkPullTest.USERNAME).randomRepo();
     }
 
     /**
@@ -220,8 +240,18 @@ public final class MkPullTest {
     private static Pull pullRequest() throws Exception {
         final Repo rpo = MkPullTest.repo();
         final MkBranches branches = (MkBranches) (rpo.branches());
-        branches.create(BASE, "e11f7ffa797f8422f016576cb7c2f5bb6f66aa51");
-        branches.create(HEAD, "5a8d0143b3fa9de883a5672d4a1f44d472657a8a");
-        return rpo.pulls().create("Test PR", HEAD, BASE);
+        branches.create(
+            MkPullTest.BASE,
+            "e11f7ffa797f8422f016576cb7c2f5bb6f66aa51"
+        );
+        branches.create(
+            MkPullTest.HEAD,
+            "5a8d0143b3fa9de883a5672d4a1f44d472657a8a"
+        );
+        return rpo.pulls().create(
+            "Test PR",
+            MkPullTest.HEAD,
+            MkPullTest.BASE
+        );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkPullsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullsTest.java
@@ -54,7 +54,11 @@ public final class MkPullsTest {
     @Test
     public void canCreateAPull() throws Exception {
         final Repo repo = new MkGithub().randomRepo();
-        final Pull pull = repo.pulls().create("hello", "", "");
+        final Pull pull = repo.pulls().create(
+            "hello",
+            "head-branch",
+            "base-branch"
+        );
         final Issue.Smart issue = new Issue.Smart(
             repo.issues().get(pull.number())
         );


### PR DESCRIPTION
Fixes #1090 by adding `Pull.base()` and `Pull.head()` getters, which return instances of the new `PullRef` class, which allows structured access to the pull request branch+commit data. Thus, the user no longer has to resort to dealing with the raw JSON directly themselves.