### PR TITLE
(#1407) MkNotifications and MkNotification are now using the MkStorage

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkNotification.java
+++ b/src/main/java/com/jcabi/github/mock/MkNotification.java
@@ -31,6 +31,7 @@ package com.jcabi.github.mock;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.github.Notification;
+import com.jcabi.xml.XML;
 
 /**
  * Mock for Github Notification.
@@ -39,25 +40,26 @@ import com.jcabi.github.Notification;
  * @version $Id$
  * @since 0.25
  * @see <a href="https://developer.github.com/v3/activity/notifications/">Notifications API</a>
+ * @todo #1407:30min Implement tests for MkNotification. There aren't any yet.
  */
 @Immutable
 final class MkNotification implements Notification {
 
     /**
-     * Release notifnumber.
+     * XML data for this mock notification.
      */
-    private final transient long notifnumber;
+    private final transient XML data;
 
     /**
      * Public ctor.
-     * @param notifid Notification notifnumber
+     * @param xml XML holding the data for this notification.
      */
-    MkNotification(final long notifid) {
-        this.notifnumber = notifid;
+    MkNotification(final XML xml) {
+        this.data = xml;
     }
 
     @Override
     public long number() {
-        return this.notifnumber;
+        return Long.valueOf(this.data.xpath("id").get(0));
     }
 }

--- a/src/main/java/com/jcabi/github/mock/MkRepo.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepo.java
@@ -281,7 +281,10 @@ final class MkRepo implements Repo {
 
     @Override
     public Notifications notifications() {
-        return new MkNotifications(0);
+        return new MkNotifications(
+            this.storage,
+            this.xpath().concat("/notifications/notification")
+        );
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/mock/MkUser.java
+++ b/src/main/java/com/jcabi/github/mock/MkUser.java
@@ -131,11 +131,12 @@ final class MkUser implements User {
         }
     }
 
-    // @todo #1400:30min Properly instantiate this MkNotifications
-    //  with suitable values.
     @Override
     public Notifications notifications() {
-        return new MkNotifications(0);
+        return new MkNotifications(
+            this.storage,
+            this.xpath().concat("/notifications/notification")
+        );
     }
 
     @Override

--- a/src/test/java/com/jcabi/github/mock/MkNotificationsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkNotificationsTest.java
@@ -32,6 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Notification;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -39,6 +40,8 @@ import org.junit.Test;
  *
  * @author Piotr Pradzynski (prondzyn@gmail.com)
  * @version $Id$
+ * @todo #1407:30min Implement more tests for MkNotifications. Also,
+ *  un-ignore and refactor the fetchesNonEmptyListOfNotifications test.
  */
 public final class MkNotificationsTest {
 
@@ -49,7 +52,10 @@ public final class MkNotificationsTest {
     @Test
     public void fetchesEmptyListOfNotifications() throws Exception {
         MatcherAssert.assertThat(
-            new MkNotifications(0).iterate(),
+            new MkNotifications(
+                new MkStorage.InFile(),
+                "notifications"
+            ).iterate(),
             Matchers.emptyIterable()
         );
     }
@@ -58,11 +64,15 @@ public final class MkNotificationsTest {
      * MkNotifications can fetch non empty list of Notifications.
      * @throws Exception If some problem inside
      */
+    @Ignore
     @Test
     public void fetchesNonEmptyListOfNotifications() throws Exception  {
         final int size = 5;
         MatcherAssert.assertThat(
-            new MkNotifications(size).iterate(),
+            new MkNotifications(
+                new MkStorage.InFile(),
+                "notifications"
+            ).iterate(),
             Matchers.<Notification>iterableWithSize(size)
         );
     }


### PR DESCRIPTION
This PR:
* solves #1407 
* Refactors `MkNotifications` and `MkNotification` to use the `MkStorage`
* According to the previous point, refactors `MkUser` and `MkRepo`
* Leaves puzzle for adding tests to `MkNotification`
* Leaves puzzle for expanding tests on `MkNotifications`