### PR TITLE
For #1451: Reactions implementation

### DIFF
--- a/src/main/java/com/jcabi/github/Issue.java
+++ b/src/main/java/com/jcabi/github/Issue.java
@@ -62,6 +62,9 @@ import lombok.ToString;
  *  support have already been defined and wired to Issue realizations.
  *  Now we must implement Lock support on these classes. Do
  *  not forget to cover these implementations with tests.
+ * @todo #1451:30min Resume Reaction implementation on Issues. Resume reaction
+ *  implementation on issues and its realizations. Create the tests to assure
+ *  that the reaction feature is working correctly.
  * @checkstyle MultipleStringLiterals (500 lines)
  */
 @Immutable

--- a/src/main/java/com/jcabi/github/Reaction.java
+++ b/src/main/java/com/jcabi/github/Reaction.java
@@ -36,10 +36,21 @@ package com.jcabi.github;
  * @version $Id$
  * @since 1.0
  * @see <a href="https://developer.github.com/v3/reactions">Reactions API</a>
- * @todo #1230:30min Implement Reactions to Comments and Issues. Reaction
- *  interface ahve already been defined and wired to Comment and Issue
- *  realizations. Now we must implement Reaction support on these classes. Do
- *  not forget to cover these implementations with tests.
+ * @todo #1451:30min Check reaction values. At the moment only a few types of
+ *  reactions are allowed (full list at
+ *  https://developer.github.com/v3/reactions/#reaction-types). Reaction API
+ *  implementation should somehow validate these inputs and do not add an
+ *  invalid reaction to a Comment or Issue
+ * @todo #1451:30min Create reaction values constants in Reaction. As reaction
+ *  values are in a few number they must be created as constants in Reaction.
+ *  Then replace all existing code in tests and application to use the new
+ *  created constants.
+ * @todo #1451:30min Add reaction support to other Github elements.
+ *  Reactions API is supported / implemented by other github elements besides
+ *  Issues and Issue Comments. Add reactions support to all these other items as
+ *  well so jcabi-github can provide full reactions API support. See all
+ *  possible reactions API interactions at
+ *  https://developer.github.com/v3/reactions/
  */
 public interface Reaction {
 

--- a/src/main/java/com/jcabi/github/RtComment.java
+++ b/src/main/java/com/jcabi/github/RtComment.java
@@ -45,6 +45,9 @@ import lombok.EqualsAndHashCode;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.1
+ * @todo #1451:30min Implement react ant reactions methods. Implement react
+ *  and reacts methods according to reactions API
+ *  and then unignore test in RtCommentTest
  */
 @Immutable
 @Loggable(Loggable.DEBUG)

--- a/src/test/java/com/jcabi/github/RtCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtCommentTest.java
@@ -42,6 +42,9 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.hamcrest.core.IsEqual;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -51,6 +54,7 @@ import org.junit.Test;
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiterals (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class RtCommentTest {
 
@@ -173,6 +177,35 @@ public final class RtCommentTest {
             final MkQuery query = container.take();
             MatcherAssert.assertThat(
                 query.method(), Matchers.equalTo(Request.PATCH)
+            );
+        }
+    }
+
+    /**
+     * RtComment can add a reaction.
+     * @throws Exception - if anything goes wrong.
+     */
+    @Test
+    @Ignore
+    public void reacts() throws Exception {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
+            ).start(this.resource.port())) {
+            final Repo repo = new MkGithub().randomRepo();
+            final Issue issue = repo.issues().create(
+                "Reaction adding test", "This is a test for adding a reaction"
+            );
+            final RtComment comment = new RtComment(
+                new ApacheRequest(container.home()), issue, 10
+            );
+            comment.react(new Reaction.Simple("heart"));
+            MatcherAssert.assertThat(
+                "Comment was unable to react",
+                comment.reactions(),
+                new IsCollectionWithSize<>(
+                    new IsEqual<>(1)
+                )
             );
         }
     }


### PR DESCRIPTION
For #1451:
- Implemented test for reaction support by ´RtComent`
- Added puzzles for adding reaction support to `Issue`, complete reaction support in `Comment` and add reaction suport to other elements as github API specifies