### PR TITLE
(#1375) Implemented MkUser.markAsRead(Date)

### DIFF
--- a/src/main/java/com/jcabi/github/RtUser.java
+++ b/src/main/java/com/jcabi/github/RtUser.java
@@ -157,7 +157,7 @@ final class RtUser implements User {
     }
 
     @Override
-    public void markAsRead(final Date lastread) {
+    public void markAsRead(final Date lastread) throws IOException {
         // Will be implemented later
     }
 

--- a/src/main/java/com/jcabi/github/User.java
+++ b/src/main/java/com/jcabi/github/User.java
@@ -102,8 +102,10 @@ public interface User extends JsonReadable, JsonPatchable {
      * @param lastread Describes the last point that notifications were
      *  checked.
      * @see <a href="https://developer.github.com/v3/activity/notifications/#mark-as-read">Mark as read</a>
+     * @throws IOException Thrown, if an error during sending request and/or
+     *  receiving response occurs.
      */
-    void markAsRead(final Date lastread);
+    void markAsRead(final Date lastread) throws IOException;
 
     /**
      * Smart user with extra features.
@@ -263,7 +265,7 @@ public interface User extends JsonReadable, JsonPatchable {
         }
 
         @Override
-        public void markAsRead(final Date lastread) {
+        public void markAsRead(final Date lastread) throws IOException {
             this.user.markAsRead(lastread);
         }
 


### PR DESCRIPTION
This PR:

* solves #1375 
* Implements `MkUser.markAsRead(Date)`
* Declares `User.markAsRead(Date)` to throw an `IOException`

`MkUser.markAsRead` expects a sequence of nodes under `...user/notifications` like this:

```xml
<notification>
    <id>1</id>
    <date>123455667788</date>
    <read>false</read>
<notification>
```

where:
* `id`: the notification's id
* `date`: creationdate (format = unix epoch time)
* `read`: boolean
