### PR TITLE
(#1395) Fixed checkstyle issues

### DIFF
--- a/src/main/java/com/jcabi/github/RtIssue.java
+++ b/src/main/java/com/jcabi/github/RtIssue.java
@@ -32,12 +32,9 @@ package com.jcabi.github;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.http.Request;
-import com.jcabi.http.response.RestResponse;
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import javax.json.JsonObject;
 import lombok.EqualsAndHashCode;
-import org.hamcrest.Matchers;
 
 /**
  * Github issue.

--- a/src/main/java/com/jcabi/github/mock/MkUser.java
+++ b/src/main/java/com/jcabi/github/mock/MkUser.java
@@ -149,11 +149,11 @@ final class MkUser implements User {
         final JsonPatch json = new JsonPatch(this.storage);
         final JsonObject read = Json.createObjectBuilder()
             .add("read", true).build();
-        for (XML id : ids) {
+        for (final XML nid : ids) {
             json.patch(
                 String.format(
-                    this.xpath() + "/notifications/notification[id = %s]",
-                    id.xpath("text()").get(0)
+                    this.xpath().concat("/notifications/notification[id = %s]"),
+                    nid.xpath("text()").get(0)
                 ),
                 read
             );

--- a/src/test/java/com/jcabi/github/RtBlobsTest.java
+++ b/src/test/java/com/jcabi/github/RtBlobsTest.java
@@ -51,6 +51,7 @@ import org.mockito.Mockito;
  * @author Alexander Lukashevich (sanai56967@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiteralsCheck (100 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (200 lines)
  */
 public final class RtBlobsTest {
     /**
@@ -59,7 +60,6 @@ public final class RtBlobsTest {
      */
     @Rule
     public final transient RandomPort resource = new RandomPort();
-
 
     /**
      * RtBlobs can create a blob.

--- a/src/test/java/com/jcabi/github/RtHooksTest.java
+++ b/src/test/java/com/jcabi/github/RtHooksTest.java
@@ -55,6 +55,7 @@ import org.mockito.Mockito;
  * @version $Id$
  * @since 0.8
  * @checkstyle MultipleStringLiterals (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @Immutable
 public final class RtHooksTest {

--- a/src/test/java/com/jcabi/github/RtPullsTest.java
+++ b/src/test/java/com/jcabi/github/RtPullsTest.java
@@ -50,6 +50,7 @@ import org.mockito.Mockito;
  *
  * @author Giang Le (giang@vn-smartsolutions.com)
  * @version $Id$
+ * @checkstyle ClassDataAbstractionCouplingCheck (200 lines)
  */
 public final class RtPullsTest {
 

--- a/src/test/java/com/jcabi/github/mock/MkUserTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkUserTest.java
@@ -44,6 +44,7 @@ import org.xembly.Directives;
  *
  * @author Ed Hillmann (edhillmann@yahoo.com)
  * @version $Id$
+ * @checkstyle MultipleStringLiteralsCheck (200 lines)
  */
 public final class MkUserTest {
 
@@ -100,6 +101,7 @@ public final class MkUserTest {
                 .add("notification")
                     .add("id").set(1).up()
                     .add("date").set(
+                        // @checkstyle MagicNumberCheck (1 line)
                         upto.minus(30, ChronoUnit.MINUTES).toEpochMilli()
                     ).up()
                     .add("read").set(false).up()
@@ -107,6 +109,7 @@ public final class MkUserTest {
                 .add("notification")
                     .add("id").set(2).up()
                     .add("date").set(
+                         // @checkstyle MagicNumberCheck (1 line)
                         upto.plus(30, ChronoUnit.MINUTES).toEpochMilli()
                     ).up()
                     .add("read").set(false).up()


### PR DESCRIPTION
This PR:
* Solves #1395 
* Fixes checkstyle issues reported [here](http://www.rultor.com/t/14334-382832345). These are:

```
[ERROR] /src/test/java/com/jcabi/github/mock/MkUserTest.java[100]: The String "notification" appears 2 times in the file. (MultipleStringLiteralsCheck)
[ERROR] /src/test/java/com/jcabi/github/mock/MkUserTest.java[101]: The String "id" appears 2 times in the file. (MultipleStringLiteralsCheck)
[ERROR] /src/test/java/com/jcabi/github/mock/MkUserTest.java[102]: The String "date" appears 2 times in the file. (MultipleStringLiteralsCheck)
[ERROR] /src/test/java/com/jcabi/github/mock/MkUserTest.java[103]: '30' is a magic number. (MagicNumberCheck)
[ERROR] /src/test/java/com/jcabi/github/mock/MkUserTest.java[105]: The String "read" appears 2 times in the file. (MultipleStringLiteralsCheck)
[ERROR] /src/test/java/com/jcabi/github/mock/MkUserTest.java[110]: '30' is a magic number. (MagicNumberCheck)
[ERROR] /src/main/java/com/jcabi/github/mock/MkUser.java[152]: Parameter id should be final. (FinalParametersCheck)
[ERROR] /src/main/java/com/jcabi/github/mock/MkUser.java[152]: Name 'id' must match pattern '^ex|[a-z]{3,}$'. (LocalVariableNameCheck)
[ERROR] /src/main/java/com/jcabi/github/mock/MkUser.java[155]: Concatenation of string literals prohibited (StringLiteralsConcatenationCheck)
[ERROR] /src/main/java/com/jcabi/github/RtIssue.java[35]: Unused import - com.jcabi.http.response.RestResponse. (UnusedImportsCheck)
[ERROR] /src/main/java/com/jcabi/github/RtIssue.java[37]: Unused import - java.net.HttpURLConnection. (UnusedImportsCheck)
[ERROR] /src/main/java/com/jcabi/github/RtIssue.java[40]: Unused import - org.hamcrest.Matchers. (UnusedImportsCheck)

```

Edit:
Some additional fixes for:
```
[ERROR] /src/test/java/com/jcabi/github/RtBlobsTest.java[55]: Class Data Abstraction Coupling is 8 (max allowed is 7) classes [ApacheRequest, Blob.Smart, Coordinates.Simple, FakeRequest, MkAnswer.Simple, MkGrizzlyContainer, RandomPort, RtBlobs]. (ClassDataAbstractionCouplingCheck)
[ERROR] /src/test/java/com/jcabi/github/RtBlobsTest.java[61]: Two consecutive empty lines (RegexpMultilineCheck)
[ERROR] /src/test/java/com/jcabi/github/RtHooksTest.java[59]: Class Data Abstraction Coupling is 8 (max allowed is 7) classes [ConcurrentHashMap, Coordinates.Simple, Hook.Smart, JdkRequest, MkAnswer.Simple, MkGrizzlyContainer, RandomPort, RtHooks]. (ClassDataAbstractionCouplingCheck)
[ERROR] /src/test/java/com/jcabi/github/RtPullsTest.java[54]: Class Data Abstraction Coupling is 8 (max allowed is 7) classes [ApacheRequest, ArrayMap, Coordinates.Simple, MkAnswer.Simple, MkGrizzlyContainer, Pull.Smart, RandomPort, RtPulls]. (ClassDataAbstractionCouplingCheck)
```