### PR TITLE
For #1482: Use try-with-resource on grizzly containers

### DIFF
--- a/src/test/java/com/jcabi/github/RtGitignoresTest.java
+++ b/src/test/java/com/jcabi/github/RtGitignoresTest.java
@@ -48,8 +48,6 @@ import org.junit.Test;
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @see <a href="http://developer.github.com/v3/gitignore/">Gitignore API</a>
- * @todo #1473:30min Continue to close grizzle servers open on tests. Use
- *  try-with-resource statement instead of try-catch whenever is possible..
  */
 @Immutable
 public final class RtGitignoresTest {
@@ -66,24 +64,27 @@ public final class RtGitignoresTest {
      */
     @Test
     public void iterateTemplateNames() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createArrayBuilder()
-                    .add("C")
-                    .add("Java")
-                    .build()
-                    .toString()
-            )
-        ).start(this.resource.port());
-        final RtGitignores gitignores = new RtGitignores(
-            new RtGithub(new JdkRequest(container.home()))
-        );
-        MatcherAssert.assertThat(
-            gitignores.iterate(),
-            Matchers.<String>iterableWithSize(2)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createArrayBuilder()
+                        .add("C")
+                        .add("Java")
+                        .build()
+                        .toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtGitignores gitignores = new RtGitignores(
+                    new RtGithub(new JdkRequest(container.home()))
+            );
+            MatcherAssert.assertThat(
+                    gitignores.iterate(),
+                    Matchers.<String>iterableWithSize(2)
+            );
+            container.stop();
+        }
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtHookTest.java
+++ b/src/test/java/com/jcabi/github/RtHookTest.java
@@ -67,13 +67,14 @@ public final class RtHookTest {
      */
     @Test
     public void performsValidRequest() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                "{\"test\":\"hook\"}"
-            )
-        ).start(this.resource.port());
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "{\"test\":\"hook\"}"
+                )
+            ).start(this.resource.port())
+        ) {
             final Hook hook = new RtHook(
                 new ApacheRequest(container.home()),
                 repo(),
@@ -87,7 +88,6 @@ public final class RtHookTest {
                 container.take().uri().toString(),
                 Matchers.endsWith("/repos/test/repo/hooks/1")
             );
-        } finally {
             container.stop();
         }
     }
