### PR TITLE
Use RandomPort rule to avoid tests fail with BindException

### DIFF
--- a/src/test/java/com/jcabi/github/RtAssigneesTest.java
+++ b/src/test/java/com/jcabi/github/RtAssigneesTest.java
@@ -72,7 +72,7 @@ public final class RtAssigneesTest {
                     .add(RtAssigneesTest.json("dummy"))
                     .build().toString()
             )
-        ).start(resource.port());
+        ).start(this.resource.port());
         final Assignees users = new RtAssignees(
             new JdkRequest(container.home()),
             this.repo()
@@ -98,7 +98,7 @@ public final class RtAssigneesTest {
                     .add(RtAssigneesTest.json("dummy"))
                     .build().toString()
             )
-        ).start(resource.port());
+        ).start(this.resource.port());
         final Assignees users = new RtAssignees(
             new JdkRequest(container.home()),
             this.repo()
@@ -124,7 +124,7 @@ public final class RtAssigneesTest {
                     .add(RtAssigneesTest.json("dummy"))
                     .build().toString()
             )
-        ).start(resource.port());
+        ).start(this.resource.port());
         final Assignees users = new RtAssignees(
             new JdkRequest(container.home()),
             this.repo()

--- a/src/test/java/com/jcabi/github/RtAssigneesTest.java
+++ b/src/test/java/com/jcabi/github/RtAssigneesTest.java
@@ -38,6 +38,7 @@ import javax.json.Json;
 import javax.json.JsonValue;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -49,6 +50,13 @@ import org.mockito.Mockito;
  * @checkstyle MultipleStringLiterals (500 lines)
  */
 public final class RtAssigneesTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
 
     /**
      * RtAssignees can iterate over assignees.
@@ -64,7 +72,7 @@ public final class RtAssigneesTest {
                     .add(RtAssigneesTest.json("dummy"))
                     .build().toString()
             )
-        ).start();
+        ).start(resource.port());
         final Assignees users = new RtAssignees(
             new JdkRequest(container.home()),
             this.repo()
@@ -90,7 +98,7 @@ public final class RtAssigneesTest {
                     .add(RtAssigneesTest.json("dummy"))
                     .build().toString()
             )
-        ).start();
+        ).start(resource.port());
         final Assignees users = new RtAssignees(
             new JdkRequest(container.home()),
             this.repo()
@@ -116,7 +124,7 @@ public final class RtAssigneesTest {
                     .add(RtAssigneesTest.json("dummy"))
                     .build().toString()
             )
-        ).start();
+        ).start(resource.port());
         final Assignees users = new RtAssignees(
             new JdkRequest(container.home()),
             this.repo()

--- a/src/test/java/com/jcabi/github/RtBranchesTest.java
+++ b/src/test/java/com/jcabi/github/RtBranchesTest.java
@@ -42,6 +42,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -51,6 +52,14 @@ import org.junit.Test;
  * @version $Id$
  */
 public final class RtBranchesTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
     /**
      * RtBranches can iterate over all branches.
      * @throws Exception if there is any error
@@ -71,7 +80,7 @@ public final class RtBranchesTest {
         final MkContainer container = new MkGrizzlyContainer()
             .next(answer)
             .next(answer)
-            .start();
+            .start(this.resource.port());
         final RtBranches branches = new RtBranches(
             new JdkRequest(container.home()),
             new MkGithub().randomRepo()

--- a/src/test/java/com/jcabi/github/RtCollaboratorsTest.java
+++ b/src/test/java/com/jcabi/github/RtCollaboratorsTest.java
@@ -43,6 +43,7 @@ import javax.json.Json;
 import javax.json.JsonValue;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -52,9 +53,18 @@ import org.mockito.Mockito;
  * @version $Id$
  * @since 0.8
  * @checkstyle MultipleStringLiteralsCheck (200 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (200 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RtCollaboratorsTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
     /**
      * RtCollaborators can iterate over a list of collaborators.
      * @throws Exception if any error occurs.
@@ -69,7 +79,7 @@ public final class RtCollaboratorsTest {
                     .add(RtCollaboratorsTest.json("dummy"))
                     .build().toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final Collaborators users = new RtCollaborators(
             new JdkRequest(container.home()),
             this.repo()
@@ -95,7 +105,7 @@ public final class RtCollaboratorsTest {
                     .add(RtCollaboratorsTest.json("dummy"))
                     .build().toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final Collaborators users = new RtCollaborators(
             new JdkRequest(container.home()),
             this.repo()
@@ -126,7 +136,7 @@ public final class RtCollaboratorsTest {
                     .add(RtCollaboratorsTest.json("dummy"))
                     .build().toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final Collaborators users = new RtCollaborators(
             new JdkRequest(container.home()),
             this.repo()
@@ -155,7 +165,7 @@ public final class RtCollaboratorsTest {
                     .add(RtCollaboratorsTest.json("dummy"))
                     .build().toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final Collaborators users = new RtCollaborators(
             new JdkRequest(container.home()),
             this.repo()

--- a/src/test/java/com/jcabi/github/RtCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtCommentTest.java
@@ -42,6 +42,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -52,6 +53,13 @@ import org.junit.Test;
  * @checkstyle MultipleStringLiterals (500 lines)
  */
 public final class RtCommentTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
 
     /**
      * RtComment should be able to compare different instances.
@@ -104,7 +112,7 @@ public final class RtCommentTest {
     public void removesComment() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
-        ).start();
+        ).start(this.resource.port());
         final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("testing3", "issue3");
         final RtComment comment = new RtComment(
@@ -131,7 +139,7 @@ public final class RtCommentTest {
         final String body = "{\"body\":\"test5\"}";
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body)
-        ).start();
+        ).start(this.resource.port());
         final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("testing4", "issue4");
         final RtComment comment = new RtComment(
@@ -156,7 +164,7 @@ public final class RtCommentTest {
     public void patchesComment() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
-        ).start();
+        ).start(this.resource.port());
         final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("testing5", "issue5");
         final RtComment comment = new RtComment(
@@ -183,7 +191,7 @@ public final class RtCommentTest {
     public void givesToString() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
-        ).start();
+        ).start(this.resource.port());
         final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("testing6", "issue6");
         final RtComment comment = new RtComment(

--- a/src/test/java/com/jcabi/github/RtCommitTest.java
+++ b/src/test/java/com/jcabi/github/RtCommitTest.java
@@ -37,6 +37,7 @@ import com.jcabi.http.request.JdkRequest;
 import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -50,6 +51,13 @@ import org.junit.Test;
 public class RtCommitTest {
 
     /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
+    /**
      * Commit.Smart can read message.
      * @throws Exception when an error occurs
      */
@@ -60,7 +68,7 @@ public class RtCommitTest {
                 HttpURLConnection.HTTP_OK,
                 "{\"sha\":\"a0b1c3\",\"commit\":{\"message\":\"hello\"}}"
             )
-        ).start();
+        ).start(this.resource.port());
         try {
             final Commit.Smart commit = new Commit.Smart(
                 new RtCommit(

--- a/src/test/java/com/jcabi/github/RtCommitsTest.java
+++ b/src/test/java/com/jcabi/github/RtCommitsTest.java
@@ -40,6 +40,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -50,6 +51,13 @@ import org.junit.Test;
  * @checkstyle MultipleStringLiterals (500 lines)
  */
 public class RtCommitsTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
 
     /**
      * Tests creating a Commit.
@@ -63,7 +71,7 @@ public class RtCommitsTest {
                 HttpURLConnection.HTTP_CREATED,
                 "{\"sha\":\"0abcd89jcabitest\"}"
             )
-        ).start();
+        ).start(this.resource.port());
         final Commits commits = new RtCommits(
             new ApacheRequest(container.home()),
             new MkGithub().randomRepo()

--- a/src/test/java/com/jcabi/github/RtContentTest.java
+++ b/src/test/java/com/jcabi/github/RtContentTest.java
@@ -45,6 +45,7 @@ import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -56,6 +57,13 @@ import org.mockito.Mockito;
  */
 @Immutable
 public final class RtContentTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
 
     /**
      * RtContent should be able to describe itself in JSON format.
@@ -84,7 +92,7 @@ public final class RtContentTest {
     public void patchWithJson() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "response")
-        ).start();
+        ).start(this.resource.port());
         final RtContent content = new RtContent(
             new ApacheRequest(container.home()),
             this.repo(),
@@ -146,7 +154,7 @@ public final class RtContentTest {
         final String raw = "the raw \u20ac";
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, raw)
-        ).start();
+        ).start(this.resource.port());
         final InputStream stream = new RtContent(
             new ApacheRequest(container.home()),
             this.repo(),

--- a/src/test/java/com/jcabi/github/RtContentsTest.java
+++ b/src/test/java/com/jcabi/github/RtContentsTest.java
@@ -42,6 +42,7 @@ import javax.json.JsonArray;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -51,10 +52,18 @@ import org.mockito.Mockito;
  * @version $Id$
  * @since 0.8
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @Immutable
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RtContentsTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
 
     /**
      * RtContents can fetch the default branch readme file.
@@ -69,7 +78,7 @@ public final class RtContentsTest {
             .build();
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body.toString())
-        ).start();
+        ).start(this.resource.port());
         final RtContents contents = new RtContents(
             new ApacheRequest(container.home()),
             repo()
@@ -106,7 +115,7 @@ public final class RtContentsTest {
             .build();
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body.toString())
-        ).start();
+        ).start(this.resource.port());
         final RtContents contents = new RtContents(
             new ApacheRequest(container.home()),
             repo()
@@ -153,7 +162,7 @@ public final class RtContentsTest {
                     .build().toString()
             )
         ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body.toString()))
-            .start();
+            .start(this.resource.port());
         final RtContents contents = new RtContents(
             new ApacheRequest(container.home()),
             repo()
@@ -211,7 +220,7 @@ public final class RtContentsTest {
                     .build().toString()
             )
         ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body.toString()))
-            .start();
+            .start(this.resource.port());
         final RtContents contents = new RtContents(
             new ApacheRequest(container.home()),
             repo()
@@ -264,7 +273,7 @@ public final class RtContentsTest {
                         .build()
                 ).build().toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final RtContents contents = new RtContents(
             new ApacheRequest(container.home()),
             repo()
@@ -315,7 +324,7 @@ public final class RtContentsTest {
                     .build().toString()
             )
         ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, resp.toString()))
-            .start();
+            .start(this.resource.port());
         try {
             final RtContents contents = new RtContents(
                 new ApacheRequest(container.home()),
@@ -368,7 +377,7 @@ public final class RtContentsTest {
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body.toString())
         ).next(new MkAnswer.Simple("{\"path\":\"README.md\"}"))
             .next(new MkAnswer.Simple("{\"path\":\".gitignore\"}"))
-            .start();
+            .start(this.resource.port());
         final RtContents contents = new RtContents(
             new ApacheRequest(container.home()),
             repo()

--- a/src/test/java/com/jcabi/github/RtDeployKeyTest.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeyTest.java
@@ -38,6 +38,7 @@ import com.jcabi.http.request.ApacheRequest;
 import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -48,6 +49,14 @@ import org.mockito.Mockito;
  * @version $Id$
  */
 public final class RtDeployKeyTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
     /**
      * RtDeployKey can delete a deploy key.
      *
@@ -60,7 +69,7 @@ public final class RtDeployKeyTest {
                 HttpURLConnection.HTTP_NO_CONTENT,
                 ""
             )
-        ).start();
+        ).start(this.resource.port());
         final DeployKey key = new RtDeployKey(
             new ApacheRequest(container.home()),
             3,

--- a/src/test/java/com/jcabi/github/RtDeployKeysTest.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeysTest.java
@@ -41,6 +41,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -52,6 +53,13 @@ import org.mockito.Mockito;
  */
 @Immutable
 public final class RtDeployKeysTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
 
     /**
      * RtDeployKeys can fetch empty list of deploy keys.
@@ -84,7 +92,7 @@ public final class RtDeployKeysTest {
                     .build().toString()
             )
         );
-        container.start();
+        container.start(this.resource.port());
         try {
             MatcherAssert.assertThat(
                 new RtDeployKeys(
@@ -130,7 +138,7 @@ public final class RtDeployKeysTest {
                 String.format("{\"id\":%d}", number)
             )
         );
-        container.start();
+        container.start(this.resource.port());
         try {
             final DeployKeys keys = new RtDeployKeys(
                 new ApacheRequest(container.home()), RtDeployKeysTest.repo()

--- a/src/test/java/com/jcabi/github/RtForkTest.java
+++ b/src/test/java/com/jcabi/github/RtForkTest.java
@@ -53,9 +53,6 @@ import org.junit.Test;
 public final class RtForkTest {
     /**
      * The rule for skipping test if there's BindException.
-     * @todo #989 Apply this rule to other classes that use MkGrizzlyContainer
-     *  and make MkGrizzlyContainers use port() given by this resource to avoid
-     *  tests fail with BindException.
      * @checkstyle VisibilityModifierCheck (3 lines)
      */
     @Rule

--- a/src/test/java/com/jcabi/github/RtForksTest.java
+++ b/src/test/java/com/jcabi/github/RtForksTest.java
@@ -41,6 +41,7 @@ import javax.json.JsonObject;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -56,6 +57,13 @@ public final class RtForksTest {
      * Fork's organization name in JSON object.
      */
     public static final String ORGANIZATION = "organization";
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
 
     /**
      * RtForks should be able to iterate its forks.
@@ -91,7 +99,7 @@ public final class RtForksTest {
                 HttpURLConnection.HTTP_ACCEPTED,
                 fork(organization).toString()
             )
-        ).next(answer).start();
+        ).next(answer).start(this.resource.port());
         final Repo owner = Mockito.mock(Repo.class);
         final Coordinates coordinates = new Coordinates.Simple(
             "test_user", "test_repo"

--- a/src/test/java/com/jcabi/github/RtGistCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentTest.java
@@ -41,14 +41,26 @@ import java.net.HttpURLConnection;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * Test case for {@link RtGistComment}.
  * @author Giang Le (giang@vn-smartsolutions.com)
  * @version $Id$
+ * @checkstyle ClassDataAbstractionCouplingCheck (150 lines)
  */
 public class RtGistCommentTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @todo Apply this rule to all other classes that use MkGrizzlyContainer
+     * and make MkGrizzlyContainers use port() given by this resource to avoid
+     * tests fail with BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
 
     /**
      * RtGistComment can patch comment and return new json.
@@ -84,8 +96,9 @@ public class RtGistCommentTest {
         );
         final MkContainer container =
             new MkGrizzlyContainer().next(first).next(second).next(third)
-                .start();
-        final MkContainer gistContainer = new MkGrizzlyContainer().start();
+                .start(this.resource.port());
+        final MkContainer gistContainer = new MkGrizzlyContainer()
+            .start(this.resource.port());
         final RtGist gist =
             new RtGist(
                 new MkGithub(),
@@ -116,7 +129,7 @@ public class RtGistCommentTest {
         final int identifier = 1;
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
-        ).start();
+        ).start(this.resource.port());
         final RtGist gist = new RtGist(
             new MkGithub(),
             new FakeRequest().withStatus(HttpURLConnection.HTTP_NO_CONTENT),

--- a/src/test/java/com/jcabi/github/RtGistCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentTest.java
@@ -54,7 +54,7 @@ public class RtGistCommentTest {
 
     /**
      * The rule for skipping test if there's BindException.
-     * @todo #1017:30min this rule to all other classes that use
+     * @todo #1017:30min Apply this rule to all other classes that use
      *  MkGrizzlyContainer and make MkGrizzlyContainers use port() given by this
      *  resource to avoid tests fail with BindException.
      * @checkstyle VisibilityModifierCheck (3 lines)

--- a/src/test/java/com/jcabi/github/RtGistCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentTest.java
@@ -54,9 +54,9 @@ public class RtGistCommentTest {
 
     /**
      * The rule for skipping test if there's BindException.
-     * @todo Apply this rule to all other classes that use MkGrizzlyContainer
-     * and make MkGrizzlyContainers use port() given by this resource to avoid
-     * tests fail with BindException.
+     * @todo #1017:30min this rule to all other classes that use
+     * MkGrizzlyContainer and make MkGrizzlyContainers use port() given by this
+     * resource to avoid tests fail with BindException.
      * @checkstyle VisibilityModifierCheck (3 lines)
      */
     @Rule

--- a/src/test/java/com/jcabi/github/RtGistCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentTest.java
@@ -55,8 +55,8 @@ public class RtGistCommentTest {
     /**
      * The rule for skipping test if there's BindException.
      * @todo #1017:30min this rule to all other classes that use
-     * MkGrizzlyContainer and make MkGrizzlyContainers use port() given by this
-     * resource to avoid tests fail with BindException.
+     *  MkGrizzlyContainer and make MkGrizzlyContainers use port() given by this
+     *  resource to avoid tests fail with BindException.
      * @checkstyle VisibilityModifierCheck (3 lines)
      */
     @Rule

--- a/src/test/java/com/jcabi/github/RtGistCommentsTest.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentsTest.java
@@ -39,6 +39,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -49,6 +50,14 @@ import org.mockito.Mockito;
  * @version $Id$
  */
 public final class RtGistCommentsTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
     /**
      * RtGistComments can get a single comment.
      * @throws Exception if some problem inside
@@ -61,7 +70,7 @@ public final class RtGistCommentsTest {
                 HttpURLConnection.HTTP_OK,
                 comment(body).toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final Gist gist = Mockito.mock(Gist.class);
         Mockito.doReturn("1").when(gist).identifier();
         final RtGistComments comments = new RtGistComments(
@@ -90,7 +99,7 @@ public final class RtGistCommentsTest {
                     .add(comment("comment 2"))
                     .build().toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final Gist gist = Mockito.mock(Gist.class);
         Mockito.doReturn("2").when(gist).identifier();
         final RtGistComments comments = new RtGistComments(
@@ -120,7 +129,7 @@ public final class RtGistCommentsTest {
                 HttpURLConnection.HTTP_CREATED,
                 comment(body).toString()
             )
-        ).next(answer).start();
+        ).next(answer).start(this.resource.port());
         final Gist gist = Mockito.mock(Gist.class);
         Mockito.doReturn("3").when(gist).identifier();
         final RtGistComments comments = new RtGistComments(

--- a/src/test/java/com/jcabi/github/RtGistsTest.java
+++ b/src/test/java/com/jcabi/github/RtGistsTest.java
@@ -40,6 +40,7 @@ import java.net.HttpURLConnection;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -49,6 +50,13 @@ import org.junit.Test;
  * @version $Id$
  */
 public final class RtGistsTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
 
     /**
      * RtGists can create new files.
@@ -62,7 +70,7 @@ public final class RtGistsTest {
                 HttpURLConnection.HTTP_CREATED,
                 "{\"id\":\"1\"}"
             )
-        ).start();
+        ).start(this.resource.port());
         final Gists gists = new RtGists(
             new MkGithub(),
             new ApacheRequest(container.home())
@@ -90,7 +98,7 @@ public final class RtGistsTest {
     public void canRetrieveSpecificGist() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "testing")
-        ).start();
+        ).start(this.resource.port());
         final Gists gists = new RtGists(
             new MkGithub(),
             new ApacheRequest(container.home())
@@ -117,7 +125,7 @@ public final class RtGistsTest {
                 HttpURLConnection.HTTP_OK,
                 "[{\"id\":\"hello\"}]"
             )
-        ).start();
+        ).start(this.resource.port());
         final Gists gists = new RtGists(
             new MkGithub(),
             new ApacheRequest(container.home())
@@ -143,7 +151,7 @@ public final class RtGistsTest {
                 ""
             )
         )
-            .start();
+            .start(this.resource.port());
         final Gists gists = new RtGists(
             new MkGithub(),
             new ApacheRequest(container.home())


### PR DESCRIPTION
Changed one of the classes that use MkGrizzlyContainer
I see 50+ classes that use MkGrizzlyContainer, please confirm that they should be changed in the same way as RtAssigneesTest.
Maybe it's wise to create base class for all this tests?
https://github.com/jcabi/jcabi-github/issues/1017