### PR TITLE
For #1487: Use try-with-resource instead try-catch with grizzly.

### DIFF
--- a/src/test/java/com/jcabi/github/RtOrganizationTest.java
+++ b/src/test/java/com/jcabi/github/RtOrganizationTest.java
@@ -83,19 +83,20 @@ public final class RtOrganizationTest {
      */
     @Test
     public void patchWithJson() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "response")
-        ).start(this.resource.port());
-        final RtOrganization org = new RtOrganization(
-            new MkGithub(),
-            new ApacheRequest(container.home()),
-            "testPatch"
-        );
-        org.patch(
-            Json.createObjectBuilder().add("patch", "test").build()
-        );
-        final MkQuery query = container.take();
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "response")
+            ).start(this.resource.port())
+        ) {
+            final RtOrganization org = new RtOrganization(
+                new MkGithub(),
+                new ApacheRequest(container.home()),
+                "testPatch"
+            );
+            org.patch(
+                Json.createObjectBuilder().add("patch", "test").build()
+            );
+            final MkQuery query = container.take();
             MatcherAssert.assertThat(
                 query.method(),
                 Matchers.equalTo(Request.PATCH)
@@ -104,7 +105,6 @@ public final class RtOrganizationTest {
                 query.body(),
                 Matchers.equalTo("{\"patch\":\"test\"}")
             );
-        } finally {
             container.stop();
         }
     }
@@ -145,20 +145,20 @@ public final class RtOrganizationTest {
      */
     @Test
     public void canRepresentAsString() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "blah")
