### PR TITLE
Fixed mocking of Organizations

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkUserOrganizations.java
+++ b/src/main/java/com/jcabi/github/mock/MkUserOrganizations.java
@@ -104,7 +104,7 @@ final class MkUserOrganizations implements UserOrganizations {
     public Iterable<Organization> iterate() throws IOException {
         return new MkIterable<Organization>(
             this.storage,
-            "/github/orgs/org/login",
+            "/github/orgs/org",
             new OrganizationMapping(new MkOrganizations(this.storage))
         );
     }

--- a/src/test/java/com/jcabi/github/mock/MkUserOrganizationsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkUserOrganizationsTest.java
@@ -30,6 +30,7 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Github;
+import com.jcabi.github.Organization;
 import com.jcabi.github.UserOrganizations;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -58,7 +59,7 @@ public final class MkUserOrganizationsTest {
         github.organizations().get(login);
         MatcherAssert.assertThat(
             userOrgs.iterate(),
-            Matchers.not(Matchers.emptyIterable())
+            Matchers.<Organization>iterableWithSize(1)
         );
     }
 }


### PR DESCRIPTION
It appeared we don't need extra login in `MkUserOrganizations` since we use `login/text()` query in `OrganizationMapping`.