### PR TITLE
For #1204: Add support to lock and unlock

### DIFF
--- a/src/main/java/com/jcabi/github/Issue.java
+++ b/src/main/java/com/jcabi/github/Issue.java
@@ -133,6 +133,23 @@ public interface Issue extends Comparable<Issue>, JsonReadable, JsonPatchable {
     Collection<Reaction> reactions();
 
     /**
+     * Locks the issue.
+     * @param reason Lock reason
+     */
+    void lock(String reason);
+
+    /**
+     * Unlocks the issue.
+     */
+    void unlock();
+
+    /**
+     * The issue conversation is locked?
+     * @return If the issue is locked.
+     */
+    boolean isLocked();
+
+    /**
      * Smart Issue with extra features.
      */
     @Immutable
@@ -539,6 +556,21 @@ public interface Issue extends Comparable<Issue>, JsonReadable, JsonPatchable {
             throw new UnsupportedOperationException(
                 "reactions() not implemented"
             );
+        }
+
+        @Override
+        public void lock(final String reason) {
+            throw new UnsupportedOperationException("lock not implemented");
+        }
+
+        @Override
+        public void unlock() {
+            throw new UnsupportedOperationException("unlock not implemented");
+        }
+
+        @Override
+        public boolean isLocked() {
+            throw new UnsupportedOperationException("isLocked not implemented");
         }
     }
 

--- a/src/main/java/com/jcabi/github/Issue.java
+++ b/src/main/java/com/jcabi/github/Issue.java
@@ -58,6 +58,10 @@ import lombok.ToString;
  * @version $Id$
  * @since 0.1
  * @see <a href="http://developer.github.com/v3/issues/">Issues API</a>
+ * @todo #1204:30min Implement Lock and unlock features to Issue. Lock
+ *  support have already been defined and wired to Issue realizations.
+ *  Now we must implement Lock support on these classes. Do
+ *  not forget to cover these implementations with tests.
  * @checkstyle MultipleStringLiterals (500 lines)
  */
 @Immutable

--- a/src/main/java/com/jcabi/github/RtIssue.java
+++ b/src/main/java/com/jcabi/github/RtIssue.java
@@ -149,6 +149,21 @@ final class RtIssue implements Issue {
     }
 
     @Override
+    public void lock(final String reason) {
+        throw new UnsupportedOperationException("lock not implemented");
+    }
+
+    @Override
+    public void unlock() {
+        throw new UnsupportedOperationException("unlock not implemented");
+    }
+
+    @Override
+    public boolean isLocked() {
+        throw new UnsupportedOperationException("unlock not implemented");
+    }
+
+    @Override
     public JsonObject json() throws IOException {
         return new RtJson(this.request).fetch();
     }

--- a/src/main/java/com/jcabi/github/mock/MkIssue.java
+++ b/src/main/java/com/jcabi/github/mock/MkIssue.java
@@ -249,6 +249,21 @@ final class MkIssue implements Issue {
         throw new UnsupportedOperationException("reactions() not implemented");
     }
 
+    @Override
+    public void lock(final String reason) {
+        throw new UnsupportedOperationException("lock not implemented");
+    }
+
+    @Override
+    public void unlock() {
+        throw new UnsupportedOperationException("unlock not implemented");
+    }
+
+    @Override
+    public boolean isLocked() {
+        throw new UnsupportedOperationException("isLocked not implemented");
+    }
+
     /**
      * XPath of this element in XML tree.
      * @return XPath

--- a/src/main/java/com/jcabi/github/safe/SfIssue.java
+++ b/src/main/java/com/jcabi/github/safe/SfIssue.java
@@ -141,4 +141,19 @@ public final class SfIssue implements Issue {
     public Collection<Reaction> reactions() {
         return this.origin.reactions();
     }
+
+    @Override
+    public void lock(final String reason) {
+        this.origin.lock(reason);
+    }
+
+    @Override
+    public void unlock() {
+        this.origin.unlock();
+    }
+
+    @Override
+    public boolean isLocked() {
+        return this.origin.isLocked();
+    }
 }

--- a/src/test/java/com/jcabi/github/RtIssueITCase.java
+++ b/src/test/java/com/jcabi/github/RtIssueITCase.java
@@ -34,6 +34,7 @@ import com.jcabi.log.Logger;
 import java.util.Date;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -239,6 +240,37 @@ public final class RtIssueITCase {
     public void issueAlwaysExistsInGithub() throws Exception {
         MatcherAssert.assertThat(
             new Issue.Smart(RtIssueITCase.issue()).exists(), Matchers.is(true)
+        );
+    }
+
+    /**
+     * RtIssue can lock conversation.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    @Ignore
+    public void locks() throws Exception {
+        final Issue issue = new Issue.Smart(RtIssueITCase.issue());
+        issue.lock("off-topic");
+        MatcherAssert.assertThat(
+            issue.isLocked(),
+            new IsEqual<>(true)
+        );
+    }
+
+    /**
+     * RtIssue can unlock conversation.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    @Ignore
+    public void unlocks() throws Exception {
+        final Issue issue = new Issue.Smart(RtIssueITCase.issue());
+        issue.lock("too heated");
+        issue.unlock();
+        MatcherAssert.assertThat(
+            issue.isLocked(),
+            new IsEqual<>(false)
         );
     }
 


### PR DESCRIPTION
For #1204:
- Added `lock`, `unlock` and `isLocked` methods to `Issue` interface;
- Added test for lock and unlock methods
- Left todo