-        ).start(this.resource.port());
-        final RtOrganization org = new RtOrganization(
-            new MkGithub(),
-            new ApacheRequest(container.home()),
-            "testToString"
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "blah")
+            ).start(this.resource.port())
+        ) {
+            final RtOrganization org = new RtOrganization(
+                new MkGithub(),
+                new ApacheRequest(container.home()),
+                "testToString"
+            );
             MatcherAssert.assertThat(
                 org.toString(),
                 Matchers.endsWith("/orgs/testToString")
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtOrganizationsTest.java
+++ b/src/test/java/com/jcabi/github/RtOrganizationsTest.java
@@ -49,8 +49,6 @@ import org.junit.Test;
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @author Chris Rebert (github@chrisrebert.com)
  * @version $Id$
- * @todo #1482:30min Continue to close grizzle servers open on tests. Use
- *  try-with-resource statement instead of try-catch whenever is possible..
  */
 public final class RtOrganizationsTest {
 
@@ -68,10 +66,11 @@ public final class RtOrganizationsTest {
      */
     @Test
     public void fetchesSingleOrganization() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
-        ).start(this.resource.port());
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
+            ).start(this.resource.port())
+        ) {
             final Organizations orgs = new RtOrganizations(
                 new MkGithub(),
                 new ApacheRequest(container.home())
@@ -80,7 +79,6 @@ public final class RtOrganizationsTest {
                 orgs.get("org"),
                 Matchers.notNullValue()
             );
-        } finally {
             container.stop();
         }
     }
@@ -95,17 +93,18 @@ public final class RtOrganizationsTest {
     @Test
     public void retrievesOrganizations() throws Exception {
         final Github github = new MkGithub();
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createArrayBuilder()
-                    .add(org(1, "org1"))
-                    .add(org(2, "org2"))
-                    .add(org(3, "org3"))
-                    .build().toString()
-            )
-        ).start(this.resource.port());
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createArrayBuilder()
+                        .add(org(1, "org1"))
+                        .add(org(2, "org2"))
+                        .add(org(3, "org3"))
+                        .build().toString()
+                )
+            ).start(this.resource.port())
+        ) {
             final Organizations orgs = new RtOrganizations(
                 github,
                 new ApacheRequest(container.home())
@@ -118,7 +117,6 @@ public final class RtOrganizationsTest {
                 container.take().uri().toString(),
                 Matchers.endsWith("/user/orgs")
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtPaginationTest.java
+++ b/src/test/java/com/jcabi/github/RtPaginationTest.java
@@ -65,30 +65,37 @@ public final class RtPaginationTest {
      */
     @Test
     public void jumpNextPage() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            RtPaginationTest.simple("Hi Jeff")
-                .withHeader("Link", "</s?page=3&per_page=100>; rel=\"next\"")
-        ).next(RtPaginationTest.simple("Hi Mark"))
-            .start(this.resource.port());
-        final Request request = new ApacheRequest(container.home());
-        final RtPagination<JsonObject> page = new RtPagination<JsonObject>(
-            request, new RtValuePagination.Mapping<JsonObject, JsonObject>() {
-                @Override
-                public JsonObject map(final JsonObject object) {
-                    return object;
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                RtPaginationTest.simple("Hi Jeff")
+                    .withHeader(
+                        "Link",
+                        "</s?page=3&per_page=100>; rel=\"next\""
+                    )
+            ).next(RtPaginationTest.simple("Hi Mark"))
+            .start(this.resource.port())
+        ) {
+            final Request request = new ApacheRequest(container.home());
+            final RtPagination<JsonObject> page = new RtPagination<JsonObject>(
+                request,
+                new RtValuePagination.Mapping<JsonObject, JsonObject>() {
+                    @Override
+                    public JsonObject map(final JsonObject object) {
+                        return object;
+                    }
                 }
-            }
-        );
-        final Iterator<JsonObject> iterator = page.iterator();
-        MatcherAssert.assertThat(
-            iterator.next().toString(),
-            Matchers.containsString("Jeff")
-        );
-        MatcherAssert.assertThat(
-            iterator.next().toString(),
-            Matchers.containsString("Mark")
-        );
-        container.stop();
+            );
+            final Iterator<JsonObject> iterator = page.iterator();
+            MatcherAssert.assertThat(
+                iterator.next().toString(),
+                Matchers.containsString("Jeff")
+            );
+            MatcherAssert.assertThat(
+                iterator.next().toString(),
+                Matchers.containsString("Mark")
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -98,9 +105,10 @@ public final class RtPaginationTest {
      */
     @Test(expected = NoSuchElementException.class)
     public void throwsIfNoMoreElement() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer()
-            .next(simple("Hi there")).start(this.resource.port());
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer()
+                .next(simple("Hi there")).start(this.resource.port())
+        ) {
             final Request request = new ApacheRequest(container.home());
             final RtPagination<JsonObject> page = new RtPagination<JsonObject>(
                 request,
@@ -117,7 +125,6 @@ public final class RtPaginationTest {
                 iterator.next(),
                 Matchers.notNullValue()
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtPublicKeysTest.java
+++ b/src/test/java/com/jcabi/github/RtPublicKeysTest.java
@@ -66,24 +66,27 @@ public final class RtPublicKeysTest {
      */
     @Test
     public void retrievesKeys() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createArrayBuilder()
-                    .add(key(1))
-                    .add(key(2))
-                    .build().toString()
-            )
-        ).start(this.resource.port());
-        final RtPublicKeys keys = new RtPublicKeys(
-            new ApacheRequest(container.home()),
-            Mockito.mock(User.class)
-        );
-        MatcherAssert.assertThat(
-            keys.iterate(),
-            Matchers.<PublicKey>iterableWithSize(2)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createArrayBuilder()
+                        .add(key(1))
+                        .add(key(2))
+                        .build().toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtPublicKeys keys = new RtPublicKeys(
+                new ApacheRequest(container.home()),
+                Mockito.mock(User.class)
+            );
+            MatcherAssert.assertThat(
+                keys.iterate(),
+                Matchers.<PublicKey>iterableWithSize(2)
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -93,22 +96,22 @@ public final class RtPublicKeysTest {
      */
     @Test
     public void canFetchSingleKey() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                ""
-            )
-        ).start(this.resource.port());
-        final RtPublicKeys keys = new RtPublicKeys(
-            new ApacheRequest(container.home()),
-            Mockito.mock(User.class)
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    ""
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtPublicKeys keys = new RtPublicKeys(
+                new ApacheRequest(container.home()),
+                Mockito.mock(User.class)
+            );
             MatcherAssert.assertThat(
                 keys.get(1),
                 Matchers.notNullValue()
             );
-        } finally {
             container.stop();
         }
     }
@@ -120,17 +123,18 @@ public final class RtPublicKeysTest {
      */
     @Test
     public void canRemoveKey() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_NO_CONTENT,
-                ""
-            )
-        ).start(this.resource.port());
-        final RtPublicKeys keys = new RtPublicKeys(
-            new ApacheRequest(container.home()),
-            Mockito.mock(User.class)
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_NO_CONTENT,
+                    ""
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtPublicKeys keys = new RtPublicKeys(
+                new ApacheRequest(container.home()),
+                Mockito.mock(User.class)
+            );
             keys.remove(1);
             final MkQuery query = container.take();
             MatcherAssert.assertThat(
@@ -141,7 +145,6 @@ public final class RtPublicKeysTest {
                 query.method(),
                 Matchers.equalTo(Request.DELETE)
             );
-        } finally {
             container.stop();
         }
     }
@@ -152,12 +155,13 @@ public final class RtPublicKeysTest {
      */
     @Test
     public void canCreatePublicKey() throws IOException {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_CREATED, key(1).toString()
-            )
-        ).start(this.resource.port());
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_CREATED, key(1).toString()
+                )
+            ).start(this.resource.port())
+        ) {
             final RtPublicKeys keys = new RtPublicKeys(
                 new ApacheRequest(container.home()),
                 Mockito.mock(User.class)
@@ -177,7 +181,6 @@ public final class RtPublicKeysTest {
                     "{\"title\":\"theTitle\",\"key\":\"theKey\"}"
                 )
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtPublicMembersTest.java
+++ b/src/test/java/com/jcabi/github/RtPublicMembersTest.java
@@ -115,11 +115,12 @@ public final class RtPublicMembersTest {
      */
     @Test
     public void concealsMembers() throws IOException {
-        final MkContainer container = new MkGrizzlyContainer()
+        try (
+            final MkContainer container = new MkGrizzlyContainer()
             .next(new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT))
             .next(new MkAnswer.Simple(HttpURLConnection.HTTP_INTERNAL_ERROR))
-            .start(this.resource.port());
-        try {
+            .start(this.resource.port())
+        ) {
             final RtPublicMembers members = new RtPublicMembers(
                 new ApacheRequest(container.home()),
                 organization()
@@ -140,7 +141,6 @@ public final class RtPublicMembersTest {
             );
             this.thrown.expect(AssertionError.class);
             members.conceal(user());
-        } finally {
             container.stop();
         }
     }
@@ -152,11 +152,11 @@ public final class RtPublicMembersTest {
      */
     @Test
     public void publicizesMembers() throws IOException {
-        final MkContainer container = new MkGrizzlyContainer()
+        try (MkContainer container = new MkGrizzlyContainer()
             .next(new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT))
             .next(new MkAnswer.Simple(HttpURLConnection.HTTP_INTERNAL_ERROR))
-            .start(this.resource.port());
-        try {
+            .start(this.resource.port())
+        ) {
             final RtPublicMembers members = new RtPublicMembers(
                 new ApacheRequest(container.home()),
                 organization()
@@ -173,7 +173,6 @@ public final class RtPublicMembersTest {
             );
             this.thrown.expect(AssertionError.class);
             members.publicize(user());
-        } finally {
             container.stop();
         }
     }
@@ -185,13 +184,16 @@ public final class RtPublicMembersTest {
      */
     @Test
     public void checkPublicMembership() throws IOException {
-        final MkContainer container = new MkGrizzlyContainer()
-            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_NOT_FOUND))
-            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_NOT_FOUND))
-            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT))
-            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_INTERNAL_ERROR))
-            .start(this.resource.port());
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer()
+                .next(new MkAnswer.Simple(HttpURLConnection.HTTP_NOT_FOUND))
+                .next(new MkAnswer.Simple(HttpURLConnection.HTTP_NOT_FOUND))
+                .next(new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT))
+                .next(
+                    new MkAnswer.Simple(HttpURLConnection.HTTP_INTERNAL_ERROR)
+                )
+                .start(this.resource.port())
+        ) {
             final RtPublicMembers members = new RtPublicMembers(
                 new ApacheRequest(container.home()),
                 organization()
@@ -216,7 +218,6 @@ public final class RtPublicMembersTest {
             );
             this.thrown.expect(AssertionError.class);
             members.contains(user());
-        } finally {
             container.stop();
         }
     }
