### PR TITLE
(#1404) Finished randomizing MkGrizzlyContainer port on all tests

### DIFF
--- a/src/test/java/com/jcabi/github/RtGistCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentTest.java
@@ -54,9 +54,6 @@ public class RtGistCommentTest {
 
     /**
      * The rule for skipping test if there's BindException.
-     * @todo #1399:30min Apply this rule to all other classes that use
-     *  MkGrizzlyContainer and make MkGrizzlyContainers use port() given by this
-     *  resource to avoid tests fail with BindException.
      * @checkstyle VisibilityModifierCheck (3 lines)
      */
     @Rule

--- a/src/test/java/com/jcabi/github/RtPullCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtPullCommentTest.java
@@ -52,6 +52,7 @@ import org.mockito.Mockito;
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiteralsCheck (200 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (3 lines)
  */
 public final class RtPullCommentTest {
 

--- a/src/test/java/com/jcabi/github/RtPullCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtPullCommentTest.java
@@ -42,6 +42,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -54,6 +55,12 @@ import org.mockito.Mockito;
  */
 public final class RtPullCommentTest {
 
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
     /**
      * RtPullComment should be able to compare different instances.
      * @throws Exception If a problem occurs.
@@ -86,7 +93,7 @@ public final class RtPullCommentTest {
         final String body = "{\"body\":\"test\"}";
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body)
-        ).start();
+        ).start(this.resource.port());
         final Pull pull = Mockito.mock(Pull.class);
         Mockito.doReturn(repo()).when(pull).repo();
         final RtPullComment comment =
@@ -114,7 +121,7 @@ public final class RtPullCommentTest {
     public void patchesComment() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
-        ).start();
+        ).start(this.resource.port());
         final Pull pull = Mockito.mock(Pull.class);
         Mockito.doReturn(repo()).when(pull).repo();
         final RtPullComment comment =

--- a/src/test/java/com/jcabi/github/RtReferenceTest.java
+++ b/src/test/java/com/jcabi/github/RtReferenceTest.java
@@ -40,6 +40,7 @@ import java.net.HttpURLConnection;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -52,6 +53,13 @@ import org.junit.Test;
 public final class RtReferenceTest {
 
     /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
+    /**
      * RtReference should be able to execute patch.
      * @throws Exception - If something goes wrong.
      */
@@ -62,7 +70,7 @@ public final class RtReferenceTest {
                 HttpURLConnection.HTTP_OK,
                 "{\"ref\":\"refs/heads/featureA\"}"
             )
-        ).start();
+        ).start(this.resource.port());
         final Reference reference = new RtReference(
             new ApacheRequest(container.home()),
             new MkGithub().randomRepo(),
@@ -93,7 +101,7 @@ public final class RtReferenceTest {
                 HttpURLConnection.HTTP_OK,
                 "{\"ref\":\"refs/heads/featureB\"}"
             )
-        ).start();
+        ).start(this.resource.port());
         final Reference reference = new RtReference(
             new ApacheRequest(container.home()),
             new MkGithub().randomRepo(),
@@ -120,7 +128,7 @@ public final class RtReferenceTest {
                 HttpURLConnection.HTTP_OK,
                 "{\"ref\":\"refs/heads/featureC\"}"
             )
-        ).start();
+        ).start(this.resource.port());
         final Reference reference = new RtReference(
             new ApacheRequest(container.home()),
             new MkGithub().randomRepo(),
@@ -148,7 +156,7 @@ public final class RtReferenceTest {
                 HttpURLConnection.HTTP_OK,
                 "{\"ref\":\"refs/heads/featureD\"}"
             )
-        ).start();
+        ).start(this.resource.port());
         final Reference reference = new RtReference(
             new ApacheRequest(container.home()), owner, "refs/heads/featureD"
         );

--- a/src/test/java/com/jcabi/github/RtReferencesTest.java
+++ b/src/test/java/com/jcabi/github/RtReferencesTest.java
@@ -38,6 +38,7 @@ import com.jcabi.http.request.ApacheRequest;
 import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -48,6 +49,14 @@ import org.junit.Test;
  * @checkstyle MultipleStringLiterals (500 lines)
  */
 public final class RtReferencesTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
     /**
      * RtReferences should create and return a Reference.
      * @throws Exception - if something goes wrong.
@@ -59,7 +68,7 @@ public final class RtReferencesTest {
                 HttpURLConnection.HTTP_CREATED,
                 "{\"ref\":\"refs/heads/feature-a\"}"
             )
-        ).start();
+        ).start(this.resource.port());
         final References refs = new RtReferences(
             new ApacheRequest(container.home()),
             new MkGithub().randomRepo()
@@ -89,7 +98,7 @@ public final class RtReferencesTest {
                 HttpURLConnection.HTTP_OK,
                 "{\"ref\":\"refs/heads/feature-a\"}"
             )
-        ).start();
+        ).start(this.resource.port());
         final References refs = new RtReferences(
             new ApacheRequest(container.home()),
             new MkGithub().randomRepo()
@@ -112,7 +121,7 @@ public final class RtReferencesTest {
     public void removesReference() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
-        ).start();
+        ).start(this.resource.port());
         final References refs = new RtReferences(
             new ApacheRequest(container.home()),
             new MkGithub().randomRepo()
@@ -139,7 +148,7 @@ public final class RtReferencesTest {
                 HttpURLConnection.HTTP_OK,
                 "[{\"ref\":\"refs/tags/feature-b\"}]"
             )
-        ).start();
+        ).start(this.resource.port());
         final References refs = new RtReferences(
             new ApacheRequest(container.home()),
             new MkGithub().randomRepo()
@@ -169,7 +178,7 @@ public final class RtReferencesTest {
                 HttpURLConnection.HTTP_OK,
                 "[{\"ref\":\"refs/heads/feature-c\"}]"
             )
-        ).start();
+        ).start(this.resource.port());
         final References refs = new RtReferences(
             new ApacheRequest(container.home()),
             new MkGithub().randomRepo()

--- a/src/test/java/com/jcabi/github/RtReposTest.java
+++ b/src/test/java/com/jcabi/github/RtReposTest.java
@@ -54,6 +54,12 @@ import org.mockito.Mockito;
 public final class RtReposTest {
 
     /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+    /**
      * RepoRule.
      * @checkstyle VisibilityModifierCheck (3 lines)
      */
