### PR TITLE
Fix ClassCastException in RtGithub#users #1187

### DIFF
--- a/src/main/java/com/jcabi/github/RtUsers.java
+++ b/src/main/java/com/jcabi/github/RtUsers.java
@@ -105,7 +105,9 @@ final class RtUsers implements Users {
             new RtValuePagination.Mapping<User, JsonObject>() {
                 @Override
                 public User map(final JsonObject object) {
-                    return RtUsers.this.get(object.getString("id"));
+                    return RtUsers.this.get(
+                            String.valueOf(object.getInt("id"))
+                    );
                 }
             }
         );

--- a/src/test/java/com/jcabi/github/RtGithubITCase.java
+++ b/src/test/java/com/jcabi/github/RtGithubITCase.java
@@ -118,6 +118,20 @@ public final class RtGithubITCase {
     }
 
     /**
+     * RtGithub can fetch users.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void fetchesUsers() throws Exception {
+        final Github github = new RtGithub();
+        MatcherAssert.assertThat(
+                "Iterating over github.users() should return something",
+                github.users().iterate("").iterator().next(),
+                Matchers.anything()
+        );
+    }
+
+    /**
      * Create and return repo to test.
      * @return Repo
      * @throws Exception If some problem inside

--- a/src/test/java/com/jcabi/github/RtUsersTest.java
+++ b/src/test/java/com/jcabi/github/RtUsersTest.java
@@ -136,7 +136,7 @@ public final class RtUsersTest {
         final String login, final String identifier
     ) throws Exception {
         return Json.createObjectBuilder()
-            .add("id", identifier)
+            .add("id", Integer.valueOf(identifier))
             .add("login", login)
             .build();
     }


### PR DESCRIPTION
This is for #1187.

Changed the code in `RtUser` to treat the id as an integer (https://developer.github.com/v3/users/ shows the id is an integer), and cast to string afterwards. A test case, which fails if it is run on the master branch, is added in `RtGithubITCase`. `RtUsersTest` is changed so that the json object's id is now a number