@@ -227,16 +228,17 @@ public final class RtPublicMembersTest {
      */
     @Test
     public void iteratesPublicMembers() throws IOException {
-        final MkContainer container = new MkGrizzlyContainer()
-            .next(
-                new MkAnswer.Simple(
-                    HttpURLConnection.HTTP_OK,
-                    "[{\"login\":\"octobat\"}]"
-                )
-        )
+        try (
+            final MkContainer container = new MkGrizzlyContainer()
+                .next(
+                    new MkAnswer.Simple(
+                        HttpURLConnection.HTTP_OK,
+                        "[{\"login\":\"octobat\"}]"
+                    )
+            )
             .next(new MkAnswer.Simple(HttpURLConnection.HTTP_INTERNAL_ERROR))
-            .start(this.resource.port());
-        try {
+            .start(this.resource.port())
+        ) {
             final RtPublicMembers members = new RtPublicMembers(
                 new ApacheRequest(container.home()),
                 organization()
@@ -253,7 +255,6 @@ public final class RtPublicMembersTest {
             );
             this.thrown.expect(AssertionError.class);
             members.iterate().iterator().next();
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtPullCommentTest.java
+++ b/src/test/java/com/jcabi/github/RtPullCommentTest.java
@@ -95,14 +95,15 @@ public final class RtPullCommentTest {
     @Test
     public void canDescribeAsJson() throws Exception {
         final String body = "{\"body\":\"test\"}";
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body)
-        ).start(this.resource.port());
-        final Pull pull = Mockito.mock(Pull.class);
-        Mockito.doReturn(repo()).when(pull).repo();
-        final RtPullComment comment =
-            new RtPullComment(new ApacheRequest(container.home()), pull, 1);
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body)
+            ).start(this.resource.port())
+        ) {
+            final Pull pull = Mockito.mock(Pull.class);
+            Mockito.doReturn(repo()).when(pull).repo();
+            final RtPullComment comment =
+                new RtPullComment(new ApacheRequest(container.home()), pull, 1);
             final JsonObject json = comment.json();
             MatcherAssert.assertThat(
                 json.getString("body"),
@@ -112,7 +113,6 @@ public final class RtPullCommentTest {
                 container.take().uri().toString(),
                 Matchers.endsWith("/repos/joe/blueharvest/pulls/comments/1")
             );
-        } finally {
             container.stop();
         }
     }
@@ -123,14 +123,15 @@ public final class RtPullCommentTest {
      */
     @Test
     public void patchesComment() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
-        ).start(this.resource.port());
-        final Pull pull = Mockito.mock(Pull.class);
-        Mockito.doReturn(repo()).when(pull).repo();
-        final RtPullComment comment =
-            new RtPullComment(new ApacheRequest(container.home()), pull, 2);
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "")
+            ).start(this.resource.port())
+        ) {
+            final Pull pull = Mockito.mock(Pull.class);
+            Mockito.doReturn(repo()).when(pull).repo();
+            final RtPullComment comment =
+                new RtPullComment(new ApacheRequest(container.home()), pull, 2);
             final JsonObject json = Json.createObjectBuilder()
                 .add("body", "test comment").build();
             comment.patch(json);
@@ -146,7 +147,6 @@ public final class RtPullCommentTest {
                 query.uri().toString(),
                 Matchers.endsWith("/repos/joe/blueharvest/pulls/comments/2")
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtPullCommentsTest.java
+++ b/src/test/java/com/jcabi/github/RtPullCommentsTest.java
@@ -92,16 +92,17 @@ public final class RtPullCommentsTest {
     public void iteratesRepoPullComments() throws Exception {
         final Pull pull = Mockito.mock(Pull.class);
         Mockito.doReturn(repo()).when(pull).repo();
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createArrayBuilder()
-                    .add(comment("comment 1"))
-                    .add(comment("comment 2"))
-                    .build().toString()
-            )
-        ).start(this.resource.port());
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createArrayBuilder()
+                        .add(comment("comment 1"))
+                        .add(comment("comment 2"))
+                        .build().toString()
+                )
+            ).start(this.resource.port())
+        ) {
             final RtPullComments comments = new RtPullComments(
                 new JdkRequest(container.home()), pull
             );
@@ -109,7 +110,6 @@ public final class RtPullCommentsTest {
                 comments.iterate(Collections.<String, String>emptyMap()),
                 Matchers.<PullComment>iterableWithSize(2)
             );
-        } finally {
             container.stop();
         }
     }
