### PR TITLE
(#1417) Added tests for MkNotifications + fixed bugs in iterate() and get()

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkNotifications.java
+++ b/src/main/java/com/jcabi/github/mock/MkNotifications.java
@@ -80,7 +80,7 @@ final class MkNotifications implements Notifications {
                 @Override
                 public Notification map(final XML xml) {
                     return MkNotifications.this.get(
-                        Integer.valueOf(xml.xpath("id").get(0))
+                        Integer.valueOf(xml.xpath("id/text()").get(0))
                     );
                 }
             }
@@ -92,7 +92,7 @@ final class MkNotifications implements Notifications {
         try {
             return new MkNotification(
                 this.storage.xml().nodes(
-                    this.xpath.concat(String.format("[%s]", number))
+                    this.xpath.concat(String.format("[id = %s]", number))
                 ).get(0)
             );
         } catch (final IOException ex) {

--- a/src/test/java/com/jcabi/github/mock/MkNotificationsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkNotificationsTest.java
@@ -32,16 +32,14 @@ package com.jcabi.github.mock;
 import com.jcabi.github.Notification;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.xembly.Directives;
 
 /**
  * Test case for {@link MkNotifications}.
  *
  * @author Piotr Pradzynski (prondzyn@gmail.com)
  * @version $Id$
- * @todo #1407:30min Implement more tests for MkNotifications. Also,
- *  un-ignore and refactor the fetchesNonEmptyListOfNotifications test.
  */
 public final class MkNotificationsTest {
 
@@ -64,17 +62,73 @@ public final class MkNotificationsTest {
      * MkNotifications can fetch non empty list of Notifications.
      * @throws Exception If some problem inside
      */
-    @Ignore
     @Test
     public void fetchesNonEmptyListOfNotifications() throws Exception  {
-        final int size = 5;
+        final MkStorage storage = new MkStorage.InFile();
+        storage.apply(
+            new Directives().xpath("/github")
+                .add("notifications")
+                    .add("notification")
+                        .add("id").set("1").up().up()
+                    .add("notification")
+                        .add("id").set("2").up().up()
+                    .add("notification")
+                        .add("id").set("3").up().up()
+        );
         MatcherAssert.assertThat(
             new MkNotifications(
-                new MkStorage.InFile(),
-                "test"
+                storage,
+                "/github/notifications/notification"
             ).iterate(),
-            Matchers.<Notification>iterableWithSize(size)
+            Matchers.<Notification>iterableWithSize(3)
         );
     }
 
+    /**
+     * MkNotifications can fetch a notification by id.
+     * @throws Exception If something goes wrong
+     */
+    @Test
+    public void fetchesNotificationById() throws Exception {
+        final MkStorage storage = new MkStorage.InFile();
+        storage.apply(
+            new Directives().xpath("/github")
+                .add("notifications")
+                    .add("notification")
+                        .add("id").set("1").up().up()
+                    .add("notification")
+                        .add("id").set("2").up().up()
+        );
+        MatcherAssert.assertThat(
+            new MkNotifications(
+                storage,
+                "/github/notifications/notification"
+            ).get(2),
+            Matchers.notNullValue()
+        );
+    }
+
+    /**
+     * MkNotifications can fetch a notification by id.
+     * @throws Exception If something goes wrong
+     */
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void cannotFetchNotificationByNonExistentId() throws Exception {
+        final MkStorage storage = new MkStorage.InFile();
+        storage.apply(
+            new Directives().xpath("/github")
+                .add("notifications")
+                    .add("notification")
+                        .add("id").set("1").up().up()
+                    .add("notification")
+                        .add("id").set("3").up().up()
+        );
+        MatcherAssert.assertThat(
+            new MkNotifications(
+                storage,
+                "/github/notifications/notification"
+            ).get(2),
+            Matchers.notNullValue()
+        );
+    }
 }


### PR DESCRIPTION
This PR:
* solves #1417 
* Adds tests for `MkNotifications`
* Fixed error in `MkNotifications.iterate()`: *java.lang.IllegalArgumentException: Only text() nodes or attributes are retrievable with xpath() 'id': 1*
* Fixed bug in `MkNotifications.get()` where the notification nodes were not being properly selected