### PR TITLE
Bug #1366: fixed encoding/decoding of mock release assets

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkReleaseAsset.java
+++ b/src/main/java/com/jcabi/github/mock/MkReleaseAsset.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github.mock;
 
+import com.google.common.base.Charsets;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Coordinates;
@@ -153,11 +154,9 @@ final class MkReleaseAsset implements ReleaseAsset {
     @Override
     public InputStream raw() throws IOException {
         return new ByteArrayInputStream(
-            DatatypeConverter.parseBase64Binary(
-                this.storage.xml().xpath(
-                    String.format("%s/content/text()", this.xpath())
-                ).get(0)
-            )
+            this.storage.xml().xpath(
+                String.format("%s/content/text()", this.xpath())
+            ).get(0).getBytes(Charsets.UTF_8)
         );
     }
 

--- a/src/main/java/com/jcabi/github/mock/MkReleaseAsset.java
+++ b/src/main/java/com/jcabi/github/mock/MkReleaseAsset.java
@@ -39,7 +39,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import javax.json.JsonObject;
-import javax.xml.bind.DatatypeConverter;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.xembly.Directives;

--- a/src/main/java/com/jcabi/github/mock/MkReleaseAssets.java
+++ b/src/main/java/com/jcabi/github/mock/MkReleaseAssets.java
@@ -38,6 +38,7 @@ import com.jcabi.github.ReleaseAsset;
 import com.jcabi.github.ReleaseAssets;
 import com.jcabi.xml.XML;
 import java.io.IOException;
+import javax.xml.bind.DatatypeConverter;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.xembly.Directives;
@@ -146,7 +147,7 @@ final class MkReleaseAssets implements ReleaseAssets {
                 new Directives().xpath(this.xpath()).add("asset")
                     .add("id").set(Integer.toString(number)).up()
                     .add("name").set(name).up()
-                    .add("content").set(new String(content, "UTF-8")).up()
+                    .add("content").set(DatatypeConverter.printBase64Binary(content)).up()
                     .add("content_type").set(type).up()
                     .add("size").set(Integer.toString(content.length)).up()
                     .add("download_count").set("42").up()

--- a/src/main/java/com/jcabi/github/mock/MkReleaseAssets.java
+++ b/src/main/java/com/jcabi/github/mock/MkReleaseAssets.java
@@ -147,7 +147,9 @@ final class MkReleaseAssets implements ReleaseAssets {
                 new Directives().xpath(this.xpath()).add("asset")
                     .add("id").set(Integer.toString(number)).up()
                     .add("name").set(name).up()
-                    .add("content").set(DatatypeConverter.printBase64Binary(content)).up()
+                    .add("content").set(
+                        DatatypeConverter.printBase64Binary(content)
+                    ).up()
                     .add("content_type").set(type).up()
                     .add("size").set(Integer.toString(content.length)).up()
                     .add("download_count").set("42").up()

--- a/src/test/java/com/jcabi/github/mock/MkReleaseAssetTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseAssetTest.java
@@ -181,27 +181,24 @@ public final class MkReleaseAssetTest {
     }
 
     /**
-     * MkReleaseAsset should be able to fetch its raw representation.
-     *
-     * @throws Exception if some problem inside
+     * Should return the Base64-encoded value of the input contents. When
+     * decoded, should be equal to the input.
+     * 
+     * @throws Exception Unexpected.
      */
     @Test
-    public void fetchesRawRepresentation() throws Exception {
-        final String fetch = "fetch";
-        final ReleaseAssets assets = release().assets();
-        final ReleaseAsset asset = assets.upload(
-            fetch.getBytes(), "text/plain", "raw.txt"
-        );
-        final InputStream raw = new ByteArrayInputStream(
-            DatatypeConverter.parseBase64Binary(
-                fetch
-            )
-        );
+    public void canDecodeContentsIntoOriginalValue() throws Exception {
+        final String test = "This is a test asset.";
+        final ReleaseAsset asset = new MkGithub().randomRepo().releases()
+            .create("v1.0")
+            .assets()
+            .upload(test.getBytes(), "type", "name");
         MatcherAssert.assertThat(
-            IOUtils.toString(asset.raw(), StandardCharsets.UTF_8),
-            Matchers.is(IOUtils.toString(raw, StandardCharsets.UTF_8))
+            new String(
+              DatatypeConverter.parseBase64Binary(IOUtils.toString(asset.raw()))
+            ),
+            Matchers.is(test)
         );
-        asset.remove();
     }
 
     /**

--- a/src/test/java/com/jcabi/github/mock/MkReleaseAssetTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseAssetTest.java
@@ -32,9 +32,6 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Release;
 import com.jcabi.github.ReleaseAsset;
 import com.jcabi.github.ReleaseAssets;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import javax.json.Json;
 import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.io.IOUtils;
@@ -183,7 +180,7 @@ public final class MkReleaseAssetTest {
     /**
      * Should return the Base64-encoded value of the input contents. When
      * decoded, should be equal to the input.
-     * 
+     *
      * @throws Exception Unexpected.
      */
     @Test

--- a/src/test/java/com/jcabi/github/mock/MkReleaseAssetTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseAssetTest.java
@@ -181,10 +181,10 @@ public final class MkReleaseAssetTest {
      * Should return the Base64-encoded value of the input contents. When
      * decoded, should be equal to the input.
      *
-     * @throws Exception Unexpected.
+     * @throws Exception if some problem inside
      */
     @Test
-    public void canDecodeContentsIntoOriginalValue() throws Exception {
+    public void fetchesRawRepresentation() throws Exception {
         final String test = "This is a test asset.";
         final ReleaseAsset asset = new MkGithub().randomRepo().releases()
             .create("v1.0")

--- a/src/test/java/com/jcabi/github/mock/MkReleaseAssetsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseAssetsTest.java
@@ -32,6 +32,8 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Release;
 import com.jcabi.github.ReleaseAsset;
 import com.jcabi.github.ReleaseAssets;
+import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -109,6 +111,24 @@ public final class MkReleaseAssetsTest {
             rel.assets().release(),
             Matchers.is(rel)
         );
+    }
+
+    /**
+     * Must encode the input bytes into Base64.
+     * 
+     * @throws Exception Unexpected.
+     */
+    @Test
+    public void encodesContentsAsBase64() throws Exception {
+        final String test = "This is a test asset.";
+        final ReleaseAsset asset = new MkGithub().randomRepo().releases()
+            .create("v1.0")
+            .assets()
+            .upload(test.getBytes(), "type", "name");
+        MatcherAssert.assertThat(
+            IOUtils.toString(asset.raw()),
+            Matchers.is(DatatypeConverter.printBase64Binary(test.getBytes()))
+        ); 
     }
 
     /**

--- a/src/test/java/com/jcabi/github/mock/MkReleaseAssetsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseAssetsTest.java
@@ -45,6 +45,7 @@ import org.junit.Test;
  * @version $Id$
  * @since 0.8
  * @checkstyle MultipleStringLiteralsCheck (200 lines)
+ * @checkstyle MethodNameCheck (200 lines)
  */
 public final class MkReleaseAssetsTest {
 
@@ -115,7 +116,7 @@ public final class MkReleaseAssetsTest {
 
     /**
      * Must encode the input bytes into Base64.
-     * 
+     *
      * @throws Exception Unexpected.
      */
     @Test
@@ -128,7 +129,7 @@ public final class MkReleaseAssetsTest {
         MatcherAssert.assertThat(
             IOUtils.toString(asset.raw()),
             Matchers.is(DatatypeConverter.printBase64Binary(test.getBytes()))
-        ); 
+        );
     }
 
     /**

--- a/src/test/java/com/jcabi/github/mock/MkReleaseAssetsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseAssetsTest.java
@@ -116,7 +116,6 @@ public final class MkReleaseAssetsTest {
 
     /**
      * Must encode the input bytes into Base64.
-     *
      * @throws Exception Unexpected.
      */
     @Test


### PR DESCRIPTION
This PR:
* Solves #1366 
* Makes `MkReleaseAssets` encode the contents into base64 and store it
* Makes `MkReleaseAsset` just read the encoded contents from storage and returns it
 * Deletes `MkReleaseAssetTest.fetchesRawRepresentation` because it was superceded by the new `canDecodeContentsIntoOriginalValue` test.
