### PR TITLE
For #1424:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,14 +225,6 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
           </execution>
         </executions>
       </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-                <source>7</source>
-                <target>7</target>
-            </configuration>
-        </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,14 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>7</source>
+                <target>7</target>
+            </configuration>
+        </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,13 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>
           <execution>

--- a/src/main/java/com/jcabi/github/mock/MkPull.java
+++ b/src/main/java/com/jcabi/github/mock/MkPull.java
@@ -233,48 +233,42 @@ final class MkPull implements Pull {
         final JsonObject obj = new JsonNode(xml).json();
         final JsonObjectBuilder json = Json.createObjectBuilder();
         for (final Map.Entry<String, JsonValue> val : obj.entrySet()) {
-            switch (val.getKey()) {
-                case MkPull.NUMBER_PROP:
-                    json.add(
-                        MkPull.NUMBER_PROP,
-                        Integer.parseInt(xml.xpath("number/text()").get(0))
-                    );
-                    break;
-                case MkPull.USER_PROP:
-                    json.add(
-                        MkPull.USER_PROP,
-                        Json.createObjectBuilder()
-                        .add("login", xml.xpath("user/login/text()").get(0))
+            if (MkPull.NUMBER_PROP.equals(val.getKey())) {
+                json.add(
+                    MkPull.NUMBER_PROP,
+                    Integer.parseInt(xml.xpath("number/text()").get(0))
+                );
+            } else if (MkPull.USER_PROP.equals(val.getKey())) {
+                json.add(
+                    MkPull.USER_PROP,
+                    Json.createObjectBuilder()
+                    .add("login", xml.xpath("user/login/text()").get(0))
+                    .build()
+                );
+            } else if (MkPull.HEAD_PROP.equals(val.getKey())) {
+                json.add(
+                    MkPull.HEAD_PROP,
+                    Json.createObjectBuilder()
+                        .add(MkPull.REF_PROP, parts[1])
+                        .add(MkPull.LABEL_PROP, head)
                         .build()
-                    );
-                    break;
-                case MkPull.HEAD_PROP:
-                    json.add(
-                        MkPull.HEAD_PROP,
-                        Json.createObjectBuilder()
-                            .add(MkPull.REF_PROP, parts[1])
-                            .add(MkPull.LABEL_PROP, head)
-                            .build()
-                    );
-                    break;
-                case MkPull.BASE_PROP:
-                    json.add(
-                        MkPull.BASE_PROP,
-                        Json.createObjectBuilder()
-                            .add(MkPull.REF_PROP, branch)
-                            .add(
-                                MkPull.LABEL_PROP,
-                                String.format(
-                                    "%s:%s",
-                                    this.coords.user(),
-                                    branch
-                                )
-                            ).build()
-                    );
-                    break;
-                default:
-                    json.add(val.getKey(), val.getValue());
-                    break;
+                );
+            } else if (MkPull.BASE_PROP.equals(val.getKey())) {
+                json.add(
+                    MkPull.BASE_PROP,
+                    Json.createObjectBuilder()
+                        .add(MkPull.REF_PROP, branch)
+                        .add(
+                            MkPull.LABEL_PROP,
+                            String.format(
+                                "%s:%s",
+                                this.coords.user(),
+                                branch
+                            )
+                        ).build()
+                );
+            } else {
+                json.add(val.getKey(), val.getValue());
             }
         }
         json.add(

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -38,6 +38,8 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.object.HasToString;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -45,7 +47,7 @@ import org.mockito.Mockito;
  * Test case for {@link MkPull}.
  *
  * @author Carlos Miranda (miranda.cma@gmail.com)
- * @version $Id$
+ * @version $Id $
  * @checkstyle MultipleStringLiterals (500 lines)
  * @checkstyle JavadocMethodCheck (500 lines)
  */
@@ -221,7 +223,13 @@ public final class MkPullTest {
         );
         MatcherAssert.assertThat(
             pull.json().getString("somekey"),
-            Matchers.equalTo(value)
+            new IsEqual<>(value)
+        );
+        final int lines = 20;
+        pull.patch(Json.createObjectBuilder().add("additions", lines).build());
+        MatcherAssert.assertThat(
+            pull.json().getInt("additions", 20),
+            new IsEqual<>(lines)
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -217,10 +217,10 @@ public final class MkPullTest {
             .create("Test Patch", "def", "abc");
         final String value = "someValue";
         pull.patch(
-            Json.createObjectBuilder().add("patch", value).build()
+            Json.createObjectBuilder().add("somekey", value).build()
         );
         MatcherAssert.assertThat(
-            pull.json().getString("patch"),
+            pull.json().getString("somekey"),
             Matchers.equalTo(value)
         );
     }

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -222,13 +222,13 @@ public final class MkPullTest {
         );
         MatcherAssert.assertThat(
             pull.json().getString("somekey"),
-            new IsEqual<>(value)
+            new IsEqual<String>(value)
         );
         final int lines = 20;
         pull.patch(Json.createObjectBuilder().add("additions", lines).build());
         MatcherAssert.assertThat(
             pull.json().getString("additions"),
-            new IsEqual<>(new Integer(lines).toString())
+            new IsEqual<String>(new Integer(lines).toString())
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -227,8 +227,8 @@ public final class MkPullTest {
         final int lines = 20;
         pull.patch(Json.createObjectBuilder().add("additions", lines).build());
         MatcherAssert.assertThat(
-            pull.json().getInt("additions", 0),
-            new IsEqual<>(lines)
+            pull.json().getString("additions"),
+            new IsEqual<>(new Integer(lines).toString())
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkPullTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkPullTest.java
@@ -39,7 +39,6 @@ import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
-import org.hamcrest.object.HasToString;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -228,7 +227,7 @@ public final class MkPullTest {
         final int lines = 20;
         pull.patch(Json.createObjectBuilder().add("additions", lines).build());
         MatcherAssert.assertThat(
-            pull.json().getInt("additions", 20),
+            pull.json().getInt("additions", 0),
             new IsEqual<>(lines)
         );
     }


### PR DESCRIPTION
For #1424: Correct `MkPull#json()` behavior:
- `MkPull#json()` was adding a hard-coded `patch` item upon calling `patch()` method, but the test wasn't accurate because it would fail when trying to use other name for this key. So I've returned the working part of the implementation removed in https://github.com/jcabi/jcabi-github/issues/1424#issuecomment-409313715 and merged with the implementation of `number`, `head`, `base` and `comment`
- Corrected `MkJsonTest` so it uses a string different than `patch` for testing `patch()` method (assuring this way that the implementation has changed)
- Added test suggested by issue opener to assure that the class is now behaving as asked.