### PR TITLE
Add Status API tests post-overhaul

### DIFF
--- a/src/main/java/com/jcabi/github/RtStatus.java
+++ b/src/main/java/com/jcabi/github/RtStatus.java
@@ -29,7 +29,10 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
+import java.io.StringReader;
+import javax.json.Json;
 import javax.json.JsonObject;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
@@ -41,6 +44,7 @@ import lombok.EqualsAndHashCode;
  * @version $Id$
  * @since 0.23
  */
+@Immutable
 @Loggable(Loggable.DEBUG)
 @EqualsAndHashCode(of = { "cmmt", "jsn" })
 public final class RtStatus implements Status {
@@ -49,9 +53,9 @@ public final class RtStatus implements Status {
      */
     private final transient Commit cmmt;
     /**
-     * Encapsulated status JSON object.
+     * Encapsulated status JSON.
      */
-    private final transient JsonObject jsn;
+    private final transient String jsn;
 
     /**
      * Public ctor.
@@ -65,24 +69,24 @@ public final class RtStatus implements Status {
         final JsonObject obj
     ) {
         this.cmmt = cmt;
-        this.jsn = obj;
+        this.jsn = obj.toString();
     }
 
     @Override
     @NotNull(message = "JSON is never NULL")
     public JsonObject json() {
-        return this.jsn;
+        return Json.createReader(new StringReader(this.jsn)).readObject();
     }
 
     @Override
     public int identifier() {
-        return this.jsn.getInt("id");
+        return this.json().getInt("id");
     }
 
     @Override
     @NotNull(message = "URL is never NULL")
     public String url() {
-        return this.jsn.getString("url");
+        return this.json().getString("url");
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/RtStatus.java
+++ b/src/main/java/com/jcabi/github/RtStatus.java
@@ -29,7 +29,6 @@
  */
 package com.jcabi.github;
 
-import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import javax.json.JsonObject;
 import javax.validation.constraints.NotNull;
@@ -42,7 +41,6 @@ import lombok.EqualsAndHashCode;
  * @version $Id$
  * @since 0.23
  */
-@Immutable
 @Loggable(Loggable.DEBUG)
 @EqualsAndHashCode(of = { "cmmt", "jsn" })
 public final class RtStatus implements Status {

--- a/src/test/java/com/jcabi/github/RtStatusTest.java
+++ b/src/test/java/com/jcabi/github/RtStatusTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.github.mock.MkGithub;
+import java.io.IOException;
+import javax.json.Json;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RtStatus}.
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.24
+ */
+public final class RtStatusTest {
+    /**
+     * RtStatus can fetch its ID number.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesId() throws IOException {
+        final int ident = 666;
+        MatcherAssert.assertThat(
+            new RtStatus(
+                RtStatusTest.commit(),
+                Json.createObjectBuilder().add("id", ident).build()
+            ).identifier(),
+            Matchers.equalTo(ident)
+        );
+    }
+
+    /**
+     * RtStatus can fetch its URL.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesUrl() throws IOException {
+        final String url = "http://api.jcabi-github.invalid/whatever";
+        MatcherAssert.assertThat(
+            new RtStatus(
+                RtStatusTest.commit(),
+                Json.createObjectBuilder().add("url", url).build()
+            ).url(),
+            Matchers.equalTo(url)
+        );
+    }
+
+    /**
+     * RtStatus can fetch its associated commit.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesCommit() throws IOException {
+        final Commit cmmt = RtStatusTest.commit();
+        MatcherAssert.assertThat(
+            new RtStatus(cmmt, Json.createObjectBuilder().build()).commit(),
+            Matchers.equalTo(cmmt)
+        );
+    }
+
+    /**
+     * Returns a test commit to work with.
+     * @return Commit
+     * @throws IOException If there is an I/O problem.
+     */
+    private static Commit commit() throws IOException {
+        return new MkGithub().randomRepo().git().commits()
+            .get("d288364af5028c72e2a2c91c29343bae11fffcbe");
+    }
+}

--- a/src/test/java/com/jcabi/github/RtStatusesTest.java
+++ b/src/test/java/com/jcabi/github/RtStatusesTest.java
@@ -35,6 +35,8 @@ import com.jcabi.http.mock.MkAnswer;
 import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.request.ApacheRequest;
+import com.jcabi.http.request.FakeRequest;
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
@@ -50,6 +52,19 @@ import org.junit.Test;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public class RtStatusesTest {
+    /**
+     * RtStatuses can fetch its commit.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesCommit() throws IOException {
+        final Commit original = new MkGithub().randomRepo().git()
+            .commits().get("5e8d65e0dbfab0716db16493e03a0baba480625a");
+        MatcherAssert.assertThat(
+            new RtStatuses(new FakeRequest(), original).commit(),
+            Matchers.equalTo(original)
+        );
+    }
 
     /**
      * Tests creating a Commit.

--- a/src/test/java/com/jcabi/github/RtStatusesTest.java
+++ b/src/test/java/com/jcabi/github/RtStatusesTest.java
@@ -50,6 +50,8 @@ import org.junit.Test;
  * @version $Id$
  * @checkstyle MultipleStringLiterals (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @todo #1130:30min Write RtStatusesITCase, an integration test case for
+ *  RtStatuses/RtStatus against real GitHub commit status data.
  */
 public class RtStatusesTest {
     /**

--- a/src/test/java/com/jcabi/github/RtStatusesTest.java
+++ b/src/test/java/com/jcabi/github/RtStatusesTest.java
@@ -29,12 +29,16 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.mock.MkGithub;
+import com.jcabi.http.Request;
 import com.jcabi.http.mock.MkAnswer;
 import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
+import com.jcabi.http.request.ApacheRequest;
 import java.net.HttpURLConnection;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
@@ -64,11 +68,27 @@ public class RtStatusesTest {
                     .build().toString()
             )
         ).start();
+        final Request req = new ApacheRequest(container.home());
+        final Statuses statuses = new RtStatuses(
+            req,
+            new RtCommit(
+                req,
+                new MkGithub().randomRepo(),
+                "0abcd89jcabitest"
+            )
+        );
         try {
-            MatcherAssert.assertThat(
-                "whatever",
-                true
+            statuses.create(
+                new RtStatus(
+                    Status.State.Failure, "http://example.com",
+                    "description", "ctx"
+                )
             );
+            MatcherAssert.assertThat(
+                container.take().method(),
+                Matchers.equalTo(Request.POST)
+            );
+            Matchers.equalToIgnoringCase(Status.State.Failure.name());
         } finally {
             container.stop();
         }

--- a/src/test/java/com/jcabi/github/StatusTest.java
+++ b/src/test/java/com/jcabi/github/StatusTest.java
@@ -1,0 +1,378 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.google.common.base.Optional;
+import com.jcabi.github.mock.MkGithub;
+import java.io.IOException;
+import javax.json.Json;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link Status}.
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.24
+ */
+@SuppressWarnings("PMD.TooManyMethods")
+public final class StatusTest {
+    /**
+     * Name of state property in Status JSON object.
+     */
+    private static final String STATE_PROP = "state";
+    /**
+     * Name of description property in Status JSON object.
+     */
+    private static final String DESCRIPTION_PROP = "description";
+    /**
+     * Name of description property in Status JSON object.
+     */
+    private static final String TARGET_PROP = "target_url";
+
+    /**
+     * Status.Smart can fetch its commit.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesCommit() throws IOException {
+        final Commit cmmt = StatusTest.commit();
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(cmmt, Json.createObjectBuilder().build())
+            ).commit(),
+            Matchers.equalTo(cmmt)
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its ID number.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesId() throws IOException {
+        final int ident = 777;
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder().add("id", ident).build()
+                )
+            ).identifier(),
+            Matchers.equalTo(ident)
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its URL.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesUrl() throws IOException {
+        final String url = "http://api.jcabi-github.invalid/wherever";
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder().add("url", url).build()
+                )
+            ).url(),
+            Matchers.equalTo(url)
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its state when it's error.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesErrorState() throws IOException {
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder()
+                        .add(StatusTest.STATE_PROP, "error").build()
+                )
+            ).state(),
+            Matchers.equalTo(Status.State.ERROR)
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its state when it's failure.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesFailureState() throws IOException {
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder()
+                        .add(StatusTest.STATE_PROP, "failure").build()
+                )
+            ).state(),
+            Matchers.equalTo(Status.State.FAILURE)
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its state when it's pending.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesPendingState() throws IOException {
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder()
+                        .add(StatusTest.STATE_PROP, "pending").build()
+                )
+            ).state(),
+            Matchers.equalTo(Status.State.PENDING)
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its state when it's success.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesSuccessState() throws IOException {
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder()
+                        .add(StatusTest.STATE_PROP, "success").build()
+                )
+            ).state(),
+            Matchers.equalTo(Status.State.SUCCESS)
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its target URL when it's present.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesPresentTargetUrl() throws IOException {
+        final String url = "http://api.jcabi-github.invalid/good-luck";
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder()
+                        .add(StatusTest.TARGET_PROP, url).build()
+                )
+            ).targetUrl(),
+            Matchers.equalTo(Optional.of(url))
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its target URL when it's absent.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesAbsentTargetUrl() throws IOException {
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder().build()
+                )
+            ).targetUrl(),
+            Matchers.equalTo(Optional.<String>absent())
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its target URL when it's null.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesNullTargetUrl() throws IOException {
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder()
+                        .addNull(StatusTest.TARGET_PROP).build()
+                )
+            ).targetUrl(),
+            Matchers.equalTo(Optional.<String>absent())
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its description when it's present.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesPresentDescription() throws IOException {
+        final String description = "Mostly harmless";
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder()
+                        .add(StatusTest.DESCRIPTION_PROP, description).build()
+                )
+            ).description(),
+            Matchers.equalTo(description)
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its description when it's absent.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesAbsentDescription() throws IOException {
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder().build()
+                )
+            ).description(),
+            Matchers.equalTo("")
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its description when it's null.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesNullDescription() throws IOException {
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder()
+                        .addNull(StatusTest.DESCRIPTION_PROP).build()
+                )
+            ).description(),
+            Matchers.equalTo("")
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its context.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesContext() throws IOException {
+        final String context = "jcabi/github/tester";
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder().add("context", context).build()
+                )
+            ).context(),
+            Matchers.equalTo(context)
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its created-at timestamp.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void fetchesCreatedAt() throws Exception {
+        final String when = "2015-02-27T19:35:32Z";
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder().add("created_at", when).build()
+                )
+            ).createdAt(),
+            Matchers.equalTo(new Github.Time(when).date())
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its last-updated-at timestamp.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void fetchesUpdatedAt() throws Exception {
+        final String when = "2013-02-27T19:35:32Z";
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder().add("updated_at", when).build()
+                )
+            ).updatedAt(),
+            Matchers.equalTo(new Github.Time(when).date())
+        );
+    }
+
+    /**
+     * Status.Smart can fetch its creator.
+     * @throws IOException If there is an I/O problem.
+     */
+    @Test
+    public void fetchesCreator() throws IOException {
+        final String login = "bob";
+        MatcherAssert.assertThat(
+            new Status.Smart(
+                new RtStatus(
+                    StatusTest.commit(),
+                    Json.createObjectBuilder()
+                        .add(
+                            "creator",
+                            Json.createObjectBuilder()
+                                .add("login", login).build()
+                        ).build()
+                )
+            ).creator().login(),
+            Matchers.equalTo(login)
+        );
+    }
+
+    /**
+     * Returns a test commit to work with.
+     * @return Commit
+     * @throws IOException If there is an I/O problem.
+     */
+    private static Commit commit() throws IOException {
+        return new MkGithub().randomRepo().git().commits()
+            .get("d288364af5028c72e2a2c91c29343bae11fffcbe");
+    }
+}

--- a/src/test/java/com/jcabi/github/StatusTest.java
+++ b/src/test/java/com/jcabi/github/StatusTest.java
@@ -31,7 +31,6 @@ package com.jcabi.github;
 
 import com.google.common.base.Optional;
 import com.jcabi.github.mock.MkGithub;
-import java.io.IOException;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -60,10 +59,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its commit.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesCommit() throws IOException {
+    public void fetchesCommit() throws Exception {
         final Commit cmmt = StatusTest.commit();
         MatcherAssert.assertThat(
             new Status.Smart(
@@ -75,10 +74,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its ID number.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesId() throws IOException {
+    public void fetchesId() throws Exception {
         final int ident = 777;
         MatcherAssert.assertThat(
             new Status.Smart(
@@ -93,10 +92,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its URL.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesUrl() throws IOException {
+    public void fetchesUrl() throws Exception {
         final String url = "http://api.jcabi-github.invalid/wherever";
         MatcherAssert.assertThat(
             new Status.Smart(
@@ -111,10 +110,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its state when it's error.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesErrorState() throws IOException {
+    public void fetchesErrorState() throws Exception {
         MatcherAssert.assertThat(
             new Status.Smart(
                 new RtStatus(
@@ -129,10 +128,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its state when it's failure.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesFailureState() throws IOException {
+    public void fetchesFailureState() throws Exception {
         MatcherAssert.assertThat(
             new Status.Smart(
                 new RtStatus(
@@ -147,10 +146,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its state when it's pending.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesPendingState() throws IOException {
+    public void fetchesPendingState() throws Exception {
         MatcherAssert.assertThat(
             new Status.Smart(
                 new RtStatus(
@@ -165,10 +164,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its state when it's success.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesSuccessState() throws IOException {
+    public void fetchesSuccessState() throws Exception {
         MatcherAssert.assertThat(
             new Status.Smart(
                 new RtStatus(
@@ -183,10 +182,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its target URL when it's present.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesPresentTargetUrl() throws IOException {
+    public void fetchesPresentTargetUrl() throws Exception {
         final String url = "http://api.jcabi-github.invalid/good-luck";
         MatcherAssert.assertThat(
             new Status.Smart(
@@ -202,10 +201,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its target URL when it's absent.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesAbsentTargetUrl() throws IOException {
+    public void fetchesAbsentTargetUrl() throws Exception {
         MatcherAssert.assertThat(
             new Status.Smart(
                 new RtStatus(
@@ -219,10 +218,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its target URL when it's null.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesNullTargetUrl() throws IOException {
+    public void fetchesNullTargetUrl() throws Exception {
         MatcherAssert.assertThat(
             new Status.Smart(
                 new RtStatus(
@@ -237,10 +236,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its description when it's present.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesPresentDescription() throws IOException {
+    public void fetchesPresentDescription() throws Exception {
         final String description = "Mostly harmless";
         MatcherAssert.assertThat(
             new Status.Smart(
@@ -256,10 +255,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its description when it's absent.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesAbsentDescription() throws IOException {
+    public void fetchesAbsentDescription() throws Exception {
         MatcherAssert.assertThat(
             new Status.Smart(
                 new RtStatus(
@@ -273,10 +272,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its description when it's null.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesNullDescription() throws IOException {
+    public void fetchesNullDescription() throws Exception {
         MatcherAssert.assertThat(
             new Status.Smart(
                 new RtStatus(
@@ -291,10 +290,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its context.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesContext() throws IOException {
+    public void fetchesContext() throws Exception {
         final String context = "jcabi/github/tester";
         MatcherAssert.assertThat(
             new Status.Smart(
@@ -345,10 +344,10 @@ public final class StatusTest {
 
     /**
      * Status.Smart can fetch its creator.
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void fetchesCreator() throws IOException {
+    public void fetchesCreator() throws Exception {
         final String login = "bob";
         MatcherAssert.assertThat(
             new Status.Smart(
@@ -369,9 +368,9 @@ public final class StatusTest {
     /**
      * Returns a test commit to work with.
      * @return Commit
-     * @throws IOException If there is an I/O problem.
+     * @throws Exception If some problem inside
      */
-    private static Commit commit() throws IOException {
+    private static Commit commit() throws Exception {
         return new MkGithub().randomRepo().git().commits()
             .get("d288364af5028c72e2a2c91c29343bae11fffcbe");
     }

--- a/src/test/java/com/jcabi/github/StatusesTest.java
+++ b/src/test/java/com/jcabi/github/StatusesTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.google.common.base.Optional;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link Statuses}.
+ * @author Chris Rebert (github@chrisrebert.com)
+ * @version $Id$
+ * @since 0.24
+ */
+public final class StatusesTest {
+    /**
+     * Test status URL.
+     */
+    private static final String URL = "http://status.jcabi-github.invalid/42";
+
+    /**
+     * Test commit status context string.
+     */
+    private static final String CONTEXT = "jcabi/github/test";
+
+    /**
+     * StatusCreate can convert itself to JSON.
+     */
+    @Test
+    public void convertsToJsonWhenAllPresent() {
+        final String success = "Everything is awesome";
+        MatcherAssert.assertThat(
+            new Statuses.StatusCreate(Status.State.SUCCESS)
+                .withTargetUrl(Optional.of(URL))
+                .withDescription(success)
+                .withContext(Optional.of(CONTEXT))
+                .json().toString(),
+            // @checkstyle LineLength (1 line)
+            Matchers.equalTo("{\"state\":\"success\",\"description\":\"Everything is awesome\",\"context\":\"jcabi/github/test\",\"target_url\":\"http://status.jcabi-github.invalid/42\"}")
+        );
+    }
+
+    /**
+     * StatusCreate can convert itself to JSON when it has no URL.
+     */
+    @Test
+    public void convertsToJsonWhenUrlAbsent() {
+        final String success = "Living the dream!";
+        MatcherAssert.assertThat(
+            new Statuses.StatusCreate(Status.State.SUCCESS)
+                .withDescription(success)
+                .withContext(Optional.of(CONTEXT))
+                .json().toString(),
+            // @checkstyle LineLength (1 line)
+            Matchers.equalTo("{\"state\":\"success\",\"description\":\"Living the dream!\",\"context\":\"jcabi/github/test\"}")
+        );
+    }
+
+    /**
+     * StatusCreate can convert itself to JSON when it has no description.
+     */
+    @Test
+    public void convertsToJsonWhenDescriptionAbsent() {
+        MatcherAssert.assertThat(
+            new Statuses.StatusCreate(Status.State.FAILURE)
+                .withTargetUrl(Optional.of(URL))
+                .withContext(Optional.of(CONTEXT))
+                .json().toString(),
+            // @checkstyle LineLength (1 line)
+            Matchers.equalTo("{\"state\":\"failure\",\"description\":\"\",\"context\":\"jcabi/github/test\",\"target_url\":\"http://status.jcabi-github.invalid/42\"}")
+        );
+    }
+
+    /**
+     * StatusCreate can convert itself to JSON when it has no context.
+     */
+    @Test
+    public void convertsToJsonWhenContextAbsent() {
+        final String pending = "Kragle is drying...";
+        MatcherAssert.assertThat(
+            new Statuses.StatusCreate(Status.State.PENDING)
+                .withTargetUrl(Optional.of(URL))
+                .withDescription(pending)
+                .json().toString(),
+            // @checkstyle LineLength (1 line)
+            Matchers.equalTo("{\"state\":\"pending\",\"description\":\"Kragle is drying...\",\"target_url\":\"http://status.jcabi-github.invalid/42\"}")
+        );
+    }
+}

--- a/src/test/java/com/jcabi/github/StatusesTest.java
+++ b/src/test/java/com/jcabi/github/StatusesTest.java
@@ -30,6 +30,7 @@
 package com.jcabi.github;
 
 import com.google.common.base.Optional;
+import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -42,10 +43,25 @@ import org.junit.Test;
  */
 public final class StatusesTest {
     /**
+     * Name of state property in Status JSON object.
+     */
+    private static final String STATE_PROP = "state";
+    /**
+     * Name of description property in Status JSON object.
+     */
+    private static final String DESCRIPTION_PROP = "description";
+    /**
+     * Name of description property in Status JSON object.
+     */
+    private static final String TARGET_PROP = "target_url";
+    /**
+     * Name of context property in Status JSON object.
+     */
+    private static final String CONTEXT_PROP = "context";
+    /**
      * Test status URL.
      */
     private static final String URL = "http://status.jcabi-github.invalid/42";
-
     /**
      * Test commit status context string.
      */
@@ -56,15 +72,21 @@ public final class StatusesTest {
      */
     @Test
     public void convertsToJsonWhenAllPresent() {
-        final String success = "Everything is awesome";
+        final String success = "Everything is not so awesome";
         MatcherAssert.assertThat(
-            new Statuses.StatusCreate(Status.State.SUCCESS)
-                .withTargetUrl(Optional.of(URL))
+            new Statuses.StatusCreate(Status.State.ERROR)
+                .withTargetUrl(Optional.of(StatusesTest.URL))
                 .withDescription(success)
-                .withContext(Optional.of(CONTEXT))
+                .withContext(Optional.of(StatusesTest.CONTEXT))
                 .json().toString(),
-            // @checkstyle LineLength (1 line)
-            Matchers.equalTo("{\"state\":\"success\",\"description\":\"Everything is awesome\",\"context\":\"jcabi/github/test\",\"target_url\":\"http://status.jcabi-github.invalid/42\"}")
+            Matchers.equalTo(
+                Json.createObjectBuilder()
+                    .add(StatusesTest.STATE_PROP, "error")
+                    .add(StatusesTest.DESCRIPTION_PROP, success)
+                    .add(StatusesTest.CONTEXT_PROP, StatusesTest.CONTEXT)
+                    .add(StatusesTest.TARGET_PROP, StatusesTest.URL)
+                    .build().toString()
+            )
         );
     }
 
@@ -77,10 +99,15 @@ public final class StatusesTest {
         MatcherAssert.assertThat(
             new Statuses.StatusCreate(Status.State.SUCCESS)
                 .withDescription(success)
-                .withContext(Optional.of(CONTEXT))
+                .withContext(Optional.of(StatusesTest.CONTEXT))
                 .json().toString(),
-            // @checkstyle LineLength (1 line)
-            Matchers.equalTo("{\"state\":\"success\",\"description\":\"Living the dream!\",\"context\":\"jcabi/github/test\"}")
+            Matchers.equalTo(
+                Json.createObjectBuilder()
+                    .add(StatusesTest.STATE_PROP, "success")
+                    .add(StatusesTest.DESCRIPTION_PROP, success)
+                    .add(StatusesTest.CONTEXT_PROP, StatusesTest.CONTEXT)
+                    .build().toString()
+            )
         );
     }
 
@@ -91,11 +118,17 @@ public final class StatusesTest {
     public void convertsToJsonWhenDescriptionAbsent() {
         MatcherAssert.assertThat(
             new Statuses.StatusCreate(Status.State.FAILURE)
-                .withTargetUrl(Optional.of(URL))
-                .withContext(Optional.of(CONTEXT))
+                .withTargetUrl(Optional.of(StatusesTest.URL))
+                .withContext(Optional.of(StatusesTest.CONTEXT))
                 .json().toString(),
-            // @checkstyle LineLength (1 line)
-            Matchers.equalTo("{\"state\":\"failure\",\"description\":\"\",\"context\":\"jcabi/github/test\",\"target_url\":\"http://status.jcabi-github.invalid/42\"}")
+            Matchers.equalTo(
+                Json.createObjectBuilder()
+                    .add(StatusesTest.STATE_PROP, "failure")
+                    .add(StatusesTest.DESCRIPTION_PROP, "")
+                    .add(StatusesTest.CONTEXT_PROP, StatusesTest.CONTEXT)
+                    .add(StatusesTest.TARGET_PROP, StatusesTest.URL)
+                    .build().toString()
+            )
         );
     }
 
@@ -107,11 +140,16 @@ public final class StatusesTest {
         final String pending = "Kragle is drying...";
         MatcherAssert.assertThat(
             new Statuses.StatusCreate(Status.State.PENDING)
-                .withTargetUrl(Optional.of(URL))
+                .withTargetUrl(Optional.of(StatusesTest.URL))
                 .withDescription(pending)
                 .json().toString(),
-            // @checkstyle LineLength (1 line)
-            Matchers.equalTo("{\"state\":\"pending\",\"description\":\"Kragle is drying...\",\"target_url\":\"http://status.jcabi-github.invalid/42\"}")
+            Matchers.equalTo(
+                Json.createObjectBuilder()
+                    .add(StatusesTest.STATE_PROP, "pending")
+                    .add(StatusesTest.DESCRIPTION_PROP, pending)
+                    .add(StatusesTest.TARGET_PROP, StatusesTest.URL)
+                    .build().toString()
+            )
         );
     }
 }


### PR DESCRIPTION
This adds the Status API tests promised in https://github.com/jcabi/jcabi-github/pull/1127#discussion_r32581107 and requested in https://github.com/jcabi/jcabi-github/pull/1127#issuecomment-112611522