### PR TITLE
For #1110: Use MkContainers into try-with-resource blocks.

### DIFF
--- a/src/test/java/com/jcabi/github/RtAssigneesTest.java
+++ b/src/test/java/com/jcabi/github/RtAssigneesTest.java
@@ -64,24 +64,26 @@ public final class RtAssigneesTest {
      */
     @Test
     public void iteratesAssignees() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createArrayBuilder()
-                    .add(RtAssigneesTest.json("octocat"))
-                    .add(RtAssigneesTest.json("dummy"))
-                    .build().toString()
-            )
-        ).start(this.resource.port());
-        final Assignees users = new RtAssignees(
-            new JdkRequest(container.home()),
-            this.repo()
-        );
-        MatcherAssert.assertThat(
-            users.iterate(),
-            Matchers.<User>iterableWithSize(2)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createArrayBuilder()
+                        .add(RtAssigneesTest.json("octocat"))
+                        .add(RtAssigneesTest.json("dummy"))
+                        .build().toString()
+                )
+            ).start(this.resource.port());
+        ) {
+            final Assignees users = new RtAssignees(
+                new JdkRequest(container.home()),
+                this.repo()
+            );
+            MatcherAssert.assertThat(
+                users.iterate(),
+                Matchers.<User>iterableWithSize(2)
+            );
+        }
     }
 
     /**
@@ -90,24 +92,25 @@ public final class RtAssigneesTest {
      */
     @Test
     public void checkUserIsAssigneeForRepo() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_NO_CONTENT,
-                Json.createArrayBuilder()
-                    .add(RtAssigneesTest.json("octocat2"))
-                    .add(RtAssigneesTest.json("dummy"))
-                    .build().toString()
-            )
-        ).start(this.resource.port());
-        final Assignees users = new RtAssignees(
-            new JdkRequest(container.home()),
-            this.repo()
-        );
-        MatcherAssert.assertThat(
-            users.check("octocat2"),
-            Matchers.equalTo(true)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_NO_CONTENT,
+                    Json.createArrayBuilder()
+                        .add(RtAssigneesTest.json("octocat2"))
+                        .add(RtAssigneesTest.json("dummy"))
+                        .build().toString()
+                )
+            ).start(this.resource.port())) {
+            final Assignees users = new RtAssignees(
+                new JdkRequest(container.home()),
+                this.repo()
+            );
+            MatcherAssert.assertThat(
+                users.check("octocat2"),
+                Matchers.equalTo(true)
+            );
+        }
     }
 
     /**
@@ -116,24 +119,26 @@ public final class RtAssigneesTest {
      */
     @Test
     public void checkUserIsNotAssigneeForRepo() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_NOT_FOUND,
-                Json.createArrayBuilder()
-                    .add(RtAssigneesTest.json("octocat3"))
-                    .add(RtAssigneesTest.json("dummy"))
-                    .build().toString()
-            )
-        ).start(this.resource.port());
-        final Assignees users = new RtAssignees(
-            new JdkRequest(container.home()),
-            this.repo()
-        );
-        MatcherAssert.assertThat(
-            users.check("octocat33"),
-            Matchers.equalTo(false)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_NOT_FOUND,
+                    Json.createArrayBuilder()
+                        .add(RtAssigneesTest.json("octocat3"))
+                        .add(RtAssigneesTest.json("dummy"))
+                        .build().toString()
+                )
+            ).start(this.resource.port());
+        ) {
+            final Assignees users = new RtAssignees(
+                new JdkRequest(container.home()),
+                this.repo()
+            );
+            MatcherAssert.assertThat(
+                users.check("octocat33"),
+                Matchers.equalTo(false)
+            );
+        }
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtBlobsTest.java
+++ b/src/test/java/com/jcabi/github/RtBlobsTest.java
@@ -70,15 +70,15 @@ public final class RtBlobsTest {
     public void canCreateBlob() throws Exception {
         final String content = "Content of the blob";
         final String body = blob().toString();
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, body)
-        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body))
-            .start(this.resource.port());
-        final RtBlobs blobs = new RtBlobs(
-            new ApacheRequest(container.home()),
-            repo()
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, body)
+            ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body))
+            .start(this.resource.port())) {
+            final RtBlobs blobs = new RtBlobs(
+                new ApacheRequest(container.home()),
+                repo()
+            );
             final Blob blob = blobs.create(content, "utf-8");
             MatcherAssert.assertThat(
                 container.take().method(),
@@ -88,8 +88,6 @@ public final class RtBlobsTest {
                 new Blob.Smart(blob).url(),
                 Matchers.equalTo("http://localhost/1")
             );
-        } finally {
-            container.stop();
         }
     }
 

