### PR TITLE
(#1435) Added support for "events" in Hooks.create()

### DIFF
--- a/src/main/java/com/jcabi/github/Hooks.java
+++ b/src/main/java/com/jcabi/github/Hooks.java
@@ -77,16 +77,17 @@ public interface Hooks {
      * Create new hook.
      * @param name Hook name
      * @param config Configuration for the hook
+     * @param events Events that trigger the hook
      * @param active Actually trigger the hook when the events occur?
      * @return Hook
      * @throws IOException If there is any I/O problem
      * @see <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">Create a hook</a>
-     * @todo #1106:30min Add support for the "events" parameter of the hook
-     *  creation API. It's a list of strings of the names of events which the
-     *  hook will be triggered for.
+     * @todo #1435:30min Support for "events" was added to Hooks.create(). Now add corresponding
+     *  tests for RtHook and MkHook.
+     * @checkstyle ParameterNumberCheck (2 lines)
      */
     Hook create(
         String name, Map<String, String> config,
-        boolean active
+        Iterable<Event> events, boolean active
     ) throws IOException;
 }

--- a/src/main/java/com/jcabi/github/RtHooks.java
+++ b/src/main/java/com/jcabi/github/RtHooks.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Map;
 import javax.json.Json;
+import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonStructure;
@@ -118,20 +119,27 @@ final class RtHooks implements Hooks {
         return new RtHook(this.entry, this.owner, number);
     }
 
+    // @checkstyle ParameterNumberCheck (2 lines)
     @Override
     public Hook create(
         final String name,
         final Map<String, String> config,
+        final Iterable<Event> events,
         final boolean active
     ) throws IOException {
-        final JsonObjectBuilder builder = Json.createObjectBuilder();
+        final JsonObjectBuilder configs = Json.createObjectBuilder();
         for (final Map.Entry<String, String> entr : config.entrySet()) {
-            builder.add(entr.getKey(), entr.getValue());
+            configs.add(entr.getKey(), entr.getValue());
+        }
+        final JsonArrayBuilder evnts = Json.createArrayBuilder();
+        for (final Event event : events) {
+            evnts.add(event.toString());
         }
         final JsonStructure json = Json.createObjectBuilder()
             .add("name", name)
-            .add("config", builder)
+            .add("config", configs)
             .add("active", active)
+            .add("events", evnts)
             .build();
         return this.get(
             this.request.method(Request.POST)

--- a/src/main/java/com/jcabi/github/mock/MkHook.java
+++ b/src/main/java/com/jcabi/github/mock/MkHook.java
@@ -45,8 +45,6 @@ import lombok.ToString;
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @since 0.8
- * @todo #1425:30min Finish adding tests for MkHook#json(). Finish making
- *  MkHooks#create pass the missing attributes to MkHook.
  */
 @Immutable
 @Loggable(Loggable.DEBUG)

--- a/src/main/java/com/jcabi/github/mock/MkHooks.java
+++ b/src/main/java/com/jcabi/github/mock/MkHooks.java
@@ -32,6 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Coordinates;
+import com.jcabi.github.Event;
 import com.jcabi.github.Hook;
 import com.jcabi.github.Hooks;
 import com.jcabi.github.Repo;
@@ -120,11 +121,12 @@ final class MkHooks implements Hooks {
         return new MkHook(this.storage, this.self, this.coords, number);
     }
 
+    // @checkstyle ParameterNumberCheck (2 lines)
     @Override
     public Hook create(
         final String name,
         final Map<String, String> config,
-        final boolean active
+        final Iterable<Event> events, final boolean active
     ) throws IOException {
         this.storage.lock();
         final int number;
@@ -137,7 +139,11 @@ final class MkHooks implements Hooks {
                 .add("id").set(String.valueOf(number)).up()
                 .add("name").set(name).up()
                 .add("active").set(Boolean.toString(active)).up()
-                .add("events").up()
+                .add("events");
+            for (final Event event : events) {
+                dirs.add("event").set(event.toString()).up();
+            }
+            dirs.up()
                 .add("config");
             for (final Map.Entry<String, String> entr : config.entrySet()) {
                 dirs.add(entr.getKey()).set(entr.getValue()).up();

--- a/src/test/java/com/jcabi/github/RtHooksITCase.java
+++ b/src/test/java/com/jcabi/github/RtHooksITCase.java
@@ -32,6 +32,7 @@ package com.jcabi.github;
 import com.jcabi.aspects.Tv;
 import com.jcabi.github.OAuthScope.Scope;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.MatcherAssert;
@@ -163,6 +164,7 @@ public final class RtHooksITCase {
         return repo.hooks().create(
             "web",
             config,
+            Collections.<Event>emptyList(),
             false
         );
     }

--- a/src/test/java/com/jcabi/github/RtHooksTest.java
+++ b/src/test/java/com/jcabi/github/RtHooksTest.java
@@ -166,7 +166,9 @@ public final class RtHooksTest {
             RtHooksTest.repo()
         );
         try {
-            final Hook hook = hooks.create(name, config, true);
+            final Hook hook = hooks.create(
+                name, config, Collections.<Event>emptyList(), true
+            );
             MatcherAssert.assertThat(
                 container.take().method(),
                 Matchers.equalTo(Request.POST)

--- a/src/test/java/com/jcabi/github/mock/MkHooksTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkHooksTest.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github.mock;
 
+import com.jcabi.github.Event;
 import com.jcabi.github.Hook;
 import com.jcabi.github.Hooks;
 import java.util.Collections;
@@ -73,6 +74,7 @@ public final class MkHooksTest {
         final Hook hook = hooks.create(
             HOOK_TYPE,
             Collections.<String, String>emptyMap(),
+            Collections.<Event>emptyList(),
             true
         );
         MatcherAssert.assertThat(
@@ -96,6 +98,7 @@ public final class MkHooksTest {
         final Hook hook = hooks.create(
             HOOK_TYPE,
             Collections.<String, String>emptyMap(),
+            Collections.<Event>emptyList(),
             true
         );
         MatcherAssert.assertThat(
@@ -114,11 +117,13 @@ public final class MkHooksTest {
         hooks.create(
             HOOK_TYPE,
             Collections.<String, String>emptyMap(),
+            Collections.<Event>emptyList(),
             true
         );
         hooks.create(
             HOOK_TYPE,
             Collections.<String, String>emptyMap(),
+            Collections.<Event>emptyList(),
             true
         );
         MatcherAssert.assertThat(
@@ -137,6 +142,7 @@ public final class MkHooksTest {
         final Hook hook = hooks.create(
             HOOK_TYPE,
             Collections.<String, String>emptyMap(),
+            Collections.<Event>emptyList(),
             true
         );
         MatcherAssert.assertThat(


### PR DESCRIPTION
This PR is for #1435:
* Added extra parameter to `Hooks.create()`
* Deleted puzzle for #1309 because we didn't notice that issue was open (it's not in scope)
* Left puzzle to add tests