@@ -123,16 +123,17 @@ public final class RtPullCommentsTest {
     public void iteratesPullRequestComments() throws Exception {
         final Pull pull = Mockito.mock(Pull.class);
         Mockito.doReturn(repo()).when(pull).repo();
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createArrayBuilder()
-                    .add(comment("comment 3"))
-                    .add(comment("comment 4"))
-                    .build().toString()
-            )
-        ).start(this.resource.port());
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createArrayBuilder()
+                        .add(comment("comment 3"))
+                        .add(comment("comment 4"))
+                        .build().toString()
+                )
+            ).start(this.resource.port())
+        ) {
             final RtPullComments comments = new RtPullComments(
                 new JdkRequest(container.home()), pull
             );
@@ -140,7 +141,6 @@ public final class RtPullCommentsTest {
                 comments.iterate(1, Collections.<String, String>emptyMap()),
                 Matchers.<PullComment>iterableWithSize(2)
             );
-        } finally {
             container.stop();
         }
     }
@@ -158,17 +158,18 @@ public final class RtPullCommentsTest {
         final String path = "test-path";
         final int position = 4;
         final String response = pulls(body, commit, path, position).toString();
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, response)
-        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, response))
-            .start(this.resource.port());
-        final Pull pull = Mockito.mock(Pull.class);
-        Mockito.doReturn(repo()).when(pull).repo();
-        final RtPullComments pullComments = new RtPullComments(
-            new ApacheRequest(container.home()),
-                pull
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, response)
+            ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, response))
+                .start(this.resource.port())
+        ) {
+            final Pull pull = Mockito.mock(Pull.class);
+            Mockito.doReturn(repo()).when(pull).repo();
+            final RtPullComments pullComments = new RtPullComments(
+                new ApacheRequest(container.home()),
+                    pull
+            );
             final PullComment pullComment = pullComments.post(
                 body, commit, path, position
             );
@@ -180,7 +181,6 @@ public final class RtPullCommentsTest {
                 new PullComment.Smart(pullComment).commitId(),
                 Matchers.equalTo(commit)
             );
-        } finally {
             container.stop();
         }
     }