--- a/src/test/java/com/jcabi/github/RtCollaboratorsTest.java
+++ b/src/test/java/com/jcabi/github/RtCollaboratorsTest.java
@@ -71,7 +71,7 @@ public final class RtCollaboratorsTest {
      */
     @Test
     public void canIterate() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(
                 HttpURLConnection.HTTP_OK,
                 Json.createArrayBuilder()
@@ -79,16 +79,16 @@ public final class RtCollaboratorsTest {
                     .add(RtCollaboratorsTest.json("dummy"))
                     .build().toString()
             )
-        ).start(this.resource.port());
-        final Collaborators users = new RtCollaborators(
-            new JdkRequest(container.home()),
-            this.repo()
-        );
-        MatcherAssert.assertThat(
-            users.iterate(),
-            Matchers.<User>iterableWithSize(2)
-        );
-        container.stop();
+        ).start(this.resource.port())) {
+            final Collaborators users = new RtCollaborators(
+                new JdkRequest(container.home()),
+                this.repo()
+            );
+            MatcherAssert.assertThat(
+                users.iterate(),
+                Matchers.<User>iterableWithSize(2)
+            );
+        }
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtCommentTest.java
@@ -110,23 +110,21 @@ public final class RtCommentTest {
      */
     @Test
     public void removesComment() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
-        ).start(this.resource.port());
-        final Repo repo = new MkGithub().randomRepo();
-        final Issue issue = repo.issues().create("testing3", "issue3");
-        final RtComment comment = new RtComment(
-            new ApacheRequest(container.home()), issue, 10
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
+            ).start(this.resource.port())) {
+            final Repo repo = new MkGithub().randomRepo();
+            final Issue issue = repo.issues().create("testing3", "issue3");
+            final RtComment comment = new RtComment(
+                new ApacheRequest(container.home()), issue, 10
+            );
             comment.remove();
             final MkQuery query = container.take();
             MatcherAssert.assertThat(
                 query.method(),
                 Matchers.equalTo(Request.DELETE)
             );
-        } finally {
-            container.stop();
         }
     }
 
@@ -137,22 +135,20 @@ public final class RtCommentTest {
     @Test
     public void returnsItsJSon() throws Exception {
         final String body = "{\"body\":\"test5\"}";
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body)
-        ).start(this.resource.port());
-        final Repo repo = new MkGithub().randomRepo();
-        final Issue issue = repo.issues().create("testing4", "issue4");
-        final RtComment comment = new RtComment(
-            new ApacheRequest(container.home()), issue, 10
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body)
+            ).start(this.resource.port())) {
+            final Repo repo = new MkGithub().randomRepo();
+            final Issue issue = repo.issues().create("testing4", "issue4");
+            final RtComment comment = new RtComment(
+                new ApacheRequest(container.home()), issue, 10
+            );
             final JsonObject json = comment.json();
             MatcherAssert.assertThat(
                 json.getString("body"),
                 Matchers.is("test5")
             );
-        } finally {
-            container.stop();
         }
     }
 
@@ -162,24 +158,22 @@ public final class RtCommentTest {
      */
     @Test
     public void patchesComment() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
-        ).start(this.resource.port());
-        final Repo repo = new MkGithub().randomRepo();
-        final Issue issue = repo.issues().create("testing5", "issue5");
-        final RtComment comment = new RtComment(
-            new ApacheRequest(container.home()), issue, 10
-        );
-        final JsonObject jsonPatch = Json.createObjectBuilder()
-            .add("title", "test comment").build();
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
+            ).start(this.resource.port())) {
+            final Repo repo = new MkGithub().randomRepo();
+            final Issue issue = repo.issues().create("testing5", "issue5");
+            final RtComment comment = new RtComment(
+                new ApacheRequest(container.home()), issue, 10
+            );
+            final JsonObject jsonPatch = Json.createObjectBuilder()
+                .add("title", "test comment").build();
             comment.patch(jsonPatch);
             final MkQuery query = container.take();
             MatcherAssert.assertThat(
                 query.method(), Matchers.equalTo(Request.PATCH)
             );
-        } finally {
-            container.stop();
         }
     }
 
