### PR TITLE
(#1418) Added tests for MkNotification + fixed bug in MkNotification.number()

### DIFF
--- a/src/test/java/com/jcabi/github/mock/MkNotificationTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkNotificationTest.java
@@ -27,38 +27,39 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package com.jcabi.github.mock;
 
-import com.jcabi.aspects.Immutable;
-import com.jcabi.github.Notification;
-import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
 
 /**
- * Mock for Github Notification.
- *
- * @author Piotr Pradzynski (prondzyn@gmail.com)
+ * Unit tests for {@link MkNotification}.
+ * @author George Aristy (george.aristy@gmail.com)
  * @version $Id$
- * @since 0.25
- * @see <a href="https://developer.github.com/v3/activity/notifications/">Notifications API</a>
+ * @since 0.40
  */
-@Immutable
-final class MkNotification implements Notification {
-
+public final class MkNotificationTest {
     /**
-     * XML data for this mock notification.
+     * MkNotification can return its number.
      */
-    private final transient XML data;
-
-    /**
-     * Public ctor.
-     * @param xml XML holding the data for this notification.
-     */
-    MkNotification(final XML xml) {
-        this.data = xml;
-    }
-
-    @Override
-    public long number() {
-        return Long.valueOf(this.data.xpath("//id/text()").get(0));
+    @Test
+    public void returnsNumber() {
+        MatcherAssert.assertThat(
+            new MkNotification(
+                new XMLDocument(
+                    new Xembler(
+                        new Directives()
+                            .add("notification")
+                                .add("id").set("123")
+                    ).xmlQuietly()
+                )
+            ).number(),
+            Matchers.is(123L)
+        );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkNotificationTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkNotificationTest.java
@@ -59,6 +59,7 @@ public final class MkNotificationTest {
                     ).xmlQuietly()
                 )
             ).number(),
+            // @checkstyle MagicNumberCheck (1 line)
             Matchers.is(123L)
         );
     }

--- a/src/test/java/com/jcabi/github/mock/MkNotificationTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkNotificationTest.java
@@ -42,6 +42,7 @@ import org.xembly.Xembler;
  * @author George Aristy (george.aristy@gmail.com)
  * @version $Id$
  * @since 0.40
+ * @checkstyle MagicNumberCheck (500 lines)
  */
 public final class MkNotificationTest {
     /**
@@ -59,7 +60,6 @@ public final class MkNotificationTest {
                     ).xmlQuietly()
                 )
             ).number(),
-            // @checkstyle MagicNumberCheck (1 line)
             Matchers.is(123L)
         );
     }


### PR DESCRIPTION
This PR:
* solves #1418 
* Adds a test for `MkNotification`
* Fixes error in `MkNotification.number()` (I don't know the reason why it was occurring): *com.jcabi.xml.ListWrapper$NodeNotFoundException: XPath 'id/text()' not found in '<?xml version="1.0" encoding="UTF-8" standalone="n..19..uD\uA<id>123</id>\uD\uA</notification>\uD\uA': Index (0) is out of bounds (size=0)*