@@ -201,17 +201,18 @@ public final class RtPullCommentsTest {
             .add("in_reply_to", number)
             .build()
             .toString();
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, response)
-        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, response))
-            .start(this.resource.port());
-        final Pull pull = Mockito.mock(Pull.class);
-        Mockito.doReturn(repo()).when(pull).repo();
-        final RtPullComments pullComments = new RtPullComments(
-            new ApacheRequest(container.home()),
-                pull
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, response)
+            ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, response))
+                .start(this.resource.port())
+        ) {
+            final Pull pull = Mockito.mock(Pull.class);
+            Mockito.doReturn(repo()).when(pull).repo();
+            final RtPullComments pullComments = new RtPullComments(
+                new ApacheRequest(container.home()),
+                    pull
+            );
             final PullComment pullComment = pullComments.reply(
                 body, number
             );
@@ -223,7 +224,6 @@ public final class RtPullCommentsTest {
                 new PullComment.Smart(pullComment).reply(),
                 Matchers.equalTo(number)
             );
-        } finally {
             container.stop();
         }
     }
@@ -235,15 +235,16 @@ public final class RtPullCommentsTest {
      */
     @Test
     public void removesPullComment() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
-        ).start(this.resource.port());
-        final Pull pull = Mockito.mock(Pull.class);
-        final Repo repository = repo();
-        Mockito.doReturn(repository).when(pull).repo();
-        final RtPullComments comments =
-            new RtPullComments(new ApacheRequest(container.home()), pull);
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
+            ).start(this.resource.port())
+        ) {
+            final Pull pull = Mockito.mock(Pull.class);
+            final Repo repository = repo();
+            Mockito.doReturn(repository).when(pull).repo();
+            final RtPullComments comments =
+                new RtPullComments(new ApacheRequest(container.home()), pull);
             comments.remove(2);
             final MkQuery query = container.take();
             MatcherAssert.assertThat(
@@ -258,7 +259,6 @@ public final class RtPullCommentsTest {
                     )
                 )
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtPullTest.java
+++ b/src/test/java/com/jcabi/github/RtPullTest.java
@@ -76,23 +76,23 @@ public final class RtPullTest {
      */
     @Test
     public void fetchesCommits() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                "[{\"commits\":\"test\"}]"
-            )
-        ).start(this.resource.port());
-        final RtPull pull = new RtPull(
-            new ApacheRequest(container.home()),
-            this.repo(),
-            1
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "[{\"commits\":\"test\"}]"
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtPull pull = new RtPull(
+                new ApacheRequest(container.home()),
+                this.repo(),
+                1
+            );
             MatcherAssert.assertThat(
                 pull.commits(),
                 Matchers.notNullValue()
             );
-        } finally {
             container.stop();
         }
     }
