### PR TITLE
#1509 checkstyle, renaming and a little refactoring

### DIFF
--- a/src/main/java/com/jcabi/github/Repos.java
+++ b/src/main/java/com/jcabi/github/Repos.java
@@ -100,6 +100,14 @@ public interface Repos {
     );
 
     /**
+     * Check if a repository exists on Github.
+     * @param coords Coordinates of the repo.
+     * @return True if it exists, false otherwise.
+     * @throws IOException If something goes wrong.
+     */
+    boolean exists(final Coordinates coords) throws IOException;
+
+    /**
      * Settings to use when creating a new GitHub repository.
      *
      * @author Chris Rebert (github@rebertia.com)

--- a/src/main/java/com/jcabi/github/RtRepos.java
+++ b/src/main/java/com/jcabi/github/RtRepos.java
@@ -36,8 +36,6 @@ import com.jcabi.http.response.JsonResponse;
 import com.jcabi.http.response.RestResponse;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-
-import javax.json.Json;
 import javax.json.JsonObject;
 import lombok.EqualsAndHashCode;
 
@@ -138,16 +136,12 @@ final class RtRepos implements Repos {
         );
     }
 
-	public boolean contains(Coordinates coords) throws IOException {
-		String repoPath = "/" + coords.user() +"/"+ coords.repo();
-		RestResponse response = this.entry.uri().path("/repos" + repoPath)
-		.back().method(Request.GET)
-		.body().set(Json.createObjectBuilder().build()).back()
-		.fetch().as(RestResponse.class);
-		if (response.status() == HttpURLConnection.HTTP_OK) {
-			return true;
-		} else {
-			return false;
-		}
-	}
+    @Override
+    public boolean exists(final Coordinates coords) throws IOException {
+        final String repo = coords.user().concat("/").concat(coords.repo());
+        final RestResponse response = this.entry.uri()
+            .path("/repos/".concat(repo)).back()
+            .method(Request.GET).fetch().as(RestResponse.class);
+        return response.status() == HttpURLConnection.HTTP_OK;
+    }
 }

--- a/src/main/java/com/jcabi/github/mock/MkRepos.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepos.java
@@ -166,6 +166,11 @@ final class MkRepos implements Repos {
         );
     }
 
+    @Override
+    public boolean exists(final Coordinates coords) throws IOException {
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
     /**
      * XPath of this element in XML tree.
      * @return XPath


### PR DESCRIPTION
Fixes #1509 

* Renamed method ``contains`` to ``exists`` and declared it in the interface;
* Removed useless json body from the GET operation
* Fixed checkstyle errors
* Added the method in ``MkRepos`` as well, currently throwing UnsupportedOperationException.