### PR TITLE
(#1430) MkHook.json

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkHook.java
+++ b/src/main/java/com/jcabi/github/mock/MkHook.java
@@ -34,12 +34,8 @@ import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Hook;
 import com.jcabi.github.Repo;
-import com.jcabi.xml.XML;
 import java.io.IOException;
-import javax.json.Json;
-import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -105,37 +101,13 @@ final class MkHook implements Hook {
     }
     @Override
     public JsonObject json() throws IOException {
-        final XML hook = this.storage.xml().nodes(
-            String.format(
-                "//repo[@coords='%s']/hooks/hook[id='%s']",
-                this.coords, this.num
-            )
-        ).get(0);
-        final JsonArrayBuilder events = Json.createArrayBuilder();
-        for (final XML event : hook.nodes("events/child::*")) {
-            // @checkstyle MultipleStringLiteralsCheck (1 line)
-            events.add(event.xpath("name()").get(0));
-        }
-        final JsonObjectBuilder configs = Json.createObjectBuilder();
-        for (final XML config : hook.nodes("configs/child::*")) {
-            configs.add(
-                // @checkstyle MultipleStringLiteralsCheck (1 line)
-                config.xpath("name()").get(0), config.xpath("text()").get(0)
-            );
-        }
-        return Json.createObjectBuilder()
-            .add("id", this.number())
-            .add("url", hook.xpath("url/text()").get(0))
-            .add("test_url", hook.xpath("test_url/text()").get(0))
-            .add("ping_url", hook.xpath("ping_url/text()").get(0))
-            .add("name", hook.xpath("name/text()").get(0))
-            .add("events", events)
-            .add(
-                "active",
-                Boolean.parseBoolean(hook.xpath("active/text()").get(0))
-            ).add("config", configs)
-            .add("updated_at", hook.xpath("updated_at/text()").get(0))
-            .add("created_at", hook.xpath("created_at/text()").get(0))
-            .build();
+        return new JsonNode(
+            this.storage.xml().nodes(
+                String.format(
+                    "//repo[@coords='%s']/hooks/hook[id='%s']",
+                    this.repo().coordinates(), this.number()
+                )
+            ).get(0)
+        ).json();
     }
 }

--- a/src/main/java/com/jcabi/github/mock/MkHook.java
+++ b/src/main/java/com/jcabi/github/mock/MkHook.java
@@ -34,8 +34,12 @@ import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Hook;
 import com.jcabi.github.Repo;
+import com.jcabi.xml.XML;
 import java.io.IOException;
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -45,11 +49,8 @@ import lombok.ToString;
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @since 0.8
- * @todo #1425:30min Implement MkHook#json() method so it returns a json
- *  object according to the documentation in
- *  https://developer.github.com/v3/repos/hooks/#get-single-hook. Then add
- *  tests for the other fields of json and remove expects exception from
- *  MkHookTest.create().
+ * @todo #1425:30min Finish adding tests for MkHook#json(). Finish making
+ *  MkHooks#create pass the missing attributes to MkHook.
  */
 @Immutable
 @Loggable(Loggable.DEBUG)