@@ -104,23 +104,23 @@ public final class RtPullTest {
      */
     @Test
     public void fetchesFiles() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                "[{\"file1\":\"testFile\"}]"
-            )
-        ).start(this.resource.port());
-        final RtPull pull = new RtPull(
-            new ApacheRequest(container.home()),
-            this.repo(),
-            2
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "[{\"file1\":\"testFile\"}]"
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtPull pull = new RtPull(
+                new ApacheRequest(container.home()),
+                this.repo(),
+                2
+            );
             MatcherAssert.assertThat(
                 pull.files().iterator().next().getString("file1"),
                 Matchers.equalTo("testFile")
             );
-        } finally {
             container.stop();
         }
     }
@@ -133,27 +133,28 @@ public final class RtPullTest {
     public void fetchesBase() throws IOException {
         final String ref = "sweet-feature-branch";
         final String sha = "e93c6a2216c69daa574abc16e7c14767fce44ad6";
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createObjectBuilder()
-                    .add(
-                        "base",
-                        Json.createObjectBuilder()
-                            .add(RtPullTest.REF_PROP, ref)
-                            .add(RtPullTest.SHA_PROP, sha)
-                            .build()
-                    )
-                    .build()
-                    .toString()
-            )
-        ).start(this.resource.port());
-        final RtPull pull = new RtPull(
-            new ApacheRequest(container.home()),
-            this.repo(),
-            1
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createObjectBuilder()
+                        .add(
+                            "base",
+                            Json.createObjectBuilder()
+                                .add(RtPullTest.REF_PROP, ref)
+                                .add(RtPullTest.SHA_PROP, sha)
+                                .build()
+                        )
+                        .build()
+                        .toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtPull pull = new RtPull(
+                new ApacheRequest(container.home()),
+                this.repo(),
+                1
+            );
             final PullRef base = pull.base();
             MatcherAssert.assertThat(
                 base,
@@ -167,7 +168,6 @@ public final class RtPullTest {
                 base.sha(),
                 Matchers.equalTo(sha)
             );
-        } finally {
             container.stop();
         }
     }
@@ -180,27 +180,28 @@ public final class RtPullTest {
     public void fetchesHead() throws IOException {
         final String ref = "neat-other-branch";
         final String sha = "9c717b4716e4fc4d917f546e8e6b562e810e3922";
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createObjectBuilder()
-                    .add(
-                        "head",
-                        Json.createObjectBuilder()
-                            .add(RtPullTest.REF_PROP, ref)
-                            .add(RtPullTest.SHA_PROP, sha)
-                            .build()
-                    )
-                    .build()
-                    .toString()
-            )
-        ).start(this.resource.port());
-        final RtPull pull = new RtPull(
-            new ApacheRequest(container.home()),
-            this.repo(),
-            1
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createObjectBuilder()
+                        .add(
+                            "head",
+                            Json.createObjectBuilder()
+                                .add(RtPullTest.REF_PROP, ref)
+                                .add(RtPullTest.SHA_PROP, sha)
+                                .build()
+                        )
+                        .build()
+                        .toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtPull pull = new RtPull(
+                new ApacheRequest(container.home()),
+                this.repo(),
+                1
+            );
             final PullRef head = pull.head();
             MatcherAssert.assertThat(
                 head,
@@ -214,7 +215,6 @@ public final class RtPullTest {
                 head.sha(),
                 Matchers.equalTo(sha)
             );
-        } finally {
             container.stop();
         }
     }
@@ -226,16 +226,17 @@ public final class RtPullTest {
      */
     @Test
     public void executeMerge() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "testMerge")
-        ).start(this.resource.port());
-        final RtPull pull = new RtPull(
-            new ApacheRequest(container.home()),
-            this.repo(),
-            3
-        );
-        pull.merge("Test commit.");
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "testMerge")
+            ).start(this.resource.port())
+        ) {
+            final RtPull pull = new RtPull(
+                new ApacheRequest(container.home()),
+                this.repo(),
+                3
+            );
+            pull.merge("Test commit.");
             final MkQuery query = container.take();
             MatcherAssert.assertThat(
                 query.method(),
@@ -245,7 +246,6 @@ public final class RtPullTest {
                 query.body(),
                 Matchers.equalTo("{\"commit_message\":\"Test commit.\"}")
             );
-        } finally {
             container.stop();
         }
     }

