### PR TITLE
Ghe URI support fo RtGithub

### DIFF
--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -186,20 +186,6 @@ public final class RtGithub implements Github {
         this.request = req;
     }
 
-    /**
-     * Create ApacheRequest used to talk to Github server.
-     *
-     * @param uri URI of Github server to connect to
-     *
-     * @return Request object for communication with server
-     */
-    private static Request getRequest(final String uri) {
-        return new ApacheRequest(uri)
-            .header(HttpHeaders.USER_AGENT, RtGithub.USER_AGENT)
-            .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
-    }
-
     @Override
     @NotNull(message = "request can't be NULL")
     public Request entry() {
@@ -268,6 +254,20 @@ public final class RtGithub implements Github {
     @NotNull(message = "Markdown is never NULL")
     public Markdown markdown() {
         return new RtMarkdown(this, this.request);
+    }
+
+    /**
+     * Create ApacheRequest used to talk to Github server.
+     *
+     * @param uri URI of Github server to connect to
+     *
+     * @return Request object for communication with server
+     */
+    private static Request getRequest(final String uri) {
+        return new ApacheRequest(uri)
+            .header(HttpHeaders.USER_AGENT, RtGithub.USER_AGENT)
+            .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
     }
 
 }

--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -89,19 +89,9 @@ public final class RtGithub implements Github {
     );
 
     /**
-     * The default Github api URI
+     * The default Github api URI.
      */
-    public static final String DEFAULT_GITHUB_HOST = "https://api.github.com";
-
-    /**
-     * Create ApacheRequest used to talk to Github server.
-     */
-    private static Request getRequest(String uri) {
-        return new ApacheRequest(uri)
-            .header(HttpHeaders.USER_AGENT, RtGithub.USER_AGENT)
-            .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
-    }
+    private static final String DEFAULT_GITHUB_HOST = "https://api.github.com";
 
     /**
      * REST request.
@@ -194,6 +184,20 @@ public final class RtGithub implements Github {
     public RtGithub(
         @NotNull(message = "request can't be NULL") final Request req) {
         this.request = req;
+    }
+
+    /**
+     * Create ApacheRequest used to talk to Github server.
+     *
+     * @param uri URI of Github server to connect to
+     *
+     * @return Request object for communication with server
+     */
+    private static Request getRequest(final String uri) {
+        return new ApacheRequest(uri)
+            .header(HttpHeaders.USER_AGENT, RtGithub.USER_AGENT)
+            .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -88,6 +88,9 @@ public final class RtGithub implements Github {
         Manifests.read("JCabi-Date")
     );
 
+    /**
+     * The default Github api URI
+     */
     public static final String DEFAULT_GITHUB_HOST = "https://api.github.com";
 
     /**
@@ -110,7 +113,7 @@ public final class RtGithub implements Github {
      * @since 0.4
      */
     public RtGithub() {
-        this(getRequest(DEFAULT_GITHUB_HOST));
+        this(RtGithub.getRequest(DEFAULT_GITHUB_HOST));
     }
 
     /**
@@ -122,7 +125,7 @@ public final class RtGithub implements Github {
     public RtGithub(
         @NotNull(message = "user name can't be NULL") final String user,
         @NotNull(message = "password can't be NULL") final String pwd) {
-        this(URI.create(DEFAULT_GITHUB_HOST), user, pwd);
+        this(URI.create(RtGithub.DEFAULT_GITHUB_HOST), user, pwd);
     }
 
     /**
@@ -131,7 +134,7 @@ public final class RtGithub implements Github {
      */
     public RtGithub(
         @NotNull(message = "token can't be NULL") final String token) {
-        this(URI.create(DEFAULT_GITHUB_HOST), token);
+        this(URI.create(RtGithub.DEFAULT_GITHUB_HOST), token);
     }
 
     /**
@@ -140,7 +143,7 @@ public final class RtGithub implements Github {
      */
     public RtGithub(
         @NotNull(message = "uri can't be NULL") final URI uri) {
-        this(getRequest(uri.toString()));
+        this(RtGithub.getRequest(uri.toString()));
     }
 
     /**
@@ -176,7 +179,7 @@ public final class RtGithub implements Github {
         @NotNull(message = "uri can't be NULL") final URI uri,
         @NotNull(message = "token can't be NULL") final String token) {
         this(
-            getRequest(uri.toString()).header(
+            RtGithub.getRequest(uri.toString()).header(
                 HttpHeaders.AUTHORIZATION,
                 String.format("token %s", token)
             )

--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -36,6 +36,7 @@ import com.jcabi.http.request.ApacheRequest;
 import com.jcabi.http.response.JsonResponse;
 import com.jcabi.manifests.Manifests;
 import java.io.IOException;
+import java.net.URI;
 import javax.json.JsonObject;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.HttpHeaders;
@@ -90,7 +91,7 @@ public final class RtGithub implements Github {
     public static final String DEFAULT_GITHUB_HOST = "https://api.github.com";
 
     /**
-     * Create ApacheRequest used to talk to Github server
+     * Create ApacheRequest used to talk to Github server.
      */
     private static Request getRequest(String uri) {
         return new ApacheRequest(uri)
@@ -121,8 +122,39 @@ public final class RtGithub implements Github {
     public RtGithub(
         @NotNull(message = "user name can't be NULL") final String user,
         @NotNull(message = "password can't be NULL") final String pwd) {
+        this(URI.create(DEFAULT_GITHUB_HOST), user, pwd);
+    }
+
+    /**
+     * Public ctor, for authentication with OAuth2 token.
+     * @param token OAuth token
+     */
+    public RtGithub(
+        @NotNull(message = "token can't be NULL") final String token) {
+        this(URI.create(DEFAULT_GITHUB_HOST), token);
+    }
+
+    /**
+     * Public ctor, for anonymous access to Github Enterprise.
+     * @param uri URI of Github server
+     */
+    public RtGithub(
+        @NotNull(message = "uri can't be NULL") final URI uri) {
+        this(getRequest(uri.toString()));
+    }
+
+    /**
+     * Public ctor, for HTTP Basic Authentication.
+     * @param uri URI of Github server
+     * @param user User name
+     * @param pwd Password
+     */
+    public RtGithub(
+        @NotNull(message = "uri can't be NULL") final URI uri,
+        @NotNull(message = "user name can't be NULL") final String user,
+        @NotNull(message = "password can't be NULL") final String pwd) {
         this(
-            getRequest(DEFAULT_GITHUB_HOST).header(
+            getRequest(uri.toString()).header(
                 HttpHeaders.AUTHORIZATION,
                 String.format(
                     "Basic %s",
@@ -137,12 +169,14 @@ public final class RtGithub implements Github {
 
     /**
      * Public ctor, for authentication with OAuth2 token.
+     * @param uri URI of Github server
      * @param token OAuth token
      */
     public RtGithub(
+        @NotNull(message = "uri can't be NULL") final URI uri,
         @NotNull(message = "token can't be NULL") final String token) {
         this(
-            getRequest(DEFAULT_GITHUB_HOST).header(
+            getRequest(uri.toString()).header(
                 HttpHeaders.AUTHORIZATION,
                 String.format("token %s", token)
             )

--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -260,7 +260,7 @@ public final class RtGithub implements Github {
      * Create ApacheRequest used to talk to Github server.
      *
      * @param uri URI of Github server to connect to
-     *
+     * 
      * @return Request object for communication with server
      */
     private static Request getRequest(final String uri) {

--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -91,7 +91,7 @@ public final class RtGithub implements Github {
     /**
      * The default Github api URI.
      */
-    private static final String DEFAULT_GITHUB_HOST = "https://api.github.com";
+    private static final String DEFAULT_HOST = "https://api.github.com";
 
     /**
      * REST request.
@@ -103,7 +103,7 @@ public final class RtGithub implements Github {
      * @since 0.4
      */
     public RtGithub() {
-        this(RtGithub.getRequest(DEFAULT_GITHUB_HOST));
+        this(RtGithub.getRequest(DEFAULT_HOST));
     }
 
     /**
@@ -115,7 +115,7 @@ public final class RtGithub implements Github {
     public RtGithub(
         @NotNull(message = "user name can't be NULL") final String user,
         @NotNull(message = "password can't be NULL") final String pwd) {
-        this(URI.create(RtGithub.DEFAULT_GITHUB_HOST), user, pwd);
+        this(URI.create(RtGithub.DEFAULT_HOST), user, pwd);
     }
 
     /**
@@ -124,7 +124,7 @@ public final class RtGithub implements Github {
      */
     public RtGithub(
         @NotNull(message = "token can't be NULL") final String token) {
-        this(URI.create(RtGithub.DEFAULT_GITHUB_HOST), token);
+        this(URI.create(RtGithub.DEFAULT_HOST), token);
     }
 
     /**
@@ -260,7 +260,6 @@ public final class RtGithub implements Github {
      * Create ApacheRequest used to talk to Github server.
      *
      * @param uri URI of Github server to connect to
-     * 
      * @return Request object for communication with server
      */
     private static Request getRequest(final String uri) {

--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -87,14 +87,17 @@ public final class RtGithub implements Github {
         Manifests.read("JCabi-Date")
     );
 
+    public static final String DEFAULT_GITHUB_HOST = "https://api.github.com";
+
     /**
-     * Default request to start with.
+     * Create ApacheRequest used to talk to Github server
      */
-    private static final Request REQUEST =
-        new ApacheRequest("https://api.github.com")
+    private static Request getRequest(String uri) {
+        return new ApacheRequest(uri)
             .header(HttpHeaders.USER_AGENT, RtGithub.USER_AGENT)
             .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+    }
 
     /**
      * REST request.
@@ -106,7 +109,7 @@ public final class RtGithub implements Github {
      * @since 0.4
      */
     public RtGithub() {
-        this(RtGithub.REQUEST);
+        this(getRequest(DEFAULT_GITHUB_HOST));
     }
 
     /**
@@ -119,7 +122,7 @@ public final class RtGithub implements Github {
         @NotNull(message = "user name can't be NULL") final String user,
         @NotNull(message = "password can't be NULL") final String pwd) {
         this(
-            RtGithub.REQUEST.header(
+            getRequest(DEFAULT_GITHUB_HOST).header(
                 HttpHeaders.AUTHORIZATION,
                 String.format(
                     "Basic %s",
@@ -139,7 +142,7 @@ public final class RtGithub implements Github {
     public RtGithub(
         @NotNull(message = "token can't be NULL") final String token) {
         this(
-            RtGithub.REQUEST.header(
+            getRequest(DEFAULT_GITHUB_HOST).header(
                 HttpHeaders.AUTHORIZATION,
                 String.format("token %s", token)
             )

--- a/src/test/java/com/jcabi/github/RtGithubTest.java
+++ b/src/test/java/com/jcabi/github/RtGithubTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class RtGithubTest {
 
     /**

--- a/src/test/java/com/jcabi/github/RtGithubTest.java
+++ b/src/test/java/com/jcabi/github/RtGithubTest.java
@@ -29,9 +29,8 @@
  */
 package com.jcabi.github;
 
-import java.net.URI;
-
 import com.jcabi.http.request.FakeRequest;
+import java.net.URI;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;

--- a/src/test/java/com/jcabi/github/RtGithubTest.java
+++ b/src/test/java/com/jcabi/github/RtGithubTest.java
@@ -34,6 +34,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.net.URI;
+
 /**
  * Test case for {@link RtGithub}.
  *
@@ -189,6 +191,20 @@ public final class RtGithubTest {
         MatcherAssert.assertThat(
             new RtGithub(new FakeRequest()),
             Matchers.equalTo(new RtGithub(new FakeRequest()))
+        );
+    }
+
+    /**
+     * RtGithub can connect easily to another Github [enterprise] server
+     */
+    @Test
+    public void connectsToAnotherGithubServer() throws Exception {
+        final RtGithub github = new RtGithub(URI.create("http://localhost:12345"));
+        MatcherAssert.assertThat(
+            github.entry().uri().toString(),
+              Matchers.equalTo(
+                "http://localhost:12345/"
+              )
         );
     }
 }

--- a/src/test/java/com/jcabi/github/RtGithubTest.java
+++ b/src/test/java/com/jcabi/github/RtGithubTest.java
@@ -199,12 +199,11 @@ public final class RtGithubTest {
      */
     @Test
     public void connectsToAnotherGithubServer() throws Exception {
-        final RtGithub github = new RtGithub(URI.create("http://localhost:12345"));
         MatcherAssert.assertThat(
-            github.entry().uri().toString(),
-              Matchers.equalTo(
+            new RtGithub(URI.create("http://localhost:12345")).entry().uri().toString(),
+            Matchers.equalTo(
                 "http://localhost:12345/"
-              )
+            )
         );
     }
 }

--- a/src/test/java/com/jcabi/github/RtGithubTest.java
+++ b/src/test/java/com/jcabi/github/RtGithubTest.java
@@ -29,12 +29,12 @@
  */
 package com.jcabi.github;
 
+import java.net.URI;
+
 import com.jcabi.http.request.FakeRequest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import java.net.URI;
 
 /**
  * Test case for {@link RtGithub}.
@@ -195,12 +195,14 @@ public final class RtGithubTest {
     }
 
     /**
-     * RtGithub can connect easily to another Github [enterprise] server
+     * RtGithub can connect easily to another Github [enterprise] server.
+     * @throws Exception if a problem occurs.
      */
     @Test
     public void connectsToAnotherGithubServer() throws Exception {
         MatcherAssert.assertThat(
-            new RtGithub(URI.create("http://localhost:12345")).entry().uri().toString(),
+            new RtGithub(URI.create("http://localhost:12345"))
+                .entry().uri().toString(),
             Matchers.equalTo(
                 "http://localhost:12345/"
             )


### PR DESCRIPTION
This adds a few constructors to `RtGithub` in order to simplify creation when using jcabi with a github enterprise deployment. While the `Request` constructor does allow use with GHE, as a user you have to look up how the default `Request` object is created and copy that. Uses java.net's `URI` object to make the signature unique versus the user:password and token constructors.