@@ -189,22 +183,20 @@ public final class RtCommentTest {
      */
     @Test
     public void givesToString() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
-        ).start(this.resource.port());
-        final Repo repo = new MkGithub().randomRepo();
-        final Issue issue = repo.issues().create("testing6", "issue6");
-        final RtComment comment = new RtComment(
-            new ApacheRequest(container.home()), issue, 10
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
+            ).start(this.resource.port())) {
+            final Repo repo = new MkGithub().randomRepo();
+            final Issue issue = repo.issues().create("testing6", "issue6");
+            final RtComment comment = new RtComment(
+                new ApacheRequest(container.home()), issue, 10
+            );
             final String stringComment = comment.toString();
             MatcherAssert.assertThat(
                 stringComment, Matchers.not(Matchers.isEmptyOrNullString())
             );
             MatcherAssert.assertThat(stringComment, Matchers.endsWith("10"));
-        } finally {
-            container.stop();
         }
     }
 }

--- a/src/test/java/com/jcabi/github/RtCommitTest.java
+++ b/src/test/java/com/jcabi/github/RtCommitTest.java
@@ -63,13 +63,13 @@ public class RtCommitTest {
      */
     @Test
     public final void readsMessage() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                "{\"sha\":\"a0b1c3\",\"commit\":{\"message\":\"hello\"}}"
-            )
-        ).start(this.resource.port());
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "{\"sha\":\"a0b1c3\",\"commit\":{\"message\":\"hello\"}}"
+                )
+            ).start(this.resource.port())) {
             final Commit.Smart commit = new Commit.Smart(
                 new RtCommit(
                     new JdkRequest(container.home()),
@@ -81,8 +81,6 @@ public class RtCommitTest {
                 commit.message(),
                 Matchers.equalTo("hello")
             );
-        } finally {
-            container.stop();
         }
     }
 }

--- a/src/test/java/com/jcabi/github/RtCommitsTest.java
+++ b/src/test/java/com/jcabi/github/RtCommitsTest.java
@@ -66,23 +66,23 @@ public class RtCommitsTest {
      */
     @Test
     public final void createsCommit() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_CREATED,
-                "{\"sha\":\"0abcd89jcabitest\"}"
-            )
-        ).start(this.resource.port());
-        final Commits commits = new RtCommits(
-            new ApacheRequest(container.home()),
-            new MkGithub().randomRepo()
-        );
-        final JsonObject author = Json.createObjectBuilder()
-            .add("name", "Scott").add("email", "scott@gmail.com")
-            .add("date", "2011-06-17T14:53:35-07:00").build();
-        final JsonObject input = Json.createObjectBuilder()
-            .add("message", "initial version")
-            .add("author", author).build();
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_CREATED,
+                    "{\"sha\":\"0abcd89jcabitest\"}"
+                )
+            ).start(this.resource.port())) {
+            final Commits commits = new RtCommits(
+                new ApacheRequest(container.home()),
+                new MkGithub().randomRepo()
+            );
+            final JsonObject author = Json.createObjectBuilder()
+                .add("name", "Scott").add("email", "scott@gmail.com")
+                .add("date", "2011-06-17T14:53:35-07:00").build();
+            final JsonObject input = Json.createObjectBuilder()
+                .add("message", "initial version")
+                .add("author", author).build();
             final Commit newCommit = commits.create(input);
             MatcherAssert.assertThat(
                 newCommit,
@@ -96,8 +96,6 @@ public class RtCommitsTest {
                 newCommit.sha(),
                 Matchers.equalTo("0abcd89jcabitest")
             );
-        } finally {
-            container.stop();
         }
     }
 }

--- a/src/test/java/com/jcabi/github/RtContentTest.java
+++ b/src/test/java/com/jcabi/github/RtContentTest.java
@@ -90,19 +90,18 @@ public final class RtContentTest {
      */
     @Test
     public void patchWithJson() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "response")
-        ).start(this.resource.port());
-        final RtContent content = new RtContent(
-            new ApacheRequest(container.home()),
-            this.repo(),
-            "path"
-        );
-        content.patch(
-            Json.createObjectBuilder().add("patch", "test").build()
-        );
-        final MkQuery query = container.take();
-        try {
+        ).start(this.resource.port())) {
+            final RtContent content = new RtContent(
+                new ApacheRequest(container.home()),
+                this.repo(),
+                "path"
+            );
+            content.patch(
+                Json.createObjectBuilder().add("patch", "test").build()
+            );
+            final MkQuery query = container.take();
             MatcherAssert.assertThat(
                 query.method(),
                 Matchers.equalTo(Request.PATCH)
@@ -111,8 +110,6 @@ public final class RtContentTest {
                 query.body(),
                 Matchers.equalTo("{\"patch\":\"test\"}")
             );
-        } finally {
-            container.stop();
         }
     }
 