--- a/src/test/java/com/jcabi/github/RtPullsTest.java
+++ b/src/test/java/com/jcabi/github/RtPullsTest.java
@@ -70,24 +70,27 @@ public final class RtPullsTest {
     public void createPull() throws Exception {
         final String title = "new feature";
         final String body = pull(title).toString();
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, body)
-        ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body))
-            .start(this.resource.port());
-        final RtPulls pulls = new RtPulls(
-            new ApacheRequest(container.home()),
-            repo()
-        );
-        final Pull pull = pulls.create(title, "octocat", "master");
-        MatcherAssert.assertThat(
-            container.take().method(),
-            Matchers.equalTo(Request.POST)
-        );
-        MatcherAssert.assertThat(
-            new Pull.Smart(pull).title(),
-            Matchers.equalTo(title)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_CREATED, body)
+            ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, body))
+                .start(this.resource.port())
+        ) {
+            final RtPulls pulls = new RtPulls(
+                new ApacheRequest(container.home()),
+                repo()
+            );
+            final Pull pull = pulls.create(title, "octocat", "master");
+            MatcherAssert.assertThat(
+                container.take().method(),
+                Matchers.equalTo(Request.POST)
+            );
+            MatcherAssert.assertThat(
+                new Pull.Smart(pull).title(),
+                Matchers.equalTo(title)
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -97,22 +100,25 @@ public final class RtPullsTest {
     @Test
     public void getSinglePull() throws Exception {
         final String title = "new-feature";
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                pull(title).toString()
-            )
-        ).start(this.resource.port());
-        final RtPulls pulls = new RtPulls(
-            new ApacheRequest(container.home()),
-            repo()
-        );
-        final Pull pull = pulls.get(Tv.BILLION);
-        MatcherAssert.assertThat(
-            new Pull.Smart(pull).title(),
-            Matchers.equalTo(title)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    pull(title).toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtPulls pulls = new RtPulls(
+                new ApacheRequest(container.home()),
+                repo()
+            );
+            final Pull pull = pulls.get(Tv.BILLION);
+            MatcherAssert.assertThat(
+                new Pull.Smart(pull).title(),
+                Matchers.equalTo(title)
+            );
+            container.stop();
+        }
     }
 
     /**
@@ -121,24 +127,27 @@ public final class RtPullsTest {
      */
     @Test
     public void iteratePulls() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                Json.createArrayBuilder()
-                    .add(pull("new-topic"))
-                    .add(pull("Amazing new feature"))
-                    .build().toString()
-            )
-        ).start(this.resource.port());
-        final RtPulls pulls = new RtPulls(
-            new ApacheRequest(container.home()),
-            repo()
-        );
-        MatcherAssert.assertThat(
-            pulls.iterate(new ArrayMap<String, String>()),
-            Matchers.<Pull>iterableWithSize(2)
-        );
-        container.stop();
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createArrayBuilder()
+                        .add(pull("new-topic"))
+                        .add(pull("Amazing new feature"))
+                        .build().toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final RtPulls pulls = new RtPulls(
+                new ApacheRequest(container.home()),
+                repo()
+            );
+            MatcherAssert.assertThat(
+                pulls.iterate(new ArrayMap<String, String>()),
+                Matchers.<Pull>iterableWithSize(2)
+            );
+            container.stop();
+        }
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtReferenceTest.java
+++ b/src/test/java/com/jcabi/github/RtReferenceTest.java
@@ -49,6 +49,8 @@ import org.junit.Test;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @checkstyle MultipleStringLiterals (500 lines)
+ * @todo #1487:30min Continue to close grizzle servers open on tests. Use
+ *  try-with-resource statement instead of try-catch whenever is possible.
  */
 public final class RtReferenceTest {
 

--- a/src/test/java/com/jcabi/github/RtReferencesTest.java
+++ b/src/test/java/com/jcabi/github/RtReferencesTest.java
@@ -63,17 +63,18 @@ public final class RtReferencesTest {
      */
     @Test
     public void createsReference() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_CREATED,
-                "{\"ref\":\"refs/heads/feature-a\"}"
-            )
-        ).start(this.resource.port());
-        final References refs = new RtReferences(
-            new ApacheRequest(container.home()),
-            new MkGithub().randomRepo()
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_CREATED,
+                    "{\"ref\":\"refs/heads/feature-a\"}"
+                )
+            ).start(this.resource.port())
+        ) {
+            final References refs = new RtReferences(
+                new ApacheRequest(container.home()),
+                new MkGithub().randomRepo()
+            );
             MatcherAssert.assertThat(
                 refs.create("abceefgh3456", "refs/heads/feature-a"),
                 Matchers.instanceOf(Reference.class)
@@ -82,7 +83,6 @@ public final class RtReferencesTest {
                 container.take().method(),
                 Matchers.equalTo(Request.POST)
             );
-        } finally {
             container.stop();
         }
     }