@@ -72,7 +78,7 @@ public final class RtReposTest {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, response)
         ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, response))
-            .start();
+            .start(this.resource.port());
         final RtRepos repos = new RtRepos(
             Mockito.mock(Github.class),
             new ApacheRequest(container.home())
@@ -104,7 +110,7 @@ public final class RtReposTest {
                     .add(response("dummy", "2"))
                     .build().toString()
             )
-        ).start();
+        ).start(this.resource.port());
         final RtRepos repos = new RtRepos(
             Mockito.mock(Github.class),
             new ApacheRequest(container.home())
@@ -124,7 +130,7 @@ public final class RtReposTest {
     public void removeRepo() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
-        ).start();
+        ).start(this.resource.port());
         final Repos repos = new RtRepos(
             Mockito.mock(Github.class),
             new ApacheRequest(container.home())

--- a/src/test/java/com/jcabi/github/RtStarsTest.java
+++ b/src/test/java/com/jcabi/github/RtStarsTest.java
@@ -39,6 +39,7 @@ import java.net.HttpURLConnection;
 import javax.ws.rs.core.UriBuilder;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -51,6 +52,13 @@ import org.mockito.Mockito;
 public final class RtStarsTest {
 
     /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
+    /**
      * RtStars can check if repo is starred.
      *
      * @throws Exception If something goes wrong.
@@ -60,7 +68,7 @@ public final class RtStarsTest {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT)
         ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_NOT_FOUND))
-            .start();
+            .start(this.resource.port());
         try {
             final Stars starred = new RtStars(
                 new ApacheRequest(container.home()),
@@ -90,7 +98,7 @@ public final class RtStarsTest {
     public void starRepository() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT)
-        ).start();
+        ).start(this.resource.port());
         final String user = "staruser";
         final String repo = "starrepo";
         final Stars stars = new RtStars(
@@ -127,7 +135,7 @@ public final class RtStarsTest {
     public void unstarRepository() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT)
-        ).start();
+        ).start(this.resource.port());
         final String user = "unstaruser";
         final String repo = "unstarrepo";
         final Stars stars = new RtStars(

--- a/src/test/java/com/jcabi/github/RtUserEmailsTest.java
+++ b/src/test/java/com/jcabi/github/RtUserEmailsTest.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -48,6 +49,12 @@ import org.junit.Test;
  */
 public final class RtUserEmailsTest {
 
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
     /**
      * RtUserEmails can fetch emails.
      * @throws Exception If some problem inside
@@ -80,7 +87,7 @@ public final class RtUserEmailsTest {
                 String.format("[{\"email\":\"%s\"}]", email)
             )
         );
-        container.start();
+        container.start(this.resource.port());
         try {
             final UserEmails emails = new RtUserEmails(
                 new ApacheRequest(container.home())

--- a/src/test/java/com/jcabi/github/wire/RetryCarefulWireTest.java
+++ b/src/test/java/com/jcabi/github/wire/RetryCarefulWireTest.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github.wire;
 
+import com.jcabi.github.RandomPort;
 import com.jcabi.http.mock.MkAnswer;
 import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
@@ -40,6 +41,7 @@ import java.net.HttpURLConnection;
 import java.util.concurrent.TimeUnit;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -59,6 +61,12 @@ public final class RetryCarefulWireTest {
      * Name of GitHub's number-of-requests-remaining rate limit header.
      */
     private static final String REMAINING_HEADER = "X-RateLimit-Remaining";
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
 
     /**
      * RetryCarefulWire can make a few requests before giving up and
@@ -78,7 +86,7 @@ public final class RetryCarefulWireTest {
                 .withHeader(REMAINING_HEADER, "9")
                 .withHeader("X-RateLimit-Reset", String.valueOf(reset))
             )
-            .start();
+            .start(this.resource.port());
         new JdkRequest(container.home())
             .through(RetryCarefulWire.class, threshold)
             .fetch()


### PR DESCRIPTION
This PR:
* solves #1404 
* finishes randomizing port used by `MkGrizzlyContainer` on all tests