@@ -152,15 +149,14 @@ public final class RtContentTest {
     @Test
     public void fetchesRawContent() throws Exception {
         final String raw = "the raw \u20ac";
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, raw)
-        ).start(this.resource.port());
-        final InputStream stream = new RtContent(
-            new ApacheRequest(container.home()),
-            this.repo(),
-            "raw"
-        ).raw();
-        try {
+        ).start(this.resource.port())) {
+            final InputStream stream = new RtContent(
+                new ApacheRequest(container.home()),
+                this.repo(),
+                "raw"
+            ).raw();
             MatcherAssert.assertThat(
                 IOUtils.toString(stream, StandardCharsets.UTF_8),
                 Matchers.is(raw)
@@ -169,9 +165,6 @@ public final class RtContentTest {
                 container.take().headers().get(HttpHeaders.ACCEPT).get(0),
                 Matchers.is("application/vnd.github.v3.raw")
             );
-        } finally {
-            stream.close();
-            container.stop();
         }
     }
 

--- a/src/test/java/com/jcabi/github/RtContentsTest.java
+++ b/src/test/java/com/jcabi/github/RtContentsTest.java
@@ -76,14 +76,14 @@ public final class RtContentsTest {
         final JsonObject body = Json.createObjectBuilder()
             .add("path", path)
             .build();
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body.toString())
-        ).start(this.resource.port());
-        final RtContents contents = new RtContents(
-            new ApacheRequest(container.home()),
-            repo()
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body.toString())
+            ).start(this.resource.port())) {
+            final RtContents contents = new RtContents(
+                new ApacheRequest(container.home()),
+                repo()
+            );
             MatcherAssert.assertThat(
                 contents.readme().path(),
                 Matchers.is(path)
@@ -97,8 +97,6 @@ public final class RtContentsTest {
                 query.body().length(),
                 Matchers.is(0)
             );
-        } finally {
-            container.stop();
         }
     }
 
@@ -113,14 +111,13 @@ public final class RtContentsTest {
         final JsonObject body = Json.createObjectBuilder()
             .add("path", path)
             .build();
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body.toString())
-        ).start(this.resource.port());
-        final RtContents contents = new RtContents(
-            new ApacheRequest(container.home()),
-            repo()
-        );
-        try {
+        ).start(this.resource.port())) {
+            final RtContents contents = new RtContents(
+                new ApacheRequest(container.home()),
+                repo()
+            );
             MatcherAssert.assertThat(
                 contents.readme("test-branch").path(),
                 Matchers.is(path)
@@ -134,8 +131,6 @@ public final class RtContentsTest {
                 query.body(),
                 Matchers.is("{\"ref\":\"test-branch\"}")
             );
-        } finally {
-            container.stop();
         }
     }
 
@@ -153,7 +148,7 @@ public final class RtContentsTest {
             .add("path", path)
             .add("name", name)
             .build();
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(
                 HttpURLConnection.HTTP_OK,
                 Json.createObjectBuilder()
@@ -162,12 +157,11 @@ public final class RtContentsTest {
                     .build().toString()
             )
         ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body.toString()))
-            .start(this.resource.port());
-        final RtContents contents = new RtContents(
-            new ApacheRequest(container.home()),
-            repo()
-        );
-        try {
+            .start(this.resource.port())) {
+            final RtContents contents = new RtContents(
+                new ApacheRequest(container.home()),
+                repo()
+            );
             final Content.Smart smart = new Content.Smart(
                 contents.get(path, "branch1")
             );
@@ -196,8 +190,6 @@ public final class RtContentsTest {
                     "/repos/test/contents/contents/test/file?ref=branch1"
                 )
             );
-        } finally {
-            container.stop();
         }
     }
 
@@ -213,24 +205,23 @@ public final class RtContentsTest {
             .add("path", path)
             .add("name", name)
             .build();
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(
                 HttpURLConnection.HTTP_CREATED,
                 Json.createObjectBuilder().add("content", body)
                     .build().toString()
             )
         ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body.toString()))
