### PR TITLE
#1517 added ctors for custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,34 @@ public class Main {
 
 ## Work with Github Enterprise or other
 
-If you want to work with Github's API through another domain, you can instantiate ``RtGithub`` with your own custom ``Request``, by using the [RtGithub(Request)](https://github.com/jcabi/jcabi-github/blob/master/src/main/java/com/jcabi/github/RtGithub.java#L147) constructor. 
+If you want to work with Github's API through another domain, you can use the URI-constructors
+of class ``RtGithub``. For instance, if you have your own instance of Github deployed under the
+domain ``https://github.mydomain.com``, do the following:
 
-Be sure to configure the ``Request`` properly. See how the [default Request](https://github.com/jcabi/jcabi-github/blob/master/src/main/java/com/jcabi/github/RtGithub.java#L82) is created -- you basically have to do the same thing, only with your custom domain.
+```java
+final Github github = new RtGithub(URI.create("https://github.mydomain.com"));
+
+//OR
+
+final Github github = new RtGithub(
+    "<<oauth2_token>>",
+    URI.create("https://github.mydomain.com")
+);
+
+//OR
+
+final Github github = new RtGithub(
+    "username", "password",
+    URI.create("https://github.mydomain.com")
+);
+```
+
+**DO NOT** change or mask your URIs! Using Github under a different domain is fine but do not
+change the URI **paths**. Changing the requests' paths is not possible since the whole architecture
+of this library relies on Github's URI paths.
+
+For more complex configurations, you can instantiate ``RtGithub`` with your own custom ``Request``, by using the [RtGithub(Request)](https://github.com/jcabi/jcabi-github/blob/master/src/main/java/com/jcabi/github/RtGithub.java#L147) constructor. 
+Be sure to configure the ``Request`` properly. See how the [default Request](https://github.com/jcabi/jcabi-github/blob/master/src/main/java/com/jcabi/github/RtGithub.java#L82) is created -- you basically have to do the same thing.
 
 ## Mock Implementation Of The API
 

--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -36,6 +36,7 @@ import com.jcabi.http.request.ApacheRequest;
 import com.jcabi.http.response.JsonResponse;
 import com.jcabi.http.wire.AutoRedirectingWire;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import javax.json.JsonObject;
 import javax.ws.rs.core.HttpHeaders;
@@ -68,6 +69,7 @@ import lombok.ToString;
  * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
 @Immutable
 @Loggable(Loggable.DEBUG)
@@ -103,14 +105,32 @@ public final class RtGithub implements Github {
     }
 
     /**
+     * Public ctor, for anonymous access to Github.<br><br>
+     *
+     * Use this ctor when you want to access Github's API over a
+     * custom domain, other than https//api.github.com.<br><br>
+     *
+     * For instance, if you have your own instance of Github deployed
+     * somewhere.
+     *
+     * <pre>
+     *     final Github myGithub = new RtGithub(
+     *         URI.create("https://github.mydomain.com")
+     *     );
+     * </pre>
+     * @param domain Your domain.
+     */
+    public RtGithub(final URI domain) {
+        this(RtGithub.REQUEST.uri().set(domain).back());
+    }
+
+    /**
      * Public ctor, for HTTP Basic Authentication.
      * @param user User name
      * @param pwd Password
      * @since 0.4
      */
-    public RtGithub(
-        final String user,
-        final String pwd) {
+    public RtGithub(final String user, final String pwd) {
         this(
             RtGithub.REQUEST.header(
                 HttpHeaders.AUTHORIZATION,
@@ -126,11 +146,74 @@ public final class RtGithub implements Github {
     }
 
     /**
+     * Public ctor, for HTTP Basic Authentication.
+     *
+     * Use this ctor when you want to access Github's API over a
+     * custom domain, other than https//api.github.com.<br><br>
+     *
+     * For instance, if you have your own instance of Github deployed
+     * somewhere.
+     *
+     * <pre>
+     *     final Github myGithub = new RtGithub(
+     *         "john_doe", "johnspassword",
+     *         URI.create("https://github.mydomain.com")
+     *     );
+     * </pre>
+     * @param user User's username.
+     * @param pwd User's password.
+     * @param domain Your custom domain.
+     */
+    public RtGithub(final String user, final String pwd, final URI domain) {
+        this(
+            RtGithub.REQUEST.uri().set(domain).back()
+                .header(
+                    HttpHeaders.AUTHORIZATION,
+                    String.format(
+                        "Basic %s",
+                        DatatypeConverter.printBase64Binary(
+                            String.format("%s:%s", user, pwd)
+                                .getBytes(StandardCharsets.UTF_8)
+                        )
+                    )
+                )
+        );
+    }
+
+    /**
+     * Public ctor, for authentication with OAuth2 token.
+     *
+     * Use this ctor when you want to access Github's API over a
+     * custom domain, other than https//api.github.com.<br><br>
+     *
+     * For instance, if you have your own instance of Github deployed
+     * somewhere.
+     *
+     * <pre>
+     *     final Github myGithub = new RtGithub(
+     *         "john_doe", "johnspassword",
+     *         URI.create("https://github.mydomain.com")
+     *     );
+     * </pre>
+     *
+     * @param token OAuth token
+     * @param domain Your custom domain.
+     */
+    public RtGithub(final String token, final URI domain) {
+        this(
+            RtGithub.REQUEST.uri().set(domain).back()
+                .header(
+                    HttpHeaders.AUTHORIZATION,
+                    String.format("token %s", token)
+                )
+        );
+    }
+
+    /**
      * Public ctor, for authentication with OAuth2 token.
      * @param token OAuth token
      */
-    public RtGithub(
-        final String token) {
+    public RtGithub(final String token) {
         this(
             RtGithub.REQUEST.header(
                 HttpHeaders.AUTHORIZATION,
@@ -144,8 +227,7 @@ public final class RtGithub implements Github {
      * @param req Request to start from
      * @since 0.4
      */
-    public RtGithub(
-        final Request req) {
+    public RtGithub(final Request req) {
         this.request = req;
     }
 


### PR DESCRIPTION
PR for #1517 

* Added constructors for class RtGithub, through which users can specify a different domain. For instance, they might work with their own instance of Github, deployed somewhere under a different domain than ``https://api.github.com``

* Added documentation in the README.