### PR TITLE
(#1390) Fixed Release.Smart.prerelease()

### DIFF
--- a/src/main/java/com/jcabi/github/Release.java
+++ b/src/main/java/com/jcabi/github/Release.java
@@ -37,6 +37,7 @@ import java.text.ParseException;
 import java.util.Date;
 import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.JsonValue;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -349,7 +350,11 @@ public interface Release extends JsonReadable, JsonPatchable {
          * @throws IOException If there is any I/O problem
          */
         public boolean prerelease() throws IOException {
-            return this.json().getBoolean("prerelease", Boolean.FALSE);
+            return Boolean.parseBoolean(
+                this.json()
+                    .getOrDefault("prerelease", JsonValue.FALSE)
+                    .toString().replace("\"", "")
+            );
         }
 
         /**

--- a/src/test/java/com/jcabi/github/mock/MkReleaseTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReleaseTest.java
@@ -33,11 +33,11 @@ import com.jcabi.github.Github;
 import com.jcabi.github.Release;
 import com.jcabi.github.Releases;
 import java.io.IOException;
+import javax.json.Json;
 import javax.json.JsonString;
 import javax.json.JsonValue;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -194,18 +194,15 @@ public final class MkReleaseTest {
     /**
      * Smart decorator returns prerelease.
      * @throws Exception If some problem inside
-     * @todo #1363:30min Release.Smart().prerelease() was refactored and unit
-     *  tests written. However, this test still fails because the MkStorage
-     *  holds the value as String instead of Boolean. Let's fix this.
      */
     @Test
-    @Ignore
     public void prerelease() throws Exception {
         final Release release = MkReleaseTest.release();
-        final Release.Smart smart = new Release.Smart(release);
-        smart.prerelease(true);
+        release.patch(
+            Json.createObjectBuilder().add("prerelease", true).build()
+        );
         MatcherAssert.assertThat(
-            smart.prerelease(),
+            new Release.Smart(release).prerelease(),
             Matchers.is(true)
         );
     }


### PR DESCRIPTION
This PR:
* Solves #1390 
* Fixes `Release.Smart#prerelease()`

Note: 
The string substitution introduced here for `prerelease()` is done because the `JsonString` implementation we use (`org.glassfish.json.JsonStringImpl`) is prepending and appending the `"` character to its value. So for a string "true" it would print `"true"` instead of just `true`.