-            .start(this.resource.port());
-        final RtContents contents = new RtContents(
-            new ApacheRequest(container.home()),
-            repo()
-        );
-        final JsonObject content = Json.createObjectBuilder()
-            .add("path", path)
-            .add("message", "theMessage")
-            .add("content", "blah")
-            .build();
-        try {
+            .start(this.resource.port())) {
+            final RtContents contents = new RtContents(
+                new ApacheRequest(container.home()),
+                repo()
+            );
+            final JsonObject content = Json.createObjectBuilder()
+                .add("path", path)
+                .add("message", "theMessage")
+                .add("content", "blah")
+                .build();
             final Content.Smart smart = new Content.Smart(
                 contents.create(content)
             );
@@ -250,8 +241,6 @@ public final class RtContentsTest {
                 container.take().uri().toString(),
                 Matchers.endsWith("/repos/test/contents/contents/test/thefile")
             );
-        } finally {
-            container.stop();
         }
     }
 
@@ -263,7 +252,7 @@ public final class RtContentsTest {
      */
     @Test
     public void canDeleteFilesFromRepository() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(
                 HttpURLConnection.HTTP_OK,
                 Json.createObjectBuilder().add(
@@ -273,12 +262,11 @@ public final class RtContentsTest {
                         .build()
                 ).build().toString()
             )
-        ).start(this.resource.port());
-        final RtContents contents = new RtContents(
-            new ApacheRequest(container.home()),
-            repo()
-        );
-        try {
+        ).start(this.resource.port())) {
+            final RtContents contents = new RtContents(
+                new ApacheRequest(container.home()),
+                repo()
+            );
             final RepoCommit commit = contents.remove(
                 Json.createObjectBuilder()
                     .add("path", "to/remove")
@@ -302,8 +290,6 @@ public final class RtContentsTest {
                 query.uri().toString(),
                 Matchers.endsWith("/repos/test/contents/contents/to/remove")
             );
-        } finally {
-            container.stop();
         }
     }
 
@@ -317,15 +303,14 @@ public final class RtContentsTest {
         final JsonObject resp = Json.createObjectBuilder()
             // @checkstyle MultipleStringLiterals (1 line)
             .add("sha", sha).build();
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(
                 HttpURLConnection.HTTP_OK,
                 Json.createObjectBuilder().add("commit", resp)
                     .build().toString()
             )
         ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, resp.toString()))
-            .start(this.resource.port());
-        try {
+            .start(this.resource.port())) {
             final RtContents contents = new RtContents(
                 new ApacheRequest(container.home()),
                 repo()
@@ -353,8 +338,6 @@ public final class RtContentsTest {
                 query.body(),
                 Matchers.equalTo(json.toString())
             );
-        } finally {
-            container.stop();
         }
     }
 
@@ -373,22 +356,19 @@ public final class RtContentsTest {
                 .add("path", ".gitignore")
                 .build()
         ).build();
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body.toString())
         ).next(new MkAnswer.Simple("{\"path\":\"README.md\"}"))
             .next(new MkAnswer.Simple("{\"path\":\".gitignore\"}"))
-            .start(this.resource.port());
-        final RtContents contents = new RtContents(
-            new ApacheRequest(container.home()),
-            repo()
-        );
-        try {
+            .start(this.resource.port())) {
+            final RtContents contents = new RtContents(
+                new ApacheRequest(container.home()),
+                repo()
+            );
             MatcherAssert.assertThat(
                 contents.iterate("dir", "branch2"),
                 Matchers.<Content>iterableWithSize(2)
             );
-        } finally {
-            container.stop();
         }
     }
 

