### PR TITLE
(#1421) Can't create private repo with MkGihub

### DIFF
--- a/src/main/java/com/jcabi/github/Repo.java
+++ b/src/main/java/com/jcabi/github/Repo.java
@@ -246,7 +246,11 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
          * @throws IOException If there is any I/O problem
          */
         public boolean isPrivate() throws IOException {
-            return JsonValue.TRUE.equals(this.json().get("private"));
+            return Boolean.parseBoolean(
+                this.json()
+                    .getOrDefault("private", JsonValue.FALSE)
+                    .toString().replace("\"", "")
+            );
         }
         @Override
         public Github github() {

--- a/src/main/java/com/jcabi/github/mock/MkRepos.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepos.java
@@ -99,7 +99,7 @@ final class MkRepos implements Repos {
                 .attr("coords", coords.toString())
                 .add("name").set(settings.name()).up()
                 .add("description").set("test repository").up()
-                .add("private").set("false").up()
+                .add("private").set(settings.isPrivate()).up()
         );
         final Repo repo = this.get(coords);
         repo.patch(settings.json());

--- a/src/test/java/com/jcabi/github/RepoTest.java
+++ b/src/test/java/com/jcabi/github/RepoTest.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import com.jcabi.github.mock.MkGithub;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -66,12 +67,12 @@ public final class RepoTest {
      */
     @Test
     public void canFetchPrivateStatus() throws Exception {
-        final Repo repo = Mockito.mock(Repo.class);
-        Mockito.doReturn(
+        final Repo repo = new MkGithub().randomRepo();
+        repo.patch(
             Json.createObjectBuilder()
                 .add("private", true)
                 .build()
-        ).when(repo).json();
+        );
         MatcherAssert.assertThat(
             new Repo.Smart(repo).isPrivate(),
             Matchers.is(true)

--- a/src/test/java/com/jcabi/github/mock/MkRepoTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkRepoTest.java
@@ -124,7 +124,7 @@ public final class MkRepoTest {
         );
         MatcherAssert.assertThat(
             new Repo.Smart(repo).isPrivate(),
-            Matchers.is(false)
+            Matchers.is(true)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkReposTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReposTest.java
@@ -115,6 +115,23 @@ public final class MkReposTest {
     }
 
     /**
+     * MkRepos can create a private repo.
+     * @throws Exception If there is any error
+     */
+    @Test
+    public void createsPrivateRepo() throws Exception {
+        final boolean priv = true;
+        MatcherAssert.assertThat(
+            new Repo.Smart(
+                new MkGithub().repos().create(
+                    new Repos.RepoCreate("test", priv)
+                )
+            ).isPrivate(),
+            Matchers.is(priv)
+        );
+    }
+
+    /**
      * Create and return Repo to test.
      * @param repos Repos
      * @param name Repo name


### PR DESCRIPTION
This PR:
* Solves #1421
* Fixes `MkRepos.create()`
* Fixes `Repos.Smart.isPrivate()` with similar solution from #1397 
* Refactored test `RepoTest.canFetchPrivateStatus()` in order to make sure that `Repo.Smart` can correctly read the `private` flag from the `MkStorage`
* Fixed assumption in `MkRepoTest.exposesAttributes()`: `MkGithub.randomRepo()` always sets the `private` flag to `true`

