### PR TITLE
For #1473: Use try-with-resource on grizzly containers

### DIFF
--- a/src/test/java/com/jcabi/github/RtGistCommentsTest.java
+++ b/src/test/java/com/jcabi/github/RtGistCommentsTest.java
@@ -48,8 +48,6 @@ import org.mockito.Mockito;
  *
  * @author Giang Le (giang@vn-smartsolutions.com)
  * @version $Id$
- * @todo #1461:30min Continue to close grizzle servers open on tests. Use
- *  try-with-resource statement instead of try-catch whenever is possible..
  */
 public final class RtGistCommentsTest {
 

--- a/src/test/java/com/jcabi/github/RtGistsTest.java
+++ b/src/test/java/com/jcabi/github/RtGistsTest.java
@@ -65,17 +65,17 @@ public final class RtGistsTest {
      */
     @Test
     public void canCreateFiles() throws Exception {
+        try (
         final MkContainer container = new MkGrizzlyContainer().next(
             new MkAnswer.Simple(
                 HttpURLConnection.HTTP_CREATED,
                 "{\"id\":\"1\"}"
             )
-        ).start(this.resource.port());
-        final Gists gists = new RtGists(
-            new MkGithub(),
-            new ApacheRequest(container.home())
-        );
-        try {
+        ).start(this.resource.port())) {
+            final Gists gists = new RtGists(
+                new MkGithub(),
+                new ApacheRequest(container.home())
+            );
             MatcherAssert.assertThat(
                 gists.create(Collections.singletonMap("test", ""), false),
                 Matchers.notNullValue()
@@ -84,7 +84,6 @@ public final class RtGistsTest {
                 container.take().body(),
                 Matchers.startsWith("{\"files\":{\"test\":{\"content\":")
             );
-        } finally {
             container.stop();
         }
     }
@@ -96,19 +95,19 @@ public final class RtGistsTest {
      */
     @Test
     public void canRetrieveSpecificGist() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "testing")
-        ).start(this.resource.port());
-        final Gists gists = new RtGists(
-            new MkGithub(),
-            new ApacheRequest(container.home())
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "testing")
+            ).start(this.resource.port())
+        ) {
+            final Gists gists = new RtGists(
+                new MkGithub(),
+                new ApacheRequest(container.home())
+            );
             MatcherAssert.assertThat(
                 gists.get("gist"),
                 Matchers.notNullValue()
             );
-        } finally {
             container.stop();
         }
     }
@@ -120,22 +119,22 @@ public final class RtGistsTest {
      */
     @Test
     public void canIterateThrouRtGists() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                "[{\"id\":\"hello\"}]"
-            )
-        ).start(this.resource.port());
-        final Gists gists = new RtGists(
-            new MkGithub(),
-            new ApacheRequest(container.home())
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "[{\"id\":\"hello\"}]"
+                )
+            ).start(this.resource.port())
+        ) {
+            final Gists gists = new RtGists(
+                new MkGithub(),
+                new ApacheRequest(container.home())
+            );
             MatcherAssert.assertThat(
                 gists.iterate().iterator().next(),
                 Matchers.notNullValue()
             );
-        } finally {
             container.stop();
         }
     }
@@ -145,25 +144,23 @@ public final class RtGistsTest {
      */
     @Test
     public void removesGistByName() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_NO_CONTENT,
-                ""
-            )
-        )
-            .start(this.resource.port());
-        final Gists gists = new RtGists(
-            new MkGithub(),
-            new ApacheRequest(container.home())
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_NO_CONTENT,
+                    ""
+                )
+            ).start(this.resource.port())) {
+            final Gists gists = new RtGists(
+                new MkGithub(),
+                new ApacheRequest(container.home())
+            );
             gists.remove("12234");
             final MkQuery query = container.take();
             MatcherAssert.assertThat(
                 query.method(),
                 Matchers.equalTo(Request.DELETE)
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtGitignoresTest.java
+++ b/src/test/java/com/jcabi/github/RtGitignoresTest.java
@@ -48,6 +48,8 @@ import org.junit.Test;
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/gitignore/">Gitignore API</a>
+ * @todo #1473:30min Continue to close grizzle servers open on tests. Use
+ *  try-with-resource statement instead of try-catch whenever is possible..
  */
 @Immutable
 public final class RtGitignoresTest {


### PR DESCRIPTION
For #1473:
- Replaced `try-catch` with `try-with-resources` in `RtGistCommentTest`, `RtGistTest` and `RtGistsTest`
- Added puzzle to `RtGitignoresTest`
- Removed puzzle from `RtGistCommentsTest`