### PR TITLE
(#1388) Refactored more tests that use MkGrizzlyContainer to start with a randomized port number

### DIFF
--- a/src/test/java/com/jcabi/github/RtBlobsTest.java
+++ b/src/test/java/com/jcabi/github/RtBlobsTest.java
@@ -41,6 +41,7 @@ import javax.json.JsonObject;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -52,6 +53,13 @@ import org.mockito.Mockito;
  * @checkstyle MultipleStringLiteralsCheck (100 lines)
  */
 public final class RtBlobsTest {
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
 
     /**
      * RtBlobs can create a blob.
@@ -64,7 +72,8 @@ public final class RtBlobsTest {
         final String body = blob().toString();
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, body)
-        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body)).start();
+        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body))
+            .start(this.resource.port());
         final RtBlobs blobs = new RtBlobs(
             new ApacheRequest(container.home()),
             repo()

--- a/src/test/java/com/jcabi/github/RtGistCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentTest.java
@@ -54,7 +54,7 @@ public class RtGistCommentTest {
 
     /**
      * The rule for skipping test if there's BindException.
-     * @todo #1377:30min Apply this rule to all other classes that use
+     * @todo #1388:30min Apply this rule to all other classes that use
      *  MkGrizzlyContainer and make MkGrizzlyContainers use port() given by this
      *  resource to avoid tests fail with BindException.
      * @checkstyle VisibilityModifierCheck (3 lines)

--- a/src/test/java/com/jcabi/github/RtHooksTest.java
+++ b/src/test/java/com/jcabi/github/RtHooksTest.java
@@ -45,6 +45,7 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -59,6 +60,13 @@ import org.mockito.Mockito;
 public final class RtHooksTest {
 
     /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
+    /**
      * RtHooks can fetch empty list of hooks.
      * @throws Exception if some problem inside
      */
@@ -66,7 +74,7 @@ public final class RtHooksTest {
     public void canFetchEmptyListOfHooks() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "[]")
-        ).start();
+        ).start(this.resource.port());
         final Hooks hooks = new RtHooks(
             new JdkRequest(container.home()),
             RtHooksTest.repo()
@@ -95,7 +103,7 @@ public final class RtHooksTest {
                     .add(hook("hook 2", Collections.<String, String>emptyMap()))
                     .build().toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final RtHooks hooks = new RtHooks(
             new JdkRequest(container.home()),
             RtHooksTest.repo()
@@ -122,7 +130,7 @@ public final class RtHooksTest {
                     Collections.<String, String>emptyMap()
                 ).toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final Hooks hooks = new RtHooks(
             new JdkRequest(container.home()),
             RtHooksTest.repo()
@@ -150,7 +158,8 @@ public final class RtHooksTest {
         final String body = RtHooksTest.hook(name, config).toString();
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, body)
-        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body)).start();
+        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body))
+            .start(this.resource.port());
         final Hooks hooks = new RtHooks(
             new JdkRequest(container.home()),
             RtHooksTest.repo()
@@ -179,7 +188,7 @@ public final class RtHooksTest {
     public void canDeleteHook() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
-        ).start();
+        ).start(this.resource.port());
         final Hooks hooks = new RtHooks(
             new JdkRequest(container.home()),
             RtHooksTest.repo()

--- a/src/test/java/com/jcabi/github/RtLabelTest.java
+++ b/src/test/java/com/jcabi/github/RtLabelTest.java
@@ -38,6 +38,7 @@ import java.net.HttpURLConnection;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -48,6 +49,14 @@ import org.mockito.Mockito;
  * @version $Id$
  */
 public final class RtLabelTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
     /**
      * RtLabel can  can fetch HTTP request and describe response as a JSON.
      *
@@ -57,7 +66,7 @@ public final class RtLabelTest {
     public void sendHttpRequestAndWriteResponseAsJson() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "{\"msg\": \"hi\"}")
-        ).start();
+        ).start(this.resource.port());
         final RtLabel label = new RtLabel(
             new ApacheRequest(container.home()),
             RtLabelTest.repo(),
@@ -79,7 +88,7 @@ public final class RtLabelTest {
     public void executePatchRequest() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "{\"msg\":\"hi\"}")
-        ).start();
+        ).start(this.resource.port());
         final RtLabel label = new RtLabel(
             new ApacheRequest(container.home()),
             RtLabelTest.repo(),

--- a/src/test/java/com/jcabi/github/RtPullTest.java
+++ b/src/test/java/com/jcabi/github/RtPullTest.java
@@ -42,6 +42,7 @@ import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -62,6 +63,13 @@ public final class RtPullTest {
     private static final String SHA_PROP = "sha";
 
     /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
+    /**
      * RtPull should be able to retrieve commits.
      *
      * @throws Exception when a problem occurs.
@@ -73,7 +81,7 @@ public final class RtPullTest {
                 HttpURLConnection.HTTP_OK,
                 "[{\"commits\":\"test\"}]"
             )
-        ).start();
+        ).start(this.resource.port());
         final RtPull pull = new RtPull(
             new ApacheRequest(container.home()),
             this.repo(),
@@ -101,7 +109,7 @@ public final class RtPullTest {
                 HttpURLConnection.HTTP_OK,
                 "[{\"file1\":\"testFile\"}]"
             )
-        ).start();
+        ).start(this.resource.port());
         final RtPull pull = new RtPull(
             new ApacheRequest(container.home()),
             this.repo(),
@@ -139,7 +147,7 @@ public final class RtPullTest {
                     .build()
                     .toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final RtPull pull = new RtPull(
             new ApacheRequest(container.home()),
             this.repo(),
@@ -186,7 +194,7 @@ public final class RtPullTest {
                     .build()
                     .toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final RtPull pull = new RtPull(
             new ApacheRequest(container.home()),
             this.repo(),
@@ -220,7 +228,7 @@ public final class RtPullTest {
     public void executeMerge() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "testMerge")
-        ).start();
+        ).start(this.resource.port());
         final RtPull pull = new RtPull(
             new ApacheRequest(container.home()),
             this.repo(),

--- a/src/test/java/com/jcabi/github/RtPullsTest.java
+++ b/src/test/java/com/jcabi/github/RtPullsTest.java
@@ -41,6 +41,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -51,6 +52,14 @@ import org.mockito.Mockito;
  * @version $Id$
  */
 public final class RtPullsTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
     /**
      * RtPulls can create a pull request.
      *
@@ -62,7 +71,8 @@ public final class RtPullsTest {
         final String body = pull(title).toString();
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, body)
-        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body)).start();
+        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body))
+            .start(this.resource.port());
         final RtPulls pulls = new RtPulls(
             new ApacheRequest(container.home()),
             repo()
@@ -91,7 +101,7 @@ public final class RtPullsTest {
                 HttpURLConnection.HTTP_OK,
                 pull(title).toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final RtPulls pulls = new RtPulls(
             new ApacheRequest(container.home()),
             repo()
@@ -118,7 +128,7 @@ public final class RtPullsTest {
                     .add(pull("Amazing new feature"))
                     .build().toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final RtPulls pulls = new RtPulls(
             new ApacheRequest(container.home()),
             repo()

--- a/src/test/java/com/jcabi/github/RtStatusesTest.java
+++ b/src/test/java/com/jcabi/github/RtStatusesTest.java
@@ -45,6 +45,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -58,6 +59,13 @@ import org.junit.Test;
  *  RtStatuses/RtStatus against real GitHub commit status data.
  */
 public final class RtStatusesTest {
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
     /**
      * RtStatuses can fetch its commit.
      * @throws IOException If there is an I/O problem.
@@ -95,7 +103,7 @@ public final class RtStatusesTest {
                     .add(contextprop, context)
                     .build().toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final Request entry = new ApacheRequest(container.home());
         final Statuses statuses = new RtStatuses(
             entry,

--- a/src/test/java/com/jcabi/github/RtValuePaginationTest.java
+++ b/src/test/java/com/jcabi/github/RtValuePaginationTest.java
@@ -42,6 +42,7 @@ import javax.json.JsonArray;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -50,6 +51,13 @@ import org.junit.Test;
  * @version $Id$
  */
 public final class RtValuePaginationTest {
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
     /**
      * RtPagination can jump to next page of results.
      * @throws Exception if there is any problem
@@ -63,7 +71,8 @@ public final class RtValuePaginationTest {
         final MkContainer container = new MkGrizzlyContainer().next(
             RtValuePaginationTest.simple(jeff, mark)
                 .withHeader("Link", "</s?page=3&per_page=100>; rel=\"next\"")
-        ).next(RtValuePaginationTest.simple(judy, jessy)).start();
+        ).next(RtValuePaginationTest.simple(judy, jessy))
+            .start(this.resource.port());
         final Request request = new ApacheRequest(container.home());
         final RtValuePagination<JsonObject, JsonArray> page =
             new RtValuePagination<JsonObject, JsonArray>(
@@ -106,7 +115,7 @@ public final class RtValuePaginationTest {
         final String mark = "other Mark";
         final MkContainer container = new MkGrizzlyContainer().next(
             RtValuePaginationTest.simple(jeff, mark)
-        ).start();
+        ).start(this.resource.port());
         try {
             final Request request = new ApacheRequest(container.home());
             final RtValuePagination<JsonObject, JsonArray> page =


### PR DESCRIPTION
This PR:
* Solves #1388 by randomizing the port used for the `MkGrizzlyContainer` in some tests
* Leaves puzzle for the rest