### PR TITLE
For #1447: Make `JsonNode` return `JsonArray` correctly

### DIFF
--- a/src/main/java/com/jcabi/github/mock/JsonNode.java
+++ b/src/main/java/com/jcabi/github/mock/JsonNode.java
@@ -31,6 +31,7 @@ package com.jcabi.github.mock;
 
 import com.jcabi.xml.XML;
 import javax.json.Json;
+import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import org.w3c.dom.Node;
@@ -39,8 +40,10 @@ import org.w3c.dom.Node;
  * Json node in XML.
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
+ * @author Paulo Lobo (pauloeduardolobo@gmail.com)
  * @version $Id$
  * @since 0.5
+ *
  */
 final class JsonNode {
 
@@ -60,11 +63,7 @@ final class JsonNode {
     /**
      * Fetch JSON object.
      * @return JSON
-     * @todo #1442:30min JsonNode should be smart enough to know when the
-     *  json's attribute is a JsonObject, or a JsonArray. Tests for this
-     *  behavior were already been implemented in JsonNodeTest. Once this is
-     *  fixed, un-ignore MkHookTest.createWithCorrectEvents() and
-     *  JsonNode.convertsXmlToJsonArray() tests.
+     * @checkstyle MultipleStringLiteralsCheck (30 lines)
      */
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public JsonObject json() {
@@ -73,11 +72,19 @@ final class JsonNode {
             final Node node = child.node();
             if (child.nodes("*").isEmpty()) {
                 builder.add(node.getNodeName(), node.getTextContent());
+            } else if (
+                !child.xpath("//@array").isEmpty()
+                    && "true".equals(child.xpath("//@array").get(0))
+            ) {
+                final JsonArrayBuilder bld = Json.createArrayBuilder();
+                for (final XML item : child.nodes("*")) {
+                    bld.add(item.node().getTextContent());
+                }
+                builder.add(node.getNodeName(), bld.build());
             } else {
                 builder.add(node.getNodeName(), new JsonNode(child).json());
             }
         }
         return builder.build();
     }
-
 }

--- a/src/test/java/com/jcabi/github/mock/JsonNodeTest.java
+++ b/src/test/java/com/jcabi/github/mock/JsonNodeTest.java
@@ -35,12 +35,12 @@ import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Test case for {@link JsonNode}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
+ * @author Paulo Lobo (pauloeduardolobo@gmail.com)
  * @version $Id$
  */
 public final class JsonNodeTest {
@@ -71,7 +71,6 @@ public final class JsonNodeTest {
      * @throws Exception If some problem inside
      */
     @Test
-    @Ignore
     public void convertsXmlToJsonArray() throws Exception {
         final XML xml = new XMLDocument(
             // @checkstyle LineLength (1 line)
@@ -80,7 +79,7 @@ public final class JsonNodeTest {
         final JsonObject json = new JsonNode(xml).json();
         MatcherAssert.assertThat(
             json.toString(),
-            new IsEqual<>("{\"users\": [\"Jeff\", \"Bauer\", \"Iko\"]}")
+            new IsEqual<>("{\"users\":[\"Jeff\",\"Bauer\",\"Iko\"]}")
         );
     }
 

--- a/src/test/java/com/jcabi/github/mock/MkHookTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkHookTest.java
@@ -36,7 +36,6 @@ import javax.json.JsonValue;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.hamcrest.core.IsEqual;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.xembly.Directives;
 
@@ -172,13 +171,13 @@ public final class MkHookTest {
      * event names.
      * @throws Exception If something goes wrong
      */
-    @Ignore
     @Test
     public void createWithCorrectEvents() throws Exception {
         final Iterable<String> events = Arrays.asList("event1", "event2");
         final int number = 123;
         final Coordinates coords = new Coordinates.Simple("user/repo");
-        final Directives xml = this.hookDirs(number, coords).add("events");
+        final Directives xml = this.hookDirs(number, coords).add("events")
+            .attr("array", "true");
         events.forEach(e -> xml.add("event").set(e).up());
         final MkStorage storage = new MkStorage.InFile();
         storage.apply(xml);


### PR DESCRIPTION
For #1447:
- Corrected method `JsonNode.json()`
- Removed `@Ignore` from tests and changed tests where needed
