### PR TITLE
Pass microseconds instead of seconds to java.util.Date constructor

### DIFF
--- a/src/main/java/com/jcabi/github/Limit.java
+++ b/src/main/java/com/jcabi/github/Limit.java
@@ -33,6 +33,7 @@ import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import java.io.IOException;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.validation.constraints.NotNull;
@@ -103,7 +104,10 @@ public interface Limit extends JsonReadable {
         @NotNull(message = "date is never NULL")
         public Date reset() throws IOException {
             return new Date(
-                (long) new SmartJson(this.origin).number("reset") * 1000
+                TimeUnit.MILLISECONDS.convert(
+                    (long) new SmartJson(this.origin).number("reset"),
+                    TimeUnit.SECONDS
+                )
             );
         }
         @Override

--- a/src/main/java/com/jcabi/github/Limit.java
+++ b/src/main/java/com/jcabi/github/Limit.java
@@ -103,7 +103,7 @@ public interface Limit extends JsonReadable {
         @NotNull(message = "date is never NULL")
         public Date reset() throws IOException {
             return new Date(
-                (long) new SmartJson(this.origin).number("reset")
+                (long) new SmartJson(this.origin).number("reset") * 1000
             );
         }
         @Override


### PR DESCRIPTION
Hi,

so I stumbled upon this bug. GitHub returns rate limit in seconds, and then java.util.Date is constructed without converting to microseconds, resulting in reset date being currently always around January 17 1970.