@@ -99,13 +99,14 @@ public final class RtHookTest {
      */
     @Test
     public void returnsEvents() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                "{ \"id\": 1, \"events\": [ \"push\", \"pull_request\" ] }"
-            )
-        ).start(this.resource.port());
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "{ \"id\": 1, \"events\": [ \"push\", \"pull_request\" ] }"
+                )
+            ).start(this.resource.port())
+        ) {
             MatcherAssert.assertThat(
                 new RtHook(
                     new ApacheRequest(container.home()),
@@ -123,7 +124,6 @@ public final class RtHookTest {
                     )
                 )
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtIssueTest.java
+++ b/src/test/java/com/jcabi/github/RtIssueTest.java
@@ -132,19 +132,20 @@ public final class RtIssueTest {
      */
     @Test
     public void patchWithJson() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "response")
-        ).start(this.resource.port());
-        final RtIssue issue = new RtIssue(
-            new ApacheRequest(container.home()),
-            this.repo(),
-            1
-        );
-        issue.patch(
-            Json.createObjectBuilder().add("patch", "test").build()
-        );
-        final MkQuery query = container.take();
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "response")
+            ).start(this.resource.port())
+        ) {
+            final RtIssue issue = new RtIssue(
+                new ApacheRequest(container.home()),
+                this.repo(),
+                1
+            );
+            issue.patch(
+                Json.createObjectBuilder().add("patch", "test").build()
+            );
+            final MkQuery query = container.take();
             MatcherAssert.assertThat(
                 query.method(),
                 Matchers.equalTo(Request.PATCH)
@@ -153,7 +154,6 @@ public final class RtIssueTest {
                 query.body(),
                 Matchers.equalTo("{\"patch\":\"test\"}")
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtIssuesTest.java
+++ b/src/test/java/com/jcabi/github/RtIssuesTest.java
@@ -70,24 +70,29 @@ public final class RtIssuesTest {
     public void createIssue() throws Exception {
         final String title = "Found a bug";
         final String body = issue(title).toString();
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, body)
-        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body))
-            .start(this.resource.port());
-        final RtIssues issues = new RtIssues(
-            new JdkRequest(container.home()),
-            repo()
-        );
-        final Issue issue = issues.create(title, "having a problem with it.");
-        MatcherAssert.assertThat(
-            container.take().method(),
-            Matchers.equalTo(Request.POST)
-        );
-        MatcherAssert.assertThat(
-            new Issue.Smart(issue).title(),
-            Matchers.equalTo(title)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, body)
+            ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body))
+                .start(this.resource.port())
+        ) {
+            final RtIssues issues = new RtIssues(
+                new JdkRequest(container.home()),
+                repo()
+            );
+            final Issue issue = issues.create(
+                title, "having a problem with it."
+            );
+            MatcherAssert.assertThat(
+                container.take().method(),
+                Matchers.equalTo(Request.POST)
+            );
+            MatcherAssert.assertThat(
+                new Issue.Smart(issue).title(),
+                Matchers.equalTo(title)
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -97,22 +102,25 @@ public final class RtIssuesTest {
     @Test
     public void getSingleIssue() throws Exception {
         final String title = "Unit test";
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                issue(title).toString()
-            )
-        ).start(this.resource.port());
-        final RtIssues issues = new RtIssues(
-            new JdkRequest(container.home()),
-            repo()
-        );
-        final Issue issue = issues.get(1);
-        MatcherAssert.assertThat(
-            new Issue.Smart(issue).title(),
-            Matchers.equalTo(title)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    issue(title).toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtIssues issues = new RtIssues(
+                new JdkRequest(container.home()),
+                repo()
+            );
+            final Issue issue = issues.get(1);
+            MatcherAssert.assertThat(
+                new Issue.Smart(issue).title(),
+                Matchers.equalTo(title)
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -121,24 +129,27 @@ public final class RtIssuesTest {
      */
     @Test
     public void iterateIssues() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createArrayBuilder()
-                    .add(issue("new issue"))
-                    .add(issue("code issue"))
-                    .build().toString()
-            )
-        ).start(this.resource.port());
-        final RtIssues issues = new RtIssues(
-            new JdkRequest(container.home()),
-            repo()
-        );
-        MatcherAssert.assertThat(
-            issues.iterate(new ArrayMap<String, String>()),
-            Matchers.<Issue>iterableWithSize(2)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createArrayBuilder()
+                        .add(issue("new issue"))
+                        .add(issue("code issue"))
+                        .build().toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtIssues issues = new RtIssues(
+                new JdkRequest(container.home()),
+                repo()
+            );
+            MatcherAssert.assertThat(
+                issues.iterate(new ArrayMap<String, String>()),
+                Matchers.<Issue>iterableWithSize(2)
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -147,30 +158,33 @@ public final class RtIssuesTest {
      */
     @Test
     public void searchIssues() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createArrayBuilder()
-                    .add(issue("some issue"))
-                    .add(issue("some other issue"))
-                    .build().toString()
-            )
-        ).start(this.resource.port());
-        final RtIssues issues = new RtIssues(
-            new JdkRequest(container.home()),
-            repo()
-        );
-        MatcherAssert.assertThat(
-            issues.search(
-                Issues.Sort.UPDATED,
-                Search.Order.ASC,
-                new EnumMap<Issues.Qualifier, String>(
-                    Issues.Qualifier.class
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createArrayBuilder()
+                        .add(issue("some issue"))
+                        .add(issue("some other issue"))
+                        .build().toString()
                 )
-            ),
-            Matchers.<Issue>iterableWithSize(2)
-        );
-        container.stop();
+            ).start(this.resource.port())
+        ) {
+            final RtIssues issues = new RtIssues(
+                new JdkRequest(container.home()),
+                repo()
+            );
+            MatcherAssert.assertThat(
+                issues.search(
+                    Issues.Sort.UPDATED,
+                    Search.Order.ASC,
+                    new EnumMap<Issues.Qualifier, String>(
+                        Issues.Qualifier.class
+                    )
+                ),
+                Matchers.<Issue>iterableWithSize(2)
+            );
+            container.stop();
+        }
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtJsonTest.java
+++ b/src/test/java/com/jcabi/github/RtJsonTest.java
@@ -61,15 +61,21 @@ public final class RtJsonTest {
      */
     @Test
     public void sendHttpRequest() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "{\"body\":\"hi\"}")
-        ).start(this.resource.port());
-        final RtJson json = new RtJson(new ApacheRequest(container.home()));
-        MatcherAssert.assertThat(
-            json.fetch().getString("body"),
-            Matchers.equalTo("hi")
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "{\"body\":\"hi\"}"
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtJson json = new RtJson(new ApacheRequest(container.home()));
+            MatcherAssert.assertThat(
+                json.fetch().getString("body"),
+                Matchers.equalTo("hi")
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -79,19 +85,25 @@ public final class RtJsonTest {
      */
     @Test
     public void executePatchRequest() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "{\"body\":\"hj\"}")
-        ).start(this.resource.port());
-        final RtJson json = new RtJson(new ApacheRequest(container.home()));
-        json.patch(
-            Json.createObjectBuilder()
-                .add("content", "hi you!")
-                .build()
-        );
-        MatcherAssert.assertThat(
-            container.take().method(),
-            Matchers.equalTo("PATCH")
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "{\"body\":\"hj\"}"
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtJson json = new RtJson(new ApacheRequest(container.home()));
+            json.patch(
+                Json.createObjectBuilder()
+                    .add("content", "hi you!")
+                    .build()
+            );
+            MatcherAssert.assertThat(
+                container.take().method(),
+                Matchers.equalTo("PATCH")
+            );
+            container.stop();
+        }
     }
 }

