### PR TITLE
Issues #903 and #1218. Returning `null` on attempts to read directory content

### DIFF
--- a/src/main/java/com/jcabi/github/RtContents.java
+++ b/src/main/java/com/jcabi/github/RtContents.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import javax.json.Json;
 import javax.json.JsonObject;
-import javax.json.JsonReader;
 import javax.json.JsonStructure;
 import lombok.EqualsAndHashCode;
 

--- a/src/main/java/com/jcabi/github/RtContents.java
+++ b/src/main/java/com/jcabi/github/RtContents.java
@@ -40,7 +40,6 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonStructure;
 import javax.json.JsonValue;
-
 import lombok.EqualsAndHashCode;
 
 /**

--- a/src/main/java/com/jcabi/github/RtContents.java
+++ b/src/main/java/com/jcabi/github/RtContents.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.JsonReader;
 import javax.json.JsonStructure;
 import lombok.EqualsAndHashCode;
 
@@ -256,16 +257,21 @@ final class RtContents implements Contents {
         final String path, final String ref
     ) throws IOException {
         final String name = "ref";
-        return new RtContent(
-            this.entry.uri().queryParam(name, ref).back(), this.owner,
-            this.request.method(Request.GET)
+        RtContent content = null;
+        JsonStructure structure = this.request.method(Request.GET)
                 .uri().path(path).queryParam(name, ref).back()
                 .fetch()
                 .as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .as(JsonResponse.class)
-                .json().readObject().getString("path")
-        );
+                .json().read();
+        if (structure instanceof JsonObject) {
+            content = new RtContent(
+                    this.entry.uri().queryParam(name, ref).back(), this.owner,
+                    ((JsonObject)structure).getString("path")
+            );
+        }
+        return content;
     }
 
 }

--- a/src/main/java/com/jcabi/github/RtContents.java
+++ b/src/main/java/com/jcabi/github/RtContents.java
@@ -253,7 +253,7 @@ final class RtContents implements Contents {
      * @see <a href="http://developer.github.com/v3/repos/contents/#get-contents">Get contents</a>
      */
     private Content content(
-            final String path, final String ref
+        final String path, final String ref
     ) throws IOException {
         final String name = "ref";
         RtContent content = null;

--- a/src/main/java/com/jcabi/github/RtContents.java
+++ b/src/main/java/com/jcabi/github/RtContents.java
@@ -39,6 +39,8 @@ import java.net.HttpURLConnection;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonStructure;
+import javax.json.JsonValue;
+
 import lombok.EqualsAndHashCode;
 
 /**
@@ -264,7 +266,7 @@ final class RtContents implements Contents {
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .as(JsonResponse.class)
                 .json().read();
-        if (structure instanceof JsonObject) {
+        if (JsonValue.ValueType.OBJECT.equals(structure.getValueType())) {
             content = new RtContent(
                     this.entry.uri().queryParam(name, ref).back(), this.owner,
                     ((JsonObject) structure).getString("path")

--- a/src/main/java/com/jcabi/github/RtContents.java
+++ b/src/main/java/com/jcabi/github/RtContents.java
@@ -254,21 +254,21 @@ final class RtContents implements Contents {
      * @see <a href="http://developer.github.com/v3/repos/contents/#get-contents">Get contents</a>
      */
     private Content content(
-        final String path, final String ref
+            final String path, final String ref
     ) throws IOException {
         final String name = "ref";
         RtContent content = null;
-        final JsonReader reader = this.request.method(Request.GET)
+        final JsonStructure structure = this.request.method(Request.GET)
                 .uri().path(path).queryParam(name, ref).back()
                 .fetch()
                 .as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .as(JsonResponse.class)
-                .json();
-        if (reader.read() instanceof JsonObject) {
+                .json().read();
+        if (structure instanceof JsonObject) {
             content = new RtContent(
                     this.entry.uri().queryParam(name, ref).back(), this.owner,
-                    reader.readObject().getString("path")
+                    ((JsonObject) structure).getString("path")
             );
         }
         return content;

--- a/src/main/java/com/jcabi/github/RtContents.java
+++ b/src/main/java/com/jcabi/github/RtContents.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.JsonReader;
 import javax.json.JsonStructure;
 import lombok.EqualsAndHashCode;
 
@@ -257,17 +258,17 @@ final class RtContents implements Contents {
     ) throws IOException {
         final String name = "ref";
         RtContent content = null;
-        JsonStructure structure = this.request.method(Request.GET)
+        final JsonReader reader = this.request.method(Request.GET)
                 .uri().path(path).queryParam(name, ref).back()
                 .fetch()
                 .as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .as(JsonResponse.class)
-                .json().read();
-        if (structure instanceof JsonObject) {
+                .json();
+        if (reader.read() instanceof JsonObject) {
             content = new RtContent(
                     this.entry.uri().queryParam(name, ref).back(), this.owner,
-                    ((JsonObject)structure).getString("path")
+                    reader.readObject().getString("path")
             );
         }
         return content;


### PR DESCRIPTION
@HDouss This PR addresses issues #903 and newly created #1218.
`JsonReader` class has `read()` method, which works for both Json Object (file) and Json Array (directory) contents. I'm making use of this method and letter testing the exact type of returned structure