--- a/src/test/java/com/jcabi/github/RtDeployKeyTest.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeyTest.java
@@ -64,24 +64,25 @@ public final class RtDeployKeyTest {
      */
     @Test
     public void canDeleteDeployKey() throws Exception {
+        try (
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(
                 HttpURLConnection.HTTP_NO_CONTENT,
                 ""
             )
-        ).start(this.resource.port());
-        final DeployKey key = new RtDeployKey(
-            new ApacheRequest(container.home()),
-            3,
-            RtDeployKeyTest.repo()
-        );
-        key.remove();
-        final MkQuery query = container.take();
-        MatcherAssert.assertThat(
-            query.method(),
-            Matchers.equalTo(Request.DELETE)
-        );
-        container.stop();
+        ).start(this.resource.port())) {
+            final DeployKey key = new RtDeployKey(
+                new ApacheRequest(container.home()),
+                3,
+                RtDeployKeyTest.repo()
+            );
+            key.remove();
+            final MkQuery query = container.take();
+            MatcherAssert.assertThat(
+                query.method(),
+                Matchers.equalTo(Request.DELETE)
+            );
+        }
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtDeployKeysTest.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeysTest.java
@@ -83,7 +83,7 @@ public final class RtDeployKeysTest {
      */
     @Test
     public void canFetchNonEmptyListOfDeployKeys() throws IOException {
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(
                 HttpURLConnection.HTTP_OK,
                 Json.createArrayBuilder()
@@ -91,9 +91,8 @@ public final class RtDeployKeysTest {
                     .add(key(2))
                     .build().toString()
             )
-        );
-        container.start(this.resource.port());
-        try {
+        )) {
+            container.start(this.resource.port());
             MatcherAssert.assertThat(
                 new RtDeployKeys(
                     new ApacheRequest(container.home()),
@@ -101,8 +100,6 @@ public final class RtDeployKeysTest {
                 ).iterate(),
                 Matchers.<DeployKey>iterableWithSize(2)
             );
-        } finally {
-            container.stop();
         }
     }
 
@@ -132,14 +129,13 @@ public final class RtDeployKeysTest {
     @Test
     public void canCreateDeployKey() throws IOException {
         final int number = 2;
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(
                 HttpURLConnection.HTTP_CREATED,
                 String.format("{\"id\":%d}", number)
             )
-        );
-        container.start(this.resource.port());
-        try {
+        )) {
+            container.start(this.resource.port());
             final DeployKeys keys = new RtDeployKeys(
                 new ApacheRequest(container.home()), RtDeployKeysTest.repo()
             );
@@ -147,8 +143,6 @@ public final class RtDeployKeysTest {
                 keys.create("Title", "Key").number(),
                 Matchers.equalTo(number)
             );
-        } finally {
-            container.stop();
         }
     }
 

--- a/src/test/java/com/jcabi/github/RtEventTest.java
+++ b/src/test/java/com/jcabi/github/RtEventTest.java
@@ -94,24 +94,21 @@ public final class RtEventTest {
      */
     @Test
     public void retrieveEventAsJson() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
+        try (final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(
                 HttpURLConnection.HTTP_OK,
                 "{\"test\":\"events\"}"
             )
-        ).start(this.resource.port());
-        final RtEvent event = new RtEvent(
-            new ApacheRequest(container.home()),
-            this.repo(),
-            3
-        );
-        try {
+        ).start(this.resource.port())) {
+            final RtEvent event = new RtEvent(
+                new ApacheRequest(container.home()),
+                this.repo(),
+                3
+            );
             MatcherAssert.assertThat(
                 event.json().getString("test"),
                 Matchers.equalTo("events")
             );
-        } finally {
-            container.stop();
         }
     }
 

--- a/src/test/java/com/jcabi/github/RtForksTest.java
+++ b/src/test/java/com/jcabi/github/RtForksTest.java
@@ -94,31 +94,32 @@ public final class RtForksTest {
             HttpURLConnection.HTTP_OK,
             fork(organization).toString()
         );
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_ACCEPTED,
-                fork(organization).toString()
-            )
-        ).next(answer).start(this.resource.port());
-        final Repo owner = Mockito.mock(Repo.class);
-        final Coordinates coordinates = new Coordinates.Simple(
-            "test_user", "test_repo"
-        );
-        Mockito.doReturn(coordinates).when(owner).coordinates();
-        final RtForks forks = new RtForks(
-            new JdkRequest(container.home()),
-            owner
-        );
-        final Fork fork = forks.create(organization);
-        MatcherAssert.assertThat(
-            container.take().method(),
-            Matchers.equalTo(Request.POST)
-        );
-        MatcherAssert.assertThat(
-            fork.json().getString(ORGANIZATION),
-            Matchers.equalTo(organization)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_ACCEPTED,
+                    fork(organization).toString()
+                )
+            ).next(answer).start(this.resource.port())) {
+            final Repo owner = Mockito.mock(Repo.class);
+            final Coordinates coordinates = new Coordinates.Simple(
+                "test_user", "test_repo"
+            );
+            Mockito.doReturn(coordinates).when(owner).coordinates();
+            final RtForks forks = new RtForks(
+                new JdkRequest(container.home()),
+                owner
+            );
+            final Fork fork = forks.create(organization);
+            MatcherAssert.assertThat(
+                container.take().method(),
+                Matchers.equalTo(Request.POST)
+            );
+            MatcherAssert.assertThat(
+                fork.json().getString(ORGANIZATION),
+                Matchers.equalTo(organization)
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
For #1110:
- Added try-with-resource blocks to close MkContainers after usage, preventing resource leaks
- Replaced try-catch approach in some classes as it was not safe enough (some methods wasn't being covered)
- Left puzzle to continue this issue