--- a/src/test/java/com/jcabi/github/RtLabelTest.java
+++ b/src/test/java/com/jcabi/github/RtLabelTest.java
@@ -64,19 +64,25 @@ public final class RtLabelTest {
      */
     @Test
     public void sendHttpRequestAndWriteResponseAsJson() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "{\"msg\": \"hi\"}")
-        ).start(this.resource.port());
-        final RtLabel label = new RtLabel(
-            new ApacheRequest(container.home()),
-            RtLabelTest.repo(),
-            "bug"
-        );
-        MatcherAssert.assertThat(
-            label.json().getString("msg"),
-            Matchers.equalTo("hi")
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "{\"msg\": \"hi\"}"
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtLabel label = new RtLabel(
+                new ApacheRequest(container.home()),
+                RtLabelTest.repo(),
+                "bug"
+            );
+            MatcherAssert.assertThat(
+                label.json().getString("msg"),
+                Matchers.equalTo("hi")
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -86,24 +92,30 @@ public final class RtLabelTest {
      */
     @Test
     public void executePatchRequest() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "{\"msg\":\"hi\"}")
-        ).start(this.resource.port());
-        final RtLabel label = new RtLabel(
-            new ApacheRequest(container.home()),
-            RtLabelTest.repo(),
-            "enhance"
-        );
-        label.patch(
-            Json.createObjectBuilder()
-                .add("content", "hi you!")
-                .build()
-        );
-        MatcherAssert.assertThat(
-            container.take().method(),
-            Matchers.equalTo(Request.PATCH)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "{\"msg\":\"hi\"}"
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtLabel label = new RtLabel(
+                new ApacheRequest(container.home()),
+                RtLabelTest.repo(),
+                "enhance"
+            );
+            label.patch(
+                Json.createObjectBuilder()
+                    .add("content", "hi you!")
+                    .build()
+            );
+            MatcherAssert.assertThat(
+                container.take().method(),
+                Matchers.equalTo(Request.PATCH)
+            );
+            container.stop();
+        }
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtLabelsTest.java
+++ b/src/test/java/com/jcabi/github/RtLabelsTest.java
@@ -67,28 +67,31 @@ public final class RtLabelsTest {
         final String name = "API";
         final String color = "FFFFFF";
         final String body = label(name, color).toString();
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, body)
-        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body))
-            .start(this.resource.port());
-        final RtLabels labels = new RtLabels(
-            new JdkRequest(container.home()),
-            repo()
-        );
-        final Label label = labels.create(name, color);
-        MatcherAssert.assertThat(
-            container.take().method(),
-            Matchers.equalTo(Request.POST)
-        );
-        MatcherAssert.assertThat(
-            new Label.Smart(label).name(),
-            Matchers.equalTo(name)
-        );
-        MatcherAssert.assertThat(
-            new Label.Smart(label).color(),
-            Matchers.equalTo(color)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, body)
+            ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body))
+                .start(this.resource.port())
+        ) {
+            final RtLabels labels = new RtLabels(
+                new JdkRequest(container.home()),
+                repo()
+            );
+            final Label label = labels.create(name, color);
+            MatcherAssert.assertThat(
+                container.take().method(),
+                Matchers.equalTo(Request.POST)
+            );
+            MatcherAssert.assertThat(
+                new Label.Smart(label).name(),
+                Matchers.equalTo(name)
+            );
+            MatcherAssert.assertThat(
+                new Label.Smart(label).color(),
+                Matchers.equalTo(color)
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -100,22 +103,25 @@ public final class RtLabelsTest {
     public void getSingleLabel() throws Exception {
         final String name = "bug";
         final String color = "f29513";
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                label(name, color).toString()
-            )
-        ).start(this.resource.port());
-        final RtLabels issues = new RtLabels(
-            new JdkRequest(container.home()),
-            repo()
-        );
-        final Label label = issues.get(name);
-        MatcherAssert.assertThat(
-            new Label.Smart(label).color(),
-            Matchers.equalTo(color)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    label(name, color).toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtLabels issues = new RtLabels(
+                new JdkRequest(container.home()),
+                repo()
+            );
+            final Label label = issues.get(name);
+            MatcherAssert.assertThat(
+                new Label.Smart(label).color(),
+                Matchers.equalTo(color)
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -124,24 +130,27 @@ public final class RtLabelsTest {
      */
     @Test
     public void deleteLabel() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
-        ).start(this.resource.port());
-        final RtLabels issues = new RtLabels(
-            new JdkRequest(container.home()),
-            repo()
-        );
-        issues.delete("issue");
-        final MkQuery query = container.take();
-        MatcherAssert.assertThat(
-            query.method(),
-            Matchers.equalTo(Request.DELETE)
-        );
-        MatcherAssert.assertThat(
-            query.body(),
-            Matchers.isEmptyOrNullString()
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
+            ).start(this.resource.port())
+        ) {
+            final RtLabels issues = new RtLabels(
+                new JdkRequest(container.home()),
+                repo()
+            );
+            issues.delete("issue");
+            final MkQuery query = container.take();
+            MatcherAssert.assertThat(
+                query.method(),
+                Matchers.equalTo(Request.DELETE)
+            );
+            MatcherAssert.assertThat(
+                query.body(),
+                Matchers.isEmptyOrNullString()
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -150,24 +159,27 @@ public final class RtLabelsTest {
      */
     @Test
     public void iterateLabels() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createArrayBuilder()
-                    .add(label("new issue", "f29512"))
-                    .add(label("new bug", "f29522"))
-                    .build().toString()
-            )
-        ).start(this.resource.port());
-        final RtLabels labels = new RtLabels(
-            new JdkRequest(container.home()),
-            repo()
-        );
-        MatcherAssert.assertThat(
-            labels.iterate(),
-            Matchers.<Label>iterableWithSize(2)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createArrayBuilder()
+                        .add(label("new issue", "f29512"))
+                        .add(label("new bug", "f29522"))
+                        .build().toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtLabels labels = new RtLabels(
+                new JdkRequest(container.home()),
+                repo()
+            );
+            MatcherAssert.assertThat(
+                labels.iterate(),
+                Matchers.<Label>iterableWithSize(2)
+            );
+            container.stop();
+        }
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtMarkdownTest.java
+++ b/src/test/java/com/jcabi/github/RtMarkdownTest.java
@@ -66,15 +66,16 @@ public final class RtMarkdownTest {
      */
     @Test
     public void returnsJsonOutput() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "{\"a\":\"b\"}")
-                .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML)
-        ).start(this.resource.port());
-        final RtMarkdown markdown = new RtMarkdown(
-            new MkGithub(),
-            new ApacheRequest(container.home())
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "{\"a\":\"b\"}")
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML)
+            ).start(this.resource.port())
+        ) {
+            final RtMarkdown markdown = new RtMarkdown(
+                new MkGithub(),
+                new ApacheRequest(container.home())
+            );
             MatcherAssert.assertThat(
                 markdown.render(
                     Json.createObjectBuilder().add("hello", "world").build()
@@ -85,7 +86,6 @@ public final class RtMarkdownTest {
                 container.take().body(),
                 Matchers.equalTo("{\"hello\":\"world\"}")
             );
-        } finally {
             container.stop();
         }
     }
@@ -97,15 +97,16 @@ public final class RtMarkdownTest {
      */
     @Test
     public void returnsRawOutput() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "Test Output")
-                .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML)
-        ).start(this.resource.port());
-        final RtMarkdown markdown = new RtMarkdown(
-            new MkGithub(),
-            new ApacheRequest(container.home())
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "Test Output")
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML)
+            ).start(this.resource.port())
+        ) {
+            final RtMarkdown markdown = new RtMarkdown(
+                new MkGithub(),
+                new ApacheRequest(container.home())
+            );
             MatcherAssert.assertThat(
                 markdown.raw("Hello World!"),
                 Matchers.equalTo("Test Output")
@@ -114,7 +115,6 @@ public final class RtMarkdownTest {
                 container.take().body(),
                 Matchers.equalTo("Hello World!")
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtMilestonesTest.java
+++ b/src/test/java/com/jcabi/github/RtMilestonesTest.java
@@ -62,10 +62,11 @@ public final class RtMilestonesTest {
      */
     @Test
     public void deleteMilestone() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
-        ).start(this.resource.port());
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
+            ).start(this.resource.port())
+        ) {
             final RtMilestones milestones = new RtMilestones(
                 new ApacheRequest(container.home()),
                 repo()
@@ -75,7 +76,6 @@ public final class RtMilestonesTest {
                 container.take().method(),
                 Matchers.equalTo(Request.DELETE)
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtOrganizationsTest.java
+++ b/src/test/java/com/jcabi/github/RtOrganizationsTest.java
@@ -49,6 +49,8 @@ import org.junit.Test;
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @author Chris Rebert (github@chrisrebert.com)
  * @version $Id$
+ * @todo #1482:30min Continue to close grizzle servers open on tests. Use
+ *  try-with-resource statement instead of try-catch whenever is possible..
  */
 public final class RtOrganizationsTest {
 


### PR DESCRIPTION
For #1482:
- Replaced try-catch-finally with try-with-resources in `RtGitignoresTest`, `RtHookTest`, `RtHooksTest`, `RtIssueTest`, `RtIssuesTest`, `RtJsonTest`, `RtLabelTest`, `RtLabelsTest`, `RtMarkdownTest` and `RtMarkdownTest`
- Left puzzle for continuing implementation