@@ -93,22 +93,22 @@ public final class RtReferencesTest {
      */
     @Test
     public void iteratesReferences() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                "{\"ref\":\"refs/heads/feature-a\"}"
-            )
-        ).start(this.resource.port());
-        final References refs = new RtReferences(
-            new ApacheRequest(container.home()),
-            new MkGithub().randomRepo()
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "{\"ref\":\"refs/heads/feature-a\"}"
+                )
+            ).start(this.resource.port())
+        ) {
+            final References refs = new RtReferences(
+                new ApacheRequest(container.home()),
+                new MkGithub().randomRepo()
+            );
             MatcherAssert.assertThat(
                 refs.iterate(),
                 Matchers.notNullValue()
             );
-        } finally {
             container.stop();
         }
     }
@@ -119,20 +119,20 @@ public final class RtReferencesTest {
      */
     @Test
     public void removesReference() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
-        ).start(this.resource.port());
-        final References refs = new RtReferences(
-            new ApacheRequest(container.home()),
-            new MkGithub().randomRepo()
-        );
-        refs.remove("heads/feature-a");
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
+            ).start(this.resource.port())
+        ) {
+            final References refs = new RtReferences(
+                new ApacheRequest(container.home()),
+                new MkGithub().randomRepo()
+            );
+            refs.remove("heads/feature-a");
             MatcherAssert.assertThat(
                 container.take().method(),
                 Matchers.equalTo(Request.DELETE)
             );
-        } finally {
             container.stop();
         }
     }
@@ -143,17 +143,18 @@ public final class RtReferencesTest {
      */
     @Test
     public void iteratesTags() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                "[{\"ref\":\"refs/tags/feature-b\"}]"
-            )
-        ).start(this.resource.port());
-        final References refs = new RtReferences(
-            new ApacheRequest(container.home()),
-            new MkGithub().randomRepo()
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "[{\"ref\":\"refs/tags/feature-b\"}]"
+                )
+            ).start(this.resource.port())
+        ) {
+            final References refs = new RtReferences(
+                new ApacheRequest(container.home()),
+                new MkGithub().randomRepo()
+            );
             MatcherAssert.assertThat(
                 refs.tags(),
                 Matchers.<Reference>iterableWithSize(1)
@@ -162,7 +163,6 @@ public final class RtReferencesTest {
                 container.take().uri().toString(),
                 Matchers.endsWith("/git/refs/tags")
             );
-        } finally {
             container.stop();
         }
     }
@@ -173,17 +173,18 @@ public final class RtReferencesTest {
      */
     @Test
     public void iteratesHeads() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                HttpURLConnection.HTTP_OK,
-                "[{\"ref\":\"refs/heads/feature-c\"}]"
-            )
-        ).start(this.resource.port());
-        final References refs = new RtReferences(
-            new ApacheRequest(container.home()),
-            new MkGithub().randomRepo()
-        );
-        try {
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    "[{\"ref\":\"refs/heads/feature-c\"}]"
+                )
+            ).start(this.resource.port())
+        ) {
+            final References refs = new RtReferences(
+                new ApacheRequest(container.home()),
+                new MkGithub().randomRepo()
+            );
             MatcherAssert.assertThat(
                 refs.heads(),
                 Matchers.<Reference>iterableWithSize(1)
@@ -192,7 +193,6 @@ public final class RtReferencesTest {
                 container.take().uri().toString(),
                 Matchers.endsWith("/git/refs/heads")
             );
-        } finally {
             container.stop();
         }
     }


### PR DESCRIPTION
For #1487: 
- Use try-with-resource instead try-catch with grizzly in `RtOrganizationTest`, `RtOrganizationsTest`, `RtPaginationTest`, `RtPublicKeysTest`, `RtPublicMembersTest`, `RtPullCommentTest`, `RtPullCommentsTest`, `RtPullTest` and `RtPullsTest.java`
- Left puzzle for continuing implementation