### PR TITLE
For #1086: Get branch by name API

### DIFF
--- a/src/main/java/com/jcabi/github/Branches.java
+++ b/src/main/java/com/jcabi/github/Branches.java
@@ -56,6 +56,7 @@ public interface Branches {
 
     /**
      * Find branches by name.
+     * @param name The name of the branch.
      * @return Branch found by name
      * @see <a href="https://developer.github.com/v3/repos/branches/#get-branch">Get Branch API</a>
      */

--- a/src/main/java/com/jcabi/github/Branches.java
+++ b/src/main/java/com/jcabi/github/Branches.java
@@ -53,4 +53,11 @@ public interface Branches {
      * @see <a href="https://developer.github.com/v3/repos/#list-branches">List Branches API</a>
      */
     Iterable<Branch> iterate();
+
+    /**
+     * Find branches by name.
+     * @return Branch found by name
+     * @see <a href="https://developer.github.com/v3/repos/branches/#get-branch">Get Branch API</a>
+     */
+    Branch find(String name);
 }

--- a/src/main/java/com/jcabi/github/RtBranches.java
+++ b/src/main/java/com/jcabi/github/RtBranches.java
@@ -100,4 +100,9 @@ final class RtBranches implements Branches {
             }
         );
     }
+
+    @Override
+    public Branch find(String name) {
+        throw new UnsupportedOperationException("find(name) not supported");
+    }
 }

--- a/src/main/java/com/jcabi/github/RtBranches.java
+++ b/src/main/java/com/jcabi/github/RtBranches.java
@@ -102,7 +102,7 @@ final class RtBranches implements Branches {
     }
 
     @Override
-    public Branch find(String name) {
+    public Branch find(final String name) {
         throw new UnsupportedOperationException("find(name) not supported");
     }
 }

--- a/src/main/java/com/jcabi/github/mock/MkBranches.java
+++ b/src/main/java/com/jcabi/github/mock/MkBranches.java
@@ -123,6 +123,11 @@ public final class MkBranches implements Branches {
         );
     }
 
+    @Override
+    public Branch find(String name) {
+        throw new UnsupportedOperationException("find(name) not implemented");
+    }
+
     /**
      * Creates a new branch.
      * @param name Name of branch

--- a/src/main/java/com/jcabi/github/mock/MkBranches.java
+++ b/src/main/java/com/jcabi/github/mock/MkBranches.java
@@ -124,7 +124,7 @@ public final class MkBranches implements Branches {
     }
 
     @Override
-    public Branch find(String name) {
+    public Branch find(final String name) {
         throw new UnsupportedOperationException("find(name) not implemented");
     }
 

--- a/src/test/java/com/jcabi/github/RtBranchesTest.java
+++ b/src/test/java/com/jcabi/github/RtBranchesTest.java
@@ -42,6 +42,8 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -101,6 +103,46 @@ public final class RtBranchesTest {
         MatcherAssert.assertThat(
             second.commit().sha(),
             Matchers.equalTo(secondsha)
+        );
+        container.stop();
+    }
+
+    /**
+     * RtBranches can find one branck by name.
+     * @throws Exception if there is any error
+     * @todo #1086:30min Implement find method in Branches implementations,
+     *  according to github get branches API, as seen in
+     *  https://developer.github.com/v3/repos/branches/#get-branch. Then
+     *  uncomment this test;
+     */
+    @Test
+    @Ignore
+    public void findBranch() throws Exception {
+        final String firstname = "first";
+        final String firstsha = "a971b1aca044105897297b87b0b0983a54dd5817";
+        final String secondname = "second";
+        final String secondsha = "5d8dc2acf9c95d0d4e8881eebe04c2f0cbb249ff";
+        final MkAnswer answer = new MkAnswer.Simple(
+            HttpURLConnection.HTTP_OK,
+            Json.createArrayBuilder()
+                .add(branch(firstname, firstsha))
+                .add(branch(secondname, secondsha))
+                .build().toString()
+        );
+        final MkContainer container = new MkGrizzlyContainer()
+            .next(answer)
+            .next(answer)
+            .start(this.resource.port());
+        final RtBranches branches = new RtBranches(
+            new JdkRequest(container.home()),
+            new MkGithub().randomRepo()
+        );
+        MatcherAssert.assertThat(
+            "could not find branch correctly",
+            branches.find("second").commit().sha(),
+            new IsEqual<>(
+                secondsha
+            )
         );
         container.stop();
     }

--- a/src/test/java/com/jcabi/github/RtBranchesTest.java
+++ b/src/test/java/com/jcabi/github/RtBranchesTest.java
@@ -52,6 +52,7 @@ import org.junit.Test;
  *
  * @author Chris Rebert (github@rebertia.com)
  * @version $Id$
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class RtBranchesTest {
 
@@ -118,15 +119,15 @@ public final class RtBranchesTest {
     @Test
     @Ignore
     public void findBranch() throws Exception {
-        final String firstname = "first";
-        final String firstsha = "a971b1aca044105897297b87b0b0983a54dd5817";
-        final String secondname = "second";
-        final String secondsha = "5d8dc2acf9c95d0d4e8881eebe04c2f0cbb249ff";
+        final String thirdname = "third";
+        final String thirdsha = "297b87b0b0983a54dd5817a971b1aca044105897";
+        final String fourthname = "fourth";
+        final String fourthsha = "d0d4e8881eebe04c5d8dc2acf9c952f0cbb249ff";
         final MkAnswer answer = new MkAnswer.Simple(
             HttpURLConnection.HTTP_OK,
             Json.createArrayBuilder()
-                .add(branch(firstname, firstsha))
-                .add(branch(secondname, secondsha))
+                .add(branch(thirdname, thirdsha))
+                .add(branch(fourthname, fourthsha))
                 .build().toString()
         );
         final MkContainer container = new MkGrizzlyContainer()
@@ -139,9 +140,9 @@ public final class RtBranchesTest {
         );
         MatcherAssert.assertThat(
             "could not find branch correctly",
-            branches.find("second").commit().sha(),
+            branches.find(fourthname).commit().sha(),
             new IsEqual<>(
-                secondsha
+                fourthsha
             )
         );
         container.stop();


### PR DESCRIPTION
For #1086:
- Added fake method `find(name)` to `Branches`
- Added test to assert `find(name)` correct behavior
- Left puzzle to implement `find(name)` according to test