### PR TITLE
#968 :  refactoring method comment to suggest that it is only being used for files not directories.

### DIFF
--- a/src/main/java/com/jcabi/github/Contents.java
+++ b/src/main/java/com/jcabi/github/Contents.java
@@ -89,7 +89,7 @@ public interface Contents {
         throws IOException;
 
     /**
-     * Get the contents of a file or symbolic link in a repository.
+     * Get the contents of a single file or symbolic link in a repository.
      * @param path The content path
      * @param ref The name of the commit/branch/tag.
      * @return Content fetched
@@ -103,8 +103,8 @@ public interface Contents {
     ) throws IOException;
 
     /**
-     * Get the contents of a file or symbolic link in a repository's default
-     * branch (usually master).
+     * Get the contents of a single file or symbolic link.
+     * in a repository's default branch (usually master).
      * @param path The content path
      * @return Content fetched
      * @throws IOException If there is any I/O problem


### PR DESCRIPTION
#968 is the issue related to this issue. This issue was raised due to using an API method to retrieve a directory which is suitable only for repository files. Therefore refactored method documentation to suggest only to use it for files.