@@ -104,6 +105,37 @@ final class MkHook implements Hook {
     }
     @Override
     public JsonObject json() throws IOException {
-        throw new UnsupportedOperationException("#json()");
+        final XML hook = this.storage.xml().nodes(
+            String.format(
+                "//repo[@coords='%s']/hooks/hook[id='%s']",
+                this.coords, this.num
+            )
+        ).get(0);
+        final JsonArrayBuilder events = Json.createArrayBuilder();
+        for (final XML event : hook.nodes("events/child::*")) {
+            // @checkstyle MultipleStringLiteralsCheck (1 line)
+            events.add(event.xpath("name()").get(0));
+        }
+        final JsonObjectBuilder configs = Json.createObjectBuilder();
+        for (final XML config : hook.nodes("configs/child::*")) {
+            configs.add(
+                // @checkstyle MultipleStringLiteralsCheck (1 line)
+                config.xpath("name()").get(0), config.xpath("text()").get(0)
+            );
+        }
+        return Json.createObjectBuilder()
+            .add("id", this.number())
+            .add("url", hook.xpath("url/text()").get(0))
+            .add("test_url", hook.xpath("test_url/text()").get(0))
+            .add("ping_url", hook.xpath("ping_url/text()").get(0))
+            .add("name", hook.xpath("name/text()").get(0))
+            .add("events", events)
+            .add(
+                "active",
+                Boolean.parseBoolean(hook.xpath("active/text()").get(0))
+            ).add("config", configs)
+            .add("updated_at", hook.xpath("updated_at/text()").get(0))
+            .add("created_at", hook.xpath("created_at/text()").get(0))
+            .build();
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkHookTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkHookTest.java
@@ -85,31 +85,12 @@ public final class MkHookTest {
         final MkStorage storage = new MkStorage.InFile();
         final Coordinates coords = new Coordinates.Simple("user/repo");
         storage.apply(
-            new Directives().xpath("/github")
-                .add("repos").add("repo").attr("coords", coords.toString())
-                .add("hooks")
-                .add("hook")
-                .add("id").set(String.valueOf(number)).up()
-                .add("url").set("http://github.com/url").up()
-                .add("test_url").set("http://github.com/test_url").up()
-                .add("ping_url").set("http://github.com/ping_url").up()
-                .add("name").set("testname").up()
-                .add("events")
-                    .add("push").up()
-                    .add("pull_request").up()
-                    .up()
-                .add("active").set("true").up()
-                .add("config")
-                    .add("url").set("http://example.com/webhook").up()
-                    .add("content_type").set("json").up()
-                    .up()
-                .add("updated_at").set("2011-09-06T20:39:23Z").up()
-                .add("created_at").set("2011-09-06T17:26:27Z").up()
+            this.hookDirs(number, coords)
         );
         MatcherAssert.assertThat(
             "Hook json returned wrong id",
-            new MkHook(storage, "login", coords, number).json().getInt("id"),
-            new IsEqual<Integer>(number)
+            new MkHook(storage, "login", coords, number).json().getString("id"),
+            new IsEqual<String>(String.valueOf(number))
         );
     }
 
@@ -124,26 +105,8 @@ public final class MkHookTest {
         final Coordinates coords = new Coordinates.Simple("user/repo");
         final MkStorage storage = new MkStorage.InFile();
         storage.apply(
-            new Directives().xpath("/github")
-                .add("repos").add("repo").attr("coords", coords.toString())
-                .add("hooks")
-                .add("hook")
-                .add("id").set(String.valueOf(number)).up()
+            this.hookDirs(number, coords)
                 .add("url").set(url).up()
-                .add("test_url").set("http://github.com/test_url").up()
-                .add("ping_url").set("http://github.com/ping_url").up()
-                .add("name").set("testname").up()
-                .add("events")
-                    .add("push").up()
-                    .add("pull_request").up()
-                    .up()
-                .add("active").set("true").up()
-                .add("config")
-                    .add("url").set("http://example.com/webhook").up()
-                    .add("content_type").set("json").up()
-                    .up()
-                .add("updated_at").set("2011-09-06T20:39:23Z").up()
-                .add("created_at").set("2011-09-06T17:26:27Z").up()
         );
         MatcherAssert.assertThat(
             "Hook json returned wrong url",
@@ -165,26 +128,8 @@ public final class MkHookTest {
         final Coordinates coords = new Coordinates.Simple("user/repo");
         final MkStorage storage = new MkStorage.InFile();
         storage.apply(
-            new Directives().xpath("/github")
-                .add("repos").add("repo").attr("coords", coords.toString())
-                .add("hooks")
-                .add("hook")
-                .add("id").set(String.valueOf(number)).up()
-                .add("url").set("http://github.com/url").up()
+            this.hookDirs(number, coords)
                 .add("test_url").set(test).up()
-                .add("ping_url").set("http://github.com/ping_url").up()
-                .add("name").set("testname").up()
-                .add("events")
-                    .add("push").up()
-                    .add("pull_request").up()
-                    .up()
-                .add("active").set("true").up()
-                .add("config")
-                    .add("url").set("http://example.com/webhook").up()
-                    .add("content_type").set("json").up()
-                    .up()
-                .add("updated_at").set("2011-09-06T20:39:23Z").up()
-                .add("created_at").set("2011-09-06T17:26:27Z").up()
         );
         MatcherAssert.assertThat(
             "Hook json returned wrong test_url",
@@ -206,26 +151,8 @@ public final class MkHookTest {
         final Coordinates coords = new Coordinates.Simple("user/repo");
         final MkStorage storage = new MkStorage.InFile();
         storage.apply(
-            new Directives().xpath("/github")
-                .add("repos").add("repo").attr("coords", coords.toString())
-                .add("hooks")
-                .add("hook")
-                .add("id").set(String.valueOf(number)).up()
-                .add("url").set("http://github.com/url").up()
-                .add("test_url").set("http://github.com/test_url").up()
+            this.hookDirs(number, coords)
                 .add("ping_url").set(ping).up()
-                .add("name").set("testname").up()
-                .add("events")
-                    .add("push").up()
-                    .add("pull_request").up()
-                    .up()
-                .add("active").set("true").up()
-                .add("config")
-                    .add("url").set("http://example.com/webhook").up()
-                    .add("content_type").set("json").up()
-                    .up()
-                .add("updated_at").set("2011-09-06T20:39:23Z").up()
-                .add("created_at").set("2011-09-06T17:26:27Z").up()
         );
         MatcherAssert.assertThat(
             "Hook json returned wrong ping_url",
@@ -234,5 +161,19 @@ public final class MkHookTest {
             ).json().getString("ping_url"),
             new IsEqual<String>(ping)
         );
+    }
+
+    /**
+     * Directives to build a hook XML that only includes its id.
+     * @param number Hook number
+     * @param coords Repo coords
+     * @return Hook directives
+     */
+    private Directives hookDirs(final int number, final Coordinates coords) {
+        return new Directives().xpath("/github")
+            .add("repos").add("repo").attr("coords", coords.toString())
+            .add("hooks")
+            .add("hook")
+            .add("id").set(String.valueOf(number)).up();
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkHookTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkHookTest.java
@@ -29,14 +29,10 @@
  */
 package com.jcabi.github.mock;
 
-import com.jcabi.aspects.Tv;
 import com.jcabi.github.Coordinates;
-import com.jcabi.github.Hook;
 import com.jcabi.github.Repo;
-import com.jcabi.xml.XML;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.junit.Before;
 import org.junit.Test;
 import org.xembly.Directives;
 
@@ -47,41 +43,53 @@ import org.xembly.Directives;
  * @since 0.42
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class MkHookTest {
-
     /**
-     * Hook to be tested.
+     * Test if {@link MkHook} is being created with the correct number.
+     * @throws Exception If something goes wrong
      */
-    private transient Hook hook;
-
-    /**
-     * XML encapsulated by the hook.
-     */
-    private transient XML xml;
-
-    /**
-     * {@link Repo} for testing.
-     */
-    private transient Repo repo;
-
-    /**
-     * Set up variables for tests.
-     * @throws Exception if something goes wrong
-     */
-    @Before
-    public void setUp() throws Exception {
-        final String login = "paulodamaso";
-        final Coordinates coordinates = new Coordinates.Simple(
-            "jcabi",
-            "jcabi-github"
+    @Test
+    public void createWithCorrectNumber() throws Exception {
+        final int number = 5;
+        MatcherAssert.assertThat(
+            "Hook returned wrong number",
+            new MkHook(null, null, null, number).number(),
+            new IsEqual<Integer>(number)
         );
+    }
+
+    /**
+     * Test if {@link MkHook} is being created with the correct repository.
+     * @throws Exception If something goes wrong
+     */
+    @Test
+    public void createWithCorrectRepo() throws Exception {
         final MkStorage storage = new MkStorage.InFile();
+        final String login = "login";
+        final Coordinates coords = new Coordinates.Simple("user/repo");
+        MatcherAssert.assertThat(
+            "Hook returned wrong repository",
+            new MkHook(storage, login, coords, 0).repo(),
+            new IsEqual<Repo>(new MkRepo(storage, login, coords))
+        );
+    }
+
+    /**
+     * Test if {@link MkHook} is being created with the correct id.
+     * @throws Exception If something goes wrong
+     */
+    @Test
+    public void createWithCorrectId() throws Exception {
+        final int number = 5;
+        final MkStorage storage = new MkStorage.InFile();
+        final Coordinates coords = new Coordinates.Simple("user/repo");
         storage.apply(
             new Directives().xpath("/github")
-                .add("repos").add("repo").attr("coords", coordinates.toString())
+                .add("repos").add("repo").attr("coords", coords.toString())
                 .add("hooks")
                 .add("hook")
-                .add("id").set(String.valueOf(Tv.FIVE)).up()
+                .add("id").set(String.valueOf(number)).up()
                 .add("url").set("http://github.com/url").up()
                 .add("test_url").set("http://github.com/test_url").up()
                 .add("ping_url").set("http://github.com/ping_url").up()
@@ -98,55 +106,10 @@ public final class MkHookTest {
                 .add("updated_at").set("2011-09-06T20:39:23Z").up()
                 .add("created_at").set("2011-09-06T17:26:27Z").up()
         );
-        this.hook =  new MkHook(
-            storage,
-            login,
-            coordinates,
-            Tv.FIVE
-        );
-        this.xml = storage.xml()
-            .nodes(String.format("//hook[id=%s]", Tv.FIVE)).get(0);
-        this.repo = new MkRepo(storage, login, coordinates);
-    }
-
-    /**
-     * Test if {@link MkHook} is being created with the correct number.
-     * @throws Exception If something goes wrong
-     */
-    @Test
-    public void createWithCorrectNumber() throws Exception {
-        MatcherAssert.assertThat(
-            "Hook returned wrong number",
-            new Integer(this.hook.number()),
-            new IsEqual<Integer>(Tv.FIVE)
-        );
-    }
-
-    /**
-     * Test if {@link MkHook} is being created with the correct repository.
-     * @throws Exception If something goes wrong
-     */
-    @Test
-    public void createWithCorrectRepo() throws Exception {
-        MatcherAssert.assertThat(
-            "Hook returned wrong repository",
-            this.hook.repo(),
-            new IsEqual<Repo>(this.repo)
-        );
-    }
-
-    /**
-     * Test if {@link MkHook} is being created with the correct id.
-     * @throws Exception If something goes wrong
-     */
-    @Test
-    public void createWithCorrectId() throws Exception {
         MatcherAssert.assertThat(
             "Hook json returned wrong id",
-            this.hook.json().getInt("id"),
-            new IsEqual<Integer>(
-                Integer.parseInt(this.xml.xpath("id/text()").get(0))
-            )
+            new MkHook(storage, "login", coords, number).json().getInt("id"),
+            new IsEqual<Integer>(number)
         );
     }
 
@@ -156,12 +119,38 @@ public final class MkHookTest {
      */
     @Test
     public void createWithCorrectUrl() throws Exception {
+        final String url = "https://github.com/user/repo/hooks/hook/5";
+        final int number = 5;
+        final Coordinates coords = new Coordinates.Simple("user/repo");
+        final MkStorage storage = new MkStorage.InFile();
+        storage.apply(
+            new Directives().xpath("/github")
+                .add("repos").add("repo").attr("coords", coords.toString())
+                .add("hooks")
+                .add("hook")
+                .add("id").set(String.valueOf(number)).up()
+                .add("url").set(url).up()
+                .add("test_url").set("http://github.com/test_url").up()
+                .add("ping_url").set("http://github.com/ping_url").up()
+                .add("name").set("testname").up()
+                .add("events")
+                    .add("push").up()
+                    .add("pull_request").up()
+                    .up()
+                .add("active").set("true").up()
+                .add("config")
+                    .add("url").set("http://example.com/webhook").up()
+                    .add("content_type").set("json").up()
+                    .up()
+                .add("updated_at").set("2011-09-06T20:39:23Z").up()
+                .add("created_at").set("2011-09-06T17:26:27Z").up()
+        );
         MatcherAssert.assertThat(
             "Hook json returned wrong url",
-            this.hook.json().getString("url"),
-            new IsEqual<String>(
-                this.xml.xpath("url/text()").get(0)
-            )
+            new MkHook(
+                storage, "login", coords, number
+            ).json().getString("url"),
+            new IsEqual<String>(url)
         );
     }
 
@@ -171,12 +160,38 @@ public final class MkHookTest {
      */
     @Test
     public void createWithCorrectTestUrl() throws Exception {
+        final String test = "https://github.com/user/repo/hooks/hook/5";
+        final int number = 5;
+        final Coordinates coords = new Coordinates.Simple("user/repo");
+        final MkStorage storage = new MkStorage.InFile();
+        storage.apply(
+            new Directives().xpath("/github")
+                .add("repos").add("repo").attr("coords", coords.toString())
+                .add("hooks")
+                .add("hook")
+                .add("id").set(String.valueOf(number)).up()
+                .add("url").set("http://github.com/url").up()
+                .add("test_url").set(test).up()
+                .add("ping_url").set("http://github.com/ping_url").up()
+                .add("name").set("testname").up()
+                .add("events")
+                    .add("push").up()
+                    .add("pull_request").up()
+                    .up()
+                .add("active").set("true").up()
+                .add("config")
+                    .add("url").set("http://example.com/webhook").up()
+                    .add("content_type").set("json").up()
+                    .up()
+                .add("updated_at").set("2011-09-06T20:39:23Z").up()
+                .add("created_at").set("2011-09-06T17:26:27Z").up()
+        );
         MatcherAssert.assertThat(
             "Hook json returned wrong test_url",
-            this.hook.json().getString("test_url"),
-            new IsEqual<String>(
-                this.xml.xpath("test_url/text()").get(0)
-            )
+            new MkHook(
+                storage, "login", coords, number
+            ).json().getString("test_url"),
+            new IsEqual<String>(test)
         );
     }
 
@@ -186,12 +201,38 @@ public final class MkHookTest {
      */
     @Test
     public void createWithCorrectPingUrl() throws Exception {
+        final String ping = "https://github.com/user/repo/hooks/hook/5";
+        final int number = 5;
+        final Coordinates coords = new Coordinates.Simple("user/repo");
+        final MkStorage storage = new MkStorage.InFile();
+        storage.apply(
+            new Directives().xpath("/github")
+                .add("repos").add("repo").attr("coords", coords.toString())
+                .add("hooks")
+                .add("hook")
+                .add("id").set(String.valueOf(number)).up()
+                .add("url").set("http://github.com/url").up()
+                .add("test_url").set("http://github.com/test_url").up()
+                .add("ping_url").set(ping).up()
+                .add("name").set("testname").up()
+                .add("events")
+                    .add("push").up()
+                    .add("pull_request").up()
+                    .up()
+                .add("active").set("true").up()
+                .add("config")
+                    .add("url").set("http://example.com/webhook").up()
+                    .add("content_type").set("json").up()
+                    .up()
+                .add("updated_at").set("2011-09-06T20:39:23Z").up()
+                .add("created_at").set("2011-09-06T17:26:27Z").up()
+        );
         MatcherAssert.assertThat(
             "Hook json returned wrong ping_url",
-            this.hook.json().getString("ping_url"),
-            new IsEqual<String>(
-                this.xml.xpath("ping_url/text()").get(0)
-            )
+            new MkHook(
+                storage, "login", coords, number
+            ).json().getString("ping_url"),
+            new IsEqual<String>(ping)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkHookTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkHookTest.java
@@ -33,16 +33,19 @@ import com.jcabi.aspects.Tv;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Hook;
 import com.jcabi.github.Repo;
+import com.jcabi.xml.XML;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Before;
 import org.junit.Test;
+import org.xembly.Directives;
 
 /**
  * Tests for {@link MkHook}.
  * @author Paulo Lobo (pauloeduardolobo@gmail.com)
  * @version $Id$
  * @since 0.42
+ * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
 public final class MkHookTest {
 
@@ -50,6 +53,11 @@ public final class MkHookTest {
      * Hook to be tested.
      */
     private transient Hook hook;
+
+    /**
+     * XML encapsulated by the hook.
+     */
+    private transient XML xml;
 
     /**
      * {@link Repo} for testing.
@@ -68,12 +76,36 @@ public final class MkHookTest {
             "jcabi-github"
         );
         final MkStorage storage = new MkStorage.InFile();
+        storage.apply(
+            new Directives().xpath("/github")
+                .add("repos").add("repo").attr("coords", coordinates.toString())
+                .add("hooks")
+                .add("hook")
+                .add("id").set(String.valueOf(Tv.FIVE)).up()
+                .add("url").set("http://github.com/url").up()
+                .add("test_url").set("http://github.com/test_url").up()
+                .add("ping_url").set("http://github.com/ping_url").up()
+                .add("name").set("testname").up()
+                .add("events")
+                    .add("push").up()
+                    .add("pull_request").up()
+                    .up()
+                .add("active").set("true").up()
+                .add("config")
+                    .add("url").set("http://example.com/webhook").up()
+                    .add("content_type").set("json").up()
+                    .up()
+                .add("updated_at").set("2011-09-06T20:39:23Z").up()
+                .add("created_at").set("2011-09-06T17:26:27Z").up()
+        );
         this.hook =  new MkHook(
             storage,
             login,
             coordinates,
             Tv.FIVE
         );
+        this.xml = storage.xml()
+            .nodes(String.format("//hook[id=%s]", Tv.FIVE)).get(0);
         this.repo = new MkRepo(storage, login, coordinates);
     }
 
@@ -107,12 +139,14 @@ public final class MkHookTest {
      * Test if {@link MkHook} is being created with the correct id.
      * @throws Exception If something goes wrong
      */
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void createWithCorrectId() throws Exception {
         MatcherAssert.assertThat(
             "Hook json returned wrong id",
             this.hook.json().getInt("id"),
-            new IsEqual<Integer>(Tv.FIVE)
+            new IsEqual<Integer>(
+                Integer.parseInt(this.xml.xpath("id/text()").get(0))
+            )
         );
     }
 
@@ -120,13 +154,13 @@ public final class MkHookTest {
      * Test if {@link MkHook} is being created with the correct url.
      * @throws Exception If something goes wrong
      */
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void createWithCorrectUrl() throws Exception {
         MatcherAssert.assertThat(
             "Hook json returned wrong url",
             this.hook.json().getString("url"),
             new IsEqual<String>(
-                "https://api.github.com/repos/jcabi/jcabi-github/hooks/1"
+                this.xml.xpath("url/text()").get(0)
             )
         );
     }
@@ -135,13 +169,13 @@ public final class MkHookTest {
      * Test if {@link MkHook} is being created with the correct test url.
      * @throws Exception If something goes wrong
      */
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void createWithCorrectTestUrl() throws Exception {
         MatcherAssert.assertThat(
             "Hook json returned wrong test_url",
             this.hook.json().getString("test_url"),
             new IsEqual<String>(
-                "https://api.github.com/repos/jcabi/jcabi-github/hooks/1/test"
+                this.xml.xpath("test_url/text()").get(0)
             )
         );
     }
@@ -150,13 +184,13 @@ public final class MkHookTest {
      * Test if {@link MkHook} is being created with the correct ping url.
      * @throws Exception If something goes wrong
      */
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void createWithCorrectPingUrl() throws Exception {
         MatcherAssert.assertThat(
             "Hook json returned wrong ping_url",
             this.hook.json().getString("ping_url"),
             new IsEqual<String>(
-                "https://api.github.com/repos/jcabi/jcabi-github/hooks/1/pings"
+                this.xml.xpath("ping_url/text()").get(0)
             )
         );
     }


### PR DESCRIPTION
This PR is for #1430:
* Implemented `MkHook.json()`
* Enabled some tests
* Left puzzle for adding more tests + fixing `MkHooks.create()`

The mock hook's data will be stored as an XML that mirrors [github's json structure](https://developer.github.com/v3/repos/hooks/#get-single-hook).