### PR TITLE
(#1384) Now using 'Existence' for all runtime exists() implementations

### DIFF
--- a/src/main/java/com/jcabi/github/Existence.java
+++ b/src/main/java/com/jcabi/github/Existence.java
@@ -40,9 +40,6 @@ import lombok.EqualsAndHashCode;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.38
- * @todo #1382:30min Use this class to implement Smart.exists() method for all
- *  Github entities we have (Comment, Issue, User etc). Maybe we can make
- *  JsonReadable abstract and have method exists() there.
  */
 @Immutable
 @Loggable(Loggable.DEBUG)

--- a/src/main/java/com/jcabi/github/Issue.java
+++ b/src/main/java/com/jcabi/github/Issue.java
@@ -514,7 +514,7 @@ public interface Issue extends Comparable<Issue>, JsonReadable, JsonPatchable {
         }
         @Override
         public boolean exists() throws IOException {
-            return this.issue.exists();
+            return new Existence(this.issue).check();
         }
     }
 

--- a/src/main/java/com/jcabi/github/RtIssue.java
+++ b/src/main/java/com/jcabi/github/RtIssue.java
@@ -137,13 +137,7 @@ final class RtIssue implements Issue {
 
     @Override
     public boolean exists() throws IOException {
-        return this.request.fetch().as(RestResponse.class)
-            .assertStatus(
-                Matchers.isOneOf(
-                    HttpURLConnection.HTTP_OK,
-                    HttpURLConnection.HTTP_NOT_FOUND
-            )
-        ).status() == HttpURLConnection.HTTP_OK;
+        return new Existence(this).check();
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/User.java
+++ b/src/main/java/com/jcabi/github/User.java
@@ -141,13 +141,7 @@ public interface User extends JsonReadable, JsonPatchable {
          * @since 0.34
          */
         public boolean exists() throws IOException {
-            boolean exists = true;
-            try {
-                this.id();
-            } catch (final AssertionError ex) {
-                exists = false;
-            }
-            return exists;
+            return new Existence(this.user).check();
         }
 
         /**


### PR DESCRIPTION
This PR:
* Solves #1384 by substituting all `exists()` implementations with the new `Existence` class where possible

Note: @amihaiemil using `Existence` for the mocks doesn't look like a good idea (I didn't try it)