### PR TITLE
User-agent data read from properties file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,9 @@
             <url>http://github.jcabi.com/</url>
         </site>
     </distributionManagement>
+    <properties>
+        <build.timestamp>${maven.build.timestamp}</build.timestamp>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>com.jcabi</groupId>
@@ -85,10 +88,6 @@
             <groupId>com.jcabi.incubator</groupId>
             <artifactId>xembly</artifactId>
             <version>0.22</version>
-        </dependency>
-        <dependency>
-            <groupId>com.jcabi</groupId>
-            <artifactId>jcabi-manifests</artifactId>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>

--- a/src/main/java/com/jcabi/github/FromProperties.java
+++ b/src/main/java/com/jcabi/github/FromProperties.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * User agent data read from properties file. It is safe to use since it will
+ * provide hardcoded values if any IOException occurs while reading the
+ * properties or when the code is run by tests.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.29
+ */
+final class FromProperties implements UserAgent {
+
+    /**
+     * Build timestamp.
+     */
+    private static final String JCABI_DATE = "JCabi-Date";
+
+    /**
+     * Project version.
+     */
+    private static final String JCABI_VERSION = "JCabi-Version";
+
+    /**
+     * Build number.
+     */
+    private static final String JCABI_BUILD = "JCabi-Build";
+
+    /**
+     * Properties.
+     */
+    private final transient Properties props = new Properties();
+
+    /**
+     * Name of the properties file to load.
+     */
+    private final transient String name;
+
+    /**
+     * Ctor.
+     * @param filename Name of the properties file to look for
+     */
+    public FromProperties(final String filename) {
+        this.name = filename;
+    }
+
+    @Override
+    public String format() {
+        boolean ioexception = false;
+        try {
+            this.props.load(
+                ClassLoader.getSystemResourceAsStream(this.name)
+            );
+        } catch (final IOException ex) {
+            ioexception = true;
+        }
+        if (ioexception || "${buildNumber}".equals(
+                this.props.getProperty(FromProperties.JCABI_BUILD)
+            )
+        ) {
+            this.props.setProperty(
+                FromProperties.JCABI_VERSION, "1.0-SNAPSHOT"
+            );
+            this.props.setProperty(
+                FromProperties.JCABI_BUILD, "d1c6740"
+            );
+            this.props.setProperty(
+                FromProperties.JCABI_DATE, "2016-12-16 08:30"
+            );
+        }
+        return String.format(
+            "jcabi-github %s %s %s",
+            this.props.getProperty(FromProperties.JCABI_VERSION),
+            this.props.getProperty(FromProperties.JCABI_BUILD),
+            this.props.getProperty(FromProperties.JCABI_DATE)
+        );
+    }
+}

--- a/src/main/java/com/jcabi/github/FromProperties.java
+++ b/src/main/java/com/jcabi/github/FromProperties.java
@@ -80,7 +80,7 @@ final class FromProperties implements UserAgent {
         boolean ioexception = false;
         try {
             this.props.load(
-                ClassLoader.getSystemResourceAsStream(this.name)
+                this.getClass().getClassLoader().getResourceAsStream(this.name)
             );
         } catch (final IOException ex) {
             ioexception = true;

--- a/src/main/java/com/jcabi/github/FromProperties.java
+++ b/src/main/java/com/jcabi/github/FromProperties.java
@@ -80,7 +80,8 @@ final class FromProperties implements UserAgent {
         boolean ioexception = false;
         try {
             this.props.load(
-                this.getClass().getClassLoader().getResourceAsStream(this.name)
+                Thread.currentThread().getContextClassLoader()
+                    .getResourceAsStream(this.name)
             );
         } catch (final IOException ex) {
             ioexception = true;

--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -34,7 +34,6 @@ import com.jcabi.aspects.Loggable;
 import com.jcabi.http.Request;
 import com.jcabi.http.request.ApacheRequest;
 import com.jcabi.http.response.JsonResponse;
-import com.jcabi.manifests.Manifests;
 import java.io.IOException;
 import javax.json.JsonObject;
 import javax.ws.rs.core.HttpHeaders;
@@ -77,21 +76,14 @@ import org.apache.commons.io.Charsets;
 public final class RtGithub implements Github {
 
     /**
-     * Version of us.
-     */
-    private static final String USER_AGENT = String.format(
-        "jcabi-github %s %s %s",
-        Manifests.read("JCabi-Version"),
-        Manifests.read("JCabi-Build"),
-        Manifests.read("JCabi-Date")
-    );
-
-    /**
      * Default request to start with.
      */
     private static final Request REQUEST =
         new ApacheRequest("https://api.github.com")
-            .header(HttpHeaders.USER_AGENT, RtGithub.USER_AGENT)
+            .header(
+                HttpHeaders.USER_AGENT,
+                new FromProperties("jcabigithub.properties").format()
+            )
             .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
 

--- a/src/main/java/com/jcabi/github/UserAgent.java
+++ b/src/main/java/com/jcabi/github/UserAgent.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2013-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+/**
+ * User agent data.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.29
+ *
+ */
+interface UserAgent {
+
+    /**
+     * Format user-agent http header value.
+     * @return String
+     */
+    String format();
+}

--- a/src/main/resources/jcabigithub.properties
+++ b/src/main/resources/jcabigithub.properties
@@ -1,0 +1,4 @@
+#User-Agent info
+JCabi-Version ${project.version}
+JCabi-Build ${buildNumber}
+JCabi-Date ${build.timestamp}


### PR DESCRIPTION
PR for #1246 
* At runtime, read user-agent data from a properties file which is rendered at build time (check the issue to see why the manifest.mf option was not good).
* Added an ``if()`` to hardcode values for when the file is read during tests' run (because then the properties' values are not rendered)