### PR TITLE
Removing hard-coded "/repos"

### DIFF
--- a/src/main/java/com/jcabi/github/Github.java
+++ b/src/main/java/com/jcabi/github/Github.java
@@ -90,6 +90,12 @@ import lombok.EqualsAndHashCode;
 public interface Github {
 
     /**
+     * Root Github Repository path
+     * @return rootRepoPath
+     */
+    String rootRepoPath();
+
+   /**
      * RESTful request, an entry point to the Github API.
      * @return Request
      */

--- a/src/main/java/com/jcabi/github/Github.java
+++ b/src/main/java/com/jcabi/github/Github.java
@@ -90,8 +90,8 @@ import lombok.EqualsAndHashCode;
 public interface Github {
 
     /**
-     * Root Github Repository path
-     * @return rootRepoPath
+     * Root Github Repository path.
+     * @return Root repo path
      */
     String rootRepoPath();
 

--- a/src/main/java/com/jcabi/github/RtAssignees.java
+++ b/src/main/java/com/jcabi/github/RtAssignees.java
@@ -76,7 +76,7 @@ final class RtAssignees implements Assignees {
         this.entry = req;
         final Coordinates coords = repo.coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/assignees")

--- a/src/main/java/com/jcabi/github/RtBlob.java
+++ b/src/main/java/com/jcabi/github/RtBlob.java
@@ -69,7 +69,7 @@ final class RtBlob implements Blob {
         final String sha) {
         final Coordinates coords = repo.coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/git")

--- a/src/main/java/com/jcabi/github/RtBlobs.java
+++ b/src/main/java/com/jcabi/github/RtBlobs.java
@@ -75,7 +75,7 @@ final class RtBlobs implements Blobs {
         this.entry = req;
         final Coordinates coords = repo.coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/git")

--- a/src/main/java/com/jcabi/github/RtBranches.java
+++ b/src/main/java/com/jcabi/github/RtBranches.java
@@ -72,7 +72,7 @@ final class RtBranches implements Branches {
         this.owner = repo;
         final Coordinates coords = repo.coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/branches")

--- a/src/main/java/com/jcabi/github/RtCollaborators.java
+++ b/src/main/java/com/jcabi/github/RtCollaborators.java
@@ -76,7 +76,7 @@ final class RtCollaborators implements Collaborators {
         this.entry = req;
         final Coordinates coords = repo.coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/collaborators")

--- a/src/main/java/com/jcabi/github/RtComment.java
+++ b/src/main/java/com/jcabi/github/RtComment.java
@@ -82,7 +82,7 @@ final class RtComment implements Comment {
     RtComment(final Request req, final Issue issue, final int number) {
         final Coordinates coords = issue.repo().coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(issue.repo().github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/issues")

--- a/src/main/java/com/jcabi/github/RtComments.java
+++ b/src/main/java/com/jcabi/github/RtComments.java
@@ -78,7 +78,7 @@ final class RtComments implements Comments {
         this.entry = req;
         final Coordinates coords = issue.repo().coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(issue.repo().github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/issues")

--- a/src/main/java/com/jcabi/github/RtCommit.java
+++ b/src/main/java/com/jcabi/github/RtCommit.java
@@ -72,7 +72,7 @@ final class RtCommit implements Commit {
     RtCommit(final Request req, final Repo repo, final String sha) {
         final Coordinates coords = repo.coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/git")

--- a/src/main/java/com/jcabi/github/RtCommits.java
+++ b/src/main/java/com/jcabi/github/RtCommits.java
@@ -74,7 +74,8 @@ public final class RtCommits implements Commits {
     ) {
         this.entry = req;
         this.owner = repo;
-        this.request = req.uri().path(repo.github().rootRepoPath()).path(repo.coordinates().user())
+        this.request = req.uri().path(repo.github().rootRepoPath())
+            .path(repo.coordinates().user())
             .path(repo.coordinates().repo())
             .path("/git")
             .path("/commits").back();

--- a/src/main/java/com/jcabi/github/RtCommits.java
+++ b/src/main/java/com/jcabi/github/RtCommits.java
@@ -74,7 +74,7 @@ public final class RtCommits implements Commits {
     ) {
         this.entry = req;
         this.owner = repo;
-        this.request = req.uri().path("/repos").path(repo.coordinates().user())
+        this.request = req.uri().path(repo.github().rootRepoPath()).path(repo.coordinates().user())
             .path(repo.coordinates().repo())
             .path("/git")
             .path("/commits").back();

--- a/src/main/java/com/jcabi/github/RtCommitsComparison.java
+++ b/src/main/java/com/jcabi/github/RtCommitsComparison.java
@@ -72,7 +72,7 @@ final class RtCommitsComparison implements CommitsComparison {
         final String base, final String head) {
         this.owner = repo;
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(repo.coordinates().toString())
             .path("/compare")
             .path(String.format("%s...%s", base, head))

--- a/src/main/java/com/jcabi/github/RtContent.java
+++ b/src/main/java/com/jcabi/github/RtContent.java
@@ -76,7 +76,7 @@ final class RtContent implements Content {
     RtContent(final Request req, final Repo repo, final String path) {
         final Coordinates coords = repo.coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/contents")

--- a/src/main/java/com/jcabi/github/RtContents.java
+++ b/src/main/java/com/jcabi/github/RtContents.java
@@ -79,7 +79,7 @@ final class RtContents implements Contents {
         this.entry = req;
         this.owner = repo;
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(repo.coordinates().user())
             .path(repo.coordinates().repo())
             .path("/contents")
@@ -96,7 +96,7 @@ final class RtContents implements Contents {
         return new RtContent(
             this.entry, this.owner,
             this.entry.uri()
-                .path("/repos")
+                .path(this.owner.github().rootRepoPath())
                 .path(this.owner.coordinates().user())
                 .path(this.owner.coordinates().repo())
                 .path("/readme")
@@ -120,7 +120,7 @@ final class RtContents implements Contents {
         return new RtContent(
             this.entry, this.owner,
             this.entry.uri()
-                .path("/repos")
+                .path(this.owner.github().rootRepoPath())
                 .path(this.owner.coordinates().user())
                 .path(this.owner.coordinates().repo())
                 .path("/readme")

--- a/src/main/java/com/jcabi/github/RtDeployKey.java
+++ b/src/main/java/com/jcabi/github/RtDeployKey.java
@@ -67,7 +67,7 @@ final class RtDeployKey implements DeployKey {
     RtDeployKey(final Request req, final int number, final Repo repo) {
         this.key = number;
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(repo.coordinates().user())
             .path(repo.coordinates().repo())
             .path("/keys")

--- a/src/main/java/com/jcabi/github/RtDeployKeys.java
+++ b/src/main/java/com/jcabi/github/RtDeployKeys.java
@@ -75,7 +75,7 @@ final class RtDeployKeys implements DeployKeys {
         this.owner = repo;
         this.entry = req;
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(repo.coordinates().user())
             .path(repo.coordinates().repo())
             .path("/keys")

--- a/src/main/java/com/jcabi/github/RtEvent.java
+++ b/src/main/java/com/jcabi/github/RtEvent.java
@@ -73,7 +73,7 @@ final class RtEvent implements Event {
     RtEvent(final Request req, final Repo repo, final int number) {
         final Coordinates coords = repo.coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/issues")

--- a/src/main/java/com/jcabi/github/RtFork.java
+++ b/src/main/java/com/jcabi/github/RtFork.java
@@ -67,7 +67,7 @@ final class RtFork implements Fork {
     RtFork(final Request req, final Repo repo, final int number) {
         final Coordinates coords = repo.coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/forks")

--- a/src/main/java/com/jcabi/github/RtForks.java
+++ b/src/main/java/com/jcabi/github/RtForks.java
@@ -75,7 +75,7 @@ final class RtForks implements Forks {
      */
     public RtForks(final Request req, final Repo repo) {
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(repo.coordinates().user())
             .path(repo.coordinates().repo())
             .path("forks")

--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -79,9 +79,9 @@ import lombok.ToString;
 public final class RtGithub implements Github {
 
     /**
-     * Root repository path
+     * Root repository path.
      */
-    private final transient String rootRepoPath = "/repos";
+    private final transient String rootPath = "/repos";
 
     /**
      * Default request to start with.
@@ -238,7 +238,7 @@ public final class RtGithub implements Github {
 
     @Override
     public String rootRepoPath() {
-        return this.rootRepoPath;
+        return this.rootPath;
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/RtGithub.java
+++ b/src/main/java/com/jcabi/github/RtGithub.java
@@ -79,6 +79,11 @@ import lombok.ToString;
 public final class RtGithub implements Github {
 
     /**
+     * Root repository path
+     */
+    private final transient String rootRepoPath = "/repos";
+
+    /**
      * Default request to start with.
      */
     private static final Request REQUEST =
@@ -229,6 +234,11 @@ public final class RtGithub implements Github {
      */
     public RtGithub(final Request req) {
         this.request = req;
+    }
+
+    @Override
+    public String rootRepoPath() {
+        return this.rootRepoPath;
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/RtHook.java
+++ b/src/main/java/com/jcabi/github/RtHook.java
@@ -72,7 +72,7 @@ final class RtHook implements Hook {
     RtHook(final Request req, final Repo repo, final int number) {
         final Coordinates coords = repo.coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/hooks")

--- a/src/main/java/com/jcabi/github/RtHooks.java
+++ b/src/main/java/com/jcabi/github/RtHooks.java
@@ -78,7 +78,7 @@ final class RtHooks implements Hooks {
         this.entry = req;
         final Coordinates coords = repo.coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/hooks")

--- a/src/main/java/com/jcabi/github/RtIssue.java
+++ b/src/main/java/com/jcabi/github/RtIssue.java
@@ -90,7 +90,7 @@ final class RtIssue implements Issue {
         this.entry = req;
         final Coordinates coords = repo.coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/issues")

--- a/src/main/java/com/jcabi/github/RtIssueEvents.java
+++ b/src/main/java/com/jcabi/github/RtIssueEvents.java
@@ -70,7 +70,7 @@ final class RtIssueEvents implements IssueEvents {
         this.entry = req;
         final Coordinates coords = repo.coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/issues")

--- a/src/main/java/com/jcabi/github/RtIssueLabels.java
+++ b/src/main/java/com/jcabi/github/RtIssueLabels.java
@@ -79,7 +79,7 @@ final class RtIssueLabels implements IssueLabels {
         final Coordinates coords = issue.repo().coordinates();
         this.entry = req;
         this.request = req.uri()
-            .path("/repos")
+            .path(issue.repo().github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/issues")

--- a/src/main/java/com/jcabi/github/RtIssues.java
+++ b/src/main/java/com/jcabi/github/RtIssues.java
@@ -81,7 +81,7 @@ final class RtIssues implements Issues {
         this.entry = req;
         final Coordinates coords = repo.coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/issues")

--- a/src/main/java/com/jcabi/github/RtLabel.java
+++ b/src/main/java/com/jcabi/github/RtLabel.java
@@ -73,7 +73,7 @@ final class RtLabel implements Label {
     RtLabel(final Request req, final Repo repo, final String name) {
         final Coordinates coords = repo.coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/labels")

--- a/src/main/java/com/jcabi/github/RtLabels.java
+++ b/src/main/java/com/jcabi/github/RtLabels.java
@@ -78,7 +78,7 @@ final class RtLabels implements Labels {
         final Coordinates coords = repo.coordinates();
         this.entry = req;
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/labels")

--- a/src/main/java/com/jcabi/github/RtMilestone.java
+++ b/src/main/java/com/jcabi/github/RtMilestone.java
@@ -71,7 +71,7 @@ final class RtMilestone implements Milestone {
     RtMilestone(final Request req, final Repo repo, final int number) {
         final Coordinates coords = repo.coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/milestones")

--- a/src/main/java/com/jcabi/github/RtMilestones.java
+++ b/src/main/java/com/jcabi/github/RtMilestones.java
@@ -77,7 +77,7 @@ final class RtMilestones implements Milestones {
         this.entry = req;
         final Coordinates coords = repo.coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/milestones")

--- a/src/main/java/com/jcabi/github/RtPull.java
+++ b/src/main/java/com/jcabi/github/RtPull.java
@@ -86,7 +86,7 @@ final class RtPull implements Pull {
         this.entry = req;
         final Coordinates coords = repo.coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/pulls")

--- a/src/main/java/com/jcabi/github/RtPullComment.java
+++ b/src/main/java/com/jcabi/github/RtPullComment.java
@@ -73,7 +73,7 @@ final class RtPullComment implements PullComment {
     RtPullComment(final Request req, final Pull pull, final int number) {
         final Coordinates coords = pull.repo().coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(pull.repo().github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/pulls")

--- a/src/main/java/com/jcabi/github/RtPullComments.java
+++ b/src/main/java/com/jcabi/github/RtPullComments.java
@@ -120,7 +120,7 @@ final class RtPullComments implements PullComments {
         final int number,
         final Map<String, String> params) {
         final Request newreq = this.entry.uri()
-            .path(owner.repo().github().rootRepoPath())
+            .path(this.owner.repo().github().rootRepoPath())
             .path(this.owner.repo().coordinates().user())
             .path(this.owner.repo().coordinates().repo())
             .path("/pulls")

--- a/src/main/java/com/jcabi/github/RtPullComments.java
+++ b/src/main/java/com/jcabi/github/RtPullComments.java
@@ -78,7 +78,7 @@ final class RtPullComments implements PullComments {
         this.owner = pull;
         this.request = this.entry.uri()
             // @checkstyle MultipleStringLiterals (8 lines)
-            .path("/repos")
+            .path(this.owner.repo().github().rootRepoPath())
             .path(pull.repo().coordinates().user())
             .path(pull.repo().coordinates().repo())
             .path("/pulls")
@@ -120,7 +120,7 @@ final class RtPullComments implements PullComments {
         final int number,
         final Map<String, String> params) {
         final Request newreq = this.entry.uri()
-            .path("/repos")
+            .path(owner.repo().github().rootRepoPath())
             .path(this.owner.repo().coordinates().user())
             .path(this.owner.repo().coordinates().repo())
             .path("/pulls")

--- a/src/main/java/com/jcabi/github/RtPulls.java
+++ b/src/main/java/com/jcabi/github/RtPulls.java
@@ -79,7 +79,7 @@ final class RtPulls implements Pulls {
         this.entry = req;
         final Coordinates coords = repo.coordinates();
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/pulls")

--- a/src/main/java/com/jcabi/github/RtReference.java
+++ b/src/main/java/com/jcabi/github/RtReference.java
@@ -71,7 +71,7 @@ final class RtReference implements Reference {
      */
     RtReference(final Request req, final Repo repo, final String ref) {
         this.request = req.uri()
-            .path("/repos").path(repo.coordinates().user())
+            .path(repo.github().rootRepoPath()).path(repo.coordinates().user())
             .path(repo.coordinates().repo()).path("/git").path(ref).back();
         this.owner = repo;
         this.name = ref;

--- a/src/main/java/com/jcabi/github/RtReferences.java
+++ b/src/main/java/com/jcabi/github/RtReferences.java
@@ -80,8 +80,12 @@ final class RtReferences implements References {
     RtReferences(final Request req, final Repo repo) {
         this.entry = req;
         this.owner = repo;
-        this.request = req.uri().path(repo.github().rootRepoPath()).path(repo.coordinates().user())
-            .path(repo.coordinates().repo()).path("/git").path("/refs").back();
+        this.request = req.uri()
+            .path(repo.github().rootRepoPath())
+            .path(repo.coordinates().user())
+            .path(repo.coordinates().repo())
+            .path("/git")
+            .path("/refs").back();
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/RtReferences.java
+++ b/src/main/java/com/jcabi/github/RtReferences.java
@@ -80,7 +80,7 @@ final class RtReferences implements References {
     RtReferences(final Request req, final Repo repo) {
         this.entry = req;
         this.owner = repo;
-        this.request = req.uri().path("/repos").path(repo.coordinates().user())
+        this.request = req.uri().path(repo.github().rootRepoPath()).path(repo.coordinates().user())
             .path(repo.coordinates().repo()).path("/git").path("/refs").back();
     }
 

--- a/src/main/java/com/jcabi/github/RtRelease.java
+++ b/src/main/java/com/jcabi/github/RtRelease.java
@@ -79,7 +79,7 @@ final class RtRelease implements Release {
         this.release = nmbr;
         this.owner = repo;
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(repo.coordinates().user())
             .path(repo.coordinates().repo())
             .path("/releases")

--- a/src/main/java/com/jcabi/github/RtReleaseAsset.java
+++ b/src/main/java/com/jcabi/github/RtReleaseAsset.java
@@ -80,7 +80,7 @@ final class RtReleaseAsset implements ReleaseAsset {
     ) {
         final Coordinates coords = release.repo().coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(release.repo().github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/releases")

--- a/src/main/java/com/jcabi/github/RtReleaseAssets.java
+++ b/src/main/java/com/jcabi/github/RtReleaseAssets.java
@@ -81,7 +81,7 @@ final class RtReleaseAssets implements ReleaseAssets {
         final Coordinates coords = release.repo().coordinates();
         // @checkstyle MultipleStringLiteralsCheck (7 lines)
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(release.repo().github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/releases")
@@ -122,7 +122,7 @@ final class RtReleaseAssets implements ReleaseAssets {
         return this.get(
             this.request.uri()
                 .set(URI.create("https://uploads.github.com"))
-                .path("/repos")
+                .path(this.owner.repo().github().rootRepoPath())
                 .path(this.owner.repo().coordinates().user())
                 .path(this.owner.repo().coordinates().repo())
                 .path("/releases")

--- a/src/main/java/com/jcabi/github/RtReleases.java
+++ b/src/main/java/com/jcabi/github/RtReleases.java
@@ -77,7 +77,7 @@ final class RtReleases implements Releases {
         this.entry = req;
         this.owner = repo;
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(repo.coordinates().user())
             .path(repo.coordinates().repo())
             .path("/releases")

--- a/src/main/java/com/jcabi/github/RtRepo.java
+++ b/src/main/java/com/jcabi/github/RtRepo.java
@@ -91,7 +91,7 @@ final class RtRepo implements Repo {
         this.entry = req;
         this.coords = crd;
         this.request = this.entry.uri()
-            .path("/repos")
+            .path(github().rootRepoPath())
             .path(this.coords.user())
             .path(this.coords.repo())
             .back();

--- a/src/main/java/com/jcabi/github/RtRepoCommit.java
+++ b/src/main/java/com/jcabi/github/RtRepoCommit.java
@@ -72,7 +72,7 @@ final class RtRepoCommit implements RepoCommit {
     RtRepoCommit(final Request req, final Repo repo, final String sha) {
         final Coordinates coords = repo.coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/commits")

--- a/src/main/java/com/jcabi/github/RtRepoCommits.java
+++ b/src/main/java/com/jcabi/github/RtRepoCommits.java
@@ -81,7 +81,7 @@ final class RtRepoCommits implements RepoCommits {
         this.entry = req;
         this.owner = repo;
         final RequestURI rep = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(repo.coordinates().user())
             .path(repo.coordinates().repo());
         this.request = rep

--- a/src/main/java/com/jcabi/github/RtRepos.java
+++ b/src/main/java/com/jcabi/github/RtRepos.java
@@ -88,7 +88,8 @@ final class RtRepos implements Repos {
         String uriPath = "user/repos";
         final String org = settings.organization();
         if (org != null && !org.isEmpty()) {
-            uriPath = "/orgs/".concat(org).concat(github().rootRepoPath());
+            uriPath = "/orgs/".concat(org)
+                .concat(this.github().rootRepoPath());
         }
         return this.get(
             new Coordinates.Simple(

--- a/src/main/java/com/jcabi/github/RtRepos.java
+++ b/src/main/java/com/jcabi/github/RtRepos.java
@@ -88,7 +88,7 @@ final class RtRepos implements Repos {
         String uriPath = "user/repos";
         final String org = settings.organization();
         if (org != null && !org.isEmpty()) {
-            uriPath = "/orgs/".concat(org).concat("/repos");
+            uriPath = "/orgs/".concat(org).concat(github().rootRepoPath());
         }
         return this.get(
             new Coordinates.Simple(
@@ -112,7 +112,7 @@ final class RtRepos implements Repos {
     @Override
     public void remove(
         final Coordinates coords) throws IOException {
-        this.entry.uri().path("/repos")
+        this.entry.uri().path(this.github().rootRepoPath())
             .back().method(Request.DELETE)
             .uri().path(coords.toString()).back()
             .fetch()
@@ -140,7 +140,7 @@ final class RtRepos implements Repos {
     public boolean exists(final Coordinates coords) throws IOException {
         final String repo = coords.user().concat("/").concat(coords.repo());
         final RestResponse response = this.entry.uri()
-            .path("/repos/".concat(repo)).back()
+            .path(this.github().rootRepoPath()).back()
             .method(Request.GET).fetch().as(RestResponse.class);
         return response.status() == HttpURLConnection.HTTP_OK;
     }

--- a/src/main/java/com/jcabi/github/RtStatuses.java
+++ b/src/main/java/com/jcabi/github/RtStatuses.java
@@ -63,7 +63,7 @@ public class RtStatuses implements Statuses {
     RtStatuses(final Request req, final Commit commit) {
         final Coordinates coords = commit.repo().coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(commit.repo().github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/statuses")

--- a/src/main/java/com/jcabi/github/RtTag.java
+++ b/src/main/java/com/jcabi/github/RtTag.java
@@ -75,7 +75,7 @@ final class RtTag implements Tag {
     ) {
         this.sha = key;
         this.owner = repo;
-        this.request = req.uri().path("/repos").path(repo.coordinates().user())
+        this.request = req.uri().path(repo().github().rootRepoPath()).path(repo.coordinates().user())
             .path(repo.coordinates().repo()).path("/git").path("/tags")
             .path(this.sha).back();
     }

--- a/src/main/java/com/jcabi/github/RtTag.java
+++ b/src/main/java/com/jcabi/github/RtTag.java
@@ -75,7 +75,9 @@ final class RtTag implements Tag {
     ) {
         this.sha = key;
         this.owner = repo;
-        this.request = req.uri().path(repo().github().rootRepoPath()).path(repo.coordinates().user())
+        this.request = req.uri()
+            .path(repo().github().rootRepoPath())
+            .path(repo.coordinates().user())
             .path(repo.coordinates().repo()).path("/git").path("/tags")
             .path(this.sha).back();
     }

--- a/src/main/java/com/jcabi/github/RtTags.java
+++ b/src/main/java/com/jcabi/github/RtTags.java
@@ -74,7 +74,7 @@ final class RtTags implements Tags {
     ) {
         this.entry = req;
         this.owner = repo;
-        this.request = req.uri().path("/repos").path(repo.coordinates().user())
+        this.request = req.uri().path(repo().github().rootRepoPath()).path(repo.coordinates().user())
             .path(repo.coordinates().repo()).path("/git").path("/tags").back();
     }
 

--- a/src/main/java/com/jcabi/github/RtTags.java
+++ b/src/main/java/com/jcabi/github/RtTags.java
@@ -74,7 +74,8 @@ final class RtTags implements Tags {
     ) {
         this.entry = req;
         this.owner = repo;
-        this.request = req.uri().path(repo().github().rootRepoPath()).path(repo.coordinates().user())
+        this.request = req.uri().path(repo().github().rootRepoPath())
+            .path(repo.coordinates().user())
             .path(repo.coordinates().repo()).path("/git").path("/tags").back();
     }
 

--- a/src/main/java/com/jcabi/github/RtTree.java
+++ b/src/main/java/com/jcabi/github/RtTree.java
@@ -74,7 +74,7 @@ final class RtTree implements Tree {
     ) {
         final Coordinates coords = repo.coordinates();
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(coords.user())
             .path(coords.repo())
             .path("/git")

--- a/src/main/java/com/jcabi/github/RtTrees.java
+++ b/src/main/java/com/jcabi/github/RtTrees.java
@@ -73,7 +73,7 @@ final class RtTrees implements Trees {
         this.entry = req;
         this.owner = repo;
         this.request = req.uri()
-            .path("/repos")
+            .path(repo.github().rootRepoPath())
             .path(repo.coordinates().user())
             .path(repo.coordinates().repo())
             .path("/git")

--- a/src/main/java/com/jcabi/github/mock/MkGithub.java
+++ b/src/main/java/com/jcabi/github/mock/MkGithub.java
@@ -77,7 +77,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 public final class MkGithub implements Github {
 
     /**
-     * Root repository path
+     * Root repository path.
      */
     private final transient String rootRepoPath = "/repos";
 

--- a/src/main/java/com/jcabi/github/mock/MkGithub.java
+++ b/src/main/java/com/jcabi/github/mock/MkGithub.java
@@ -77,6 +77,11 @@ import org.apache.commons.lang3.RandomStringUtils;
 public final class MkGithub implements Github {
 
     /**
+     * Root repository path
+     */
+    private final transient String rootRepoPath = "/repos";
+
+   /**
      * Storage.
      */
     private final transient MkStorage storage;
@@ -121,6 +126,11 @@ public final class MkGithub implements Github {
     @Override
     public String toString() {
         return this.storage.toString();
+    }
+
+    @Override
+    public String rootRepoPath() {
+        return this.rootRepoPath;
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/mock/MkRepos.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepos.java
@@ -93,7 +93,7 @@ final class MkRepos implements Repos {
         String owner = this.self;
         final String org = settings.organization();
         if (org != null && !org.isEmpty()) {
-            owner = "/orgs/".concat(org).concat("/repos");
+            owner = "/orgs/".concat(org).concat(this.github().rootRepoPath());
         }
         final Coordinates coords = new Coordinates.Simple(
             owner,

--- a/src/test/java/com/jcabi/github/Constants.java
+++ b/src/test/java/com/jcabi/github/Constants.java
@@ -1,0 +1,8 @@
+package com.jcabi.github;
+
+/**
+ * Constants for Test classes
+ */
+public class Constants {
+    static final String ROOT_REPO = "/repos";
+}

--- a/src/test/java/com/jcabi/github/Constants.java
+++ b/src/test/java/com/jcabi/github/Constants.java
@@ -1,8 +1,12 @@
 package com.jcabi.github;
 
 /**
- * Constants for Test classes
+ * Constants for Test classes.
+ * @author Hossein Amerkashi (kkashi01@gmail.com)
  */
-public class Constants {
+class Constants {
+    /**
+     * Constant for root repository path.
+     */
     static final String ROOT_REPO = "/repos";
 }

--- a/src/test/java/com/jcabi/github/IssueTest.java
+++ b/src/test/java/com/jcabi/github/IssueTest.java
@@ -188,7 +188,6 @@ public final class IssueTest {
         Mockito.doReturn(coords).when(repo).coordinates();
         Mockito.doReturn("user").when(coords).user();
         Mockito.doReturn("repo").when(coords).repo();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();

--- a/src/test/java/com/jcabi/github/IssueTest.java
+++ b/src/test/java/com/jcabi/github/IssueTest.java
@@ -188,6 +188,10 @@ public final class IssueTest {
         Mockito.doReturn(coords).when(repo).coordinates();
         Mockito.doReturn("user").when(coords).user();
         Mockito.doReturn("repo").when(coords).repo();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtAssigneesTest.java
+++ b/src/test/java/com/jcabi/github/RtAssigneesTest.java
@@ -162,6 +162,10 @@ public final class RtAssigneesTest {
         Mockito.doReturn(new Coordinates.Simple("test", "assignee"))
             .when(repo).coordinates();
         Mockito.doReturn(Mockito.mock(Github.class)).when(repo).github();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtAssigneesTest.java
+++ b/src/test/java/com/jcabi/github/RtAssigneesTest.java
@@ -162,7 +162,6 @@ public final class RtAssigneesTest {
         Mockito.doReturn(new Coordinates.Simple("test", "assignee"))
             .when(repo).coordinates();
         Mockito.doReturn(Mockito.mock(Github.class)).when(repo).github();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();

--- a/src/test/java/com/jcabi/github/RtBlobsTest.java
+++ b/src/test/java/com/jcabi/github/RtBlobsTest.java
@@ -120,11 +120,9 @@ public final class RtBlobsTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtBlobsTest.java
+++ b/src/test/java/com/jcabi/github/RtBlobsTest.java
@@ -120,6 +120,11 @@ public final class RtBlobsTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtContentTest.java
+++ b/src/test/java/com/jcabi/github/RtContentTest.java
@@ -178,11 +178,9 @@ public final class RtContentTest {
         Mockito.doReturn(coords).when(repo).coordinates();
         Mockito.doReturn("user").when(coords).user();
         Mockito.doReturn("repo").when(coords).repo();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtContentTest.java
+++ b/src/test/java/com/jcabi/github/RtContentTest.java
@@ -178,6 +178,11 @@ public final class RtContentTest {
         Mockito.doReturn(coords).when(repo).coordinates();
         Mockito.doReturn("user").when(coords).user();
         Mockito.doReturn("repo").when(coords).repo();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtContentsTest.java
+++ b/src/test/java/com/jcabi/github/RtContentsTest.java
@@ -380,6 +380,11 @@ public final class RtContentsTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "contents"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtContentsTest.java
+++ b/src/test/java/com/jcabi/github/RtContentsTest.java
@@ -380,11 +380,9 @@ public final class RtContentsTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "contents"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtDeployKeyTest.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeyTest.java
@@ -93,6 +93,11 @@ public final class RtDeployKeyTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "keys"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtDeployKeyTest.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeyTest.java
@@ -93,11 +93,9 @@ public final class RtDeployKeyTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "keys"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtDeployKeysTest.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeysTest.java
@@ -154,6 +154,11 @@ public final class RtDeployKeysTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "keys"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtDeployKeysTest.java
+++ b/src/test/java/com/jcabi/github/RtDeployKeysTest.java
@@ -154,11 +154,9 @@ public final class RtDeployKeysTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "keys"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtEventTest.java
+++ b/src/test/java/com/jcabi/github/RtEventTest.java
@@ -137,11 +137,9 @@ public final class RtEventTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "event"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtEventTest.java
+++ b/src/test/java/com/jcabi/github/RtEventTest.java
@@ -137,6 +137,11 @@ public final class RtEventTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "event"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtForksTest.java
+++ b/src/test/java/com/jcabi/github/RtForksTest.java
@@ -106,6 +106,11 @@ public final class RtForksTest {
                 "test_user", "test_repo"
             );
             Mockito.doReturn(coordinates).when(owner).coordinates();
+
+            final Github github = Mockito.mock(Github.class);
+            Mockito.doReturn(github).when(owner).github();
+            Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
             final RtForks forks = new RtForks(
                 new JdkRequest(container.home()),
                 owner
@@ -131,6 +136,11 @@ public final class RtForksTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "forks"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtForksTest.java
+++ b/src/test/java/com/jcabi/github/RtForksTest.java
@@ -109,7 +109,6 @@ public final class RtForksTest {
             final Github github = Mockito.mock(Github.class);
             Mockito.doReturn(github).when(owner).github();
             Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
             final RtForks forks = new RtForks(
                 new JdkRequest(container.home()),
                 owner

--- a/src/test/java/com/jcabi/github/RtForksTest.java
+++ b/src/test/java/com/jcabi/github/RtForksTest.java
@@ -106,7 +106,6 @@ public final class RtForksTest {
                 "test_user", "test_repo"
             );
             Mockito.doReturn(coordinates).when(owner).coordinates();
-
             final Github github = Mockito.mock(Github.class);
             Mockito.doReturn(github).when(owner).github();
             Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
@@ -136,11 +135,9 @@ public final class RtForksTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "forks"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtHookTest.java
+++ b/src/test/java/com/jcabi/github/RtHookTest.java
@@ -136,11 +136,9 @@ public final class RtHookTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "repo"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtHookTest.java
+++ b/src/test/java/com/jcabi/github/RtHookTest.java
@@ -136,6 +136,11 @@ public final class RtHookTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "repo"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtHooksTest.java
+++ b/src/test/java/com/jcabi/github/RtHooksTest.java
@@ -257,11 +257,9 @@ public final class RtHooksTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "hooks"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtHooksTest.java
+++ b/src/test/java/com/jcabi/github/RtHooksTest.java
@@ -257,6 +257,11 @@ public final class RtHooksTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "hooks"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtIssueTest.java
+++ b/src/test/java/com/jcabi/github/RtIssueTest.java
@@ -209,11 +209,9 @@ public final class RtIssueTest {
         Mockito.doReturn(coords).when(repo).coordinates();
         Mockito.doReturn("user").when(coords).user();
         Mockito.doReturn("repo").when(coords).repo();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtIssueTest.java
+++ b/src/test/java/com/jcabi/github/RtIssueTest.java
@@ -209,6 +209,11 @@ public final class RtIssueTest {
         Mockito.doReturn(coords).when(repo).coordinates();
         Mockito.doReturn("user").when(coords).user();
         Mockito.doReturn("repo").when(coords).repo();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtIssuesTest.java
+++ b/src/test/java/com/jcabi/github/RtIssuesTest.java
@@ -210,7 +210,6 @@ public final class RtIssuesTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();

--- a/src/test/java/com/jcabi/github/RtIssuesTest.java
+++ b/src/test/java/com/jcabi/github/RtIssuesTest.java
@@ -210,6 +210,10 @@ public final class RtIssuesTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtLabelTest.java
+++ b/src/test/java/com/jcabi/github/RtLabelTest.java
@@ -127,6 +127,11 @@ public final class RtLabelTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtLabelTest.java
+++ b/src/test/java/com/jcabi/github/RtLabelTest.java
@@ -127,11 +127,9 @@ public final class RtLabelTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtLabelsTest.java
+++ b/src/test/java/com/jcabi/github/RtLabelsTest.java
@@ -206,11 +206,9 @@ public final class RtLabelsTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtLabelsTest.java
+++ b/src/test/java/com/jcabi/github/RtLabelsTest.java
@@ -206,6 +206,11 @@ public final class RtLabelsTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtMilestonesTest.java
+++ b/src/test/java/com/jcabi/github/RtMilestonesTest.java
@@ -89,11 +89,9 @@ public final class RtMilestonesTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtMilestonesTest.java
+++ b/src/test/java/com/jcabi/github/RtMilestonesTest.java
@@ -89,6 +89,11 @@ public final class RtMilestonesTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtPullTest.java
+++ b/src/test/java/com/jcabi/github/RtPullTest.java
@@ -288,11 +288,9 @@ public final class RtPullTest {
         Mockito.doReturn(coords).when(repo).coordinates();
         Mockito.doReturn("/user").when(coords).user();
         Mockito.doReturn("/repo").when(coords).repo();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtPullTest.java
+++ b/src/test/java/com/jcabi/github/RtPullTest.java
@@ -288,6 +288,11 @@ public final class RtPullTest {
         Mockito.doReturn(coords).when(repo).coordinates();
         Mockito.doReturn("/user").when(coords).user();
         Mockito.doReturn("/repo").when(coords).repo();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtPullsTest.java
+++ b/src/test/java/com/jcabi/github/RtPullsTest.java
@@ -173,6 +173,11 @@ public final class RtPullsTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtPullsTest.java
+++ b/src/test/java/com/jcabi/github/RtPullsTest.java
@@ -173,11 +173,9 @@ public final class RtPullsTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtReleaseTest.java
+++ b/src/test/java/com/jcabi/github/RtReleaseTest.java
@@ -155,6 +155,9 @@ public class RtReleaseTest {
     private static RtRelease release(final URI uri) {
         final Repo repo = Mockito.mock(Repo.class);
         final Coordinates coords = Mockito.mock(Coordinates.class);
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
         Mockito.doReturn(coords).when(repo).coordinates();
         Mockito.doReturn("tstuser").when(coords).user();
         Mockito.doReturn("tstbranch").when(coords).repo();

--- a/src/test/java/com/jcabi/github/RtReleasesTest.java
+++ b/src/test/java/com/jcabi/github/RtReleasesTest.java
@@ -188,6 +188,11 @@ public final class RtReleasesTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "releases"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtReleasesTest.java
+++ b/src/test/java/com/jcabi/github/RtReleasesTest.java
@@ -188,11 +188,9 @@ public final class RtReleasesTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("test", "releases"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtRepoTest.java
+++ b/src/test/java/com/jcabi/github/RtRepoTest.java
@@ -434,8 +434,8 @@ public final class RtRepoTest {
     }
 
     /**
-     * Mocks Github
-     * @return github
+     * Mocks Github.
+     * @return Github
      */
     private Github github() {
         final Github github = Mockito.mock(Github.class);

--- a/src/test/java/com/jcabi/github/RtRepoTest.java
+++ b/src/test/java/com/jcabi/github/RtRepoTest.java
@@ -101,6 +101,7 @@ public final class RtRepoTest {
         final Repo repo = RtRepoTest.repo(
             new FakeRequest()
         );
+
         MatcherAssert.assertThat(
             repo.labels(),
             Matchers.notNullValue()
@@ -227,10 +228,11 @@ public final class RtRepoTest {
     public void identifiesItself() throws Exception {
         final Coordinates coords = new Coordinates.Simple("me", "me-branch");
         final Repo repo = new RtRepo(
-            Mockito.mock(Github.class),
+            github(),
             new FakeRequest(),
             coords
         );
+
         MatcherAssert.assertThat(
             repo.coordinates(),
             Matchers.sameInstance(coords)
@@ -423,10 +425,19 @@ public final class RtRepoTest {
      * @return Repo
      */
     private static Repo repo(final Request request) {
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return new RtRepo(
-            Mockito.mock(Github.class),
-            request,
-            new Coordinates.Simple("testuser", "testrepo")
-        );
+                github,
+                request,
+                new Coordinates.Simple("testuser", "testrepo"));
+    }
+
+    private Github github() {
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+        return github;
     }
 }

--- a/src/test/java/com/jcabi/github/RtRepoTest.java
+++ b/src/test/java/com/jcabi/github/RtRepoTest.java
@@ -425,16 +425,18 @@ public final class RtRepoTest {
      * @return Repo
      */
     private static Repo repo(final Request request) {
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return new RtRepo(
                 github,
                 request,
                 new Coordinates.Simple("testuser", "testrepo"));
     }
 
+    /**
+     * Mocks Github
+     * @return github
+     */
     private Github github() {
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();

--- a/src/test/java/com/jcabi/github/RtRepoTest.java
+++ b/src/test/java/com/jcabi/github/RtRepoTest.java
@@ -101,7 +101,6 @@ public final class RtRepoTest {
         final Repo repo = RtRepoTest.repo(
             new FakeRequest()
         );
-
         MatcherAssert.assertThat(
             repo.labels(),
             Matchers.notNullValue()
@@ -228,11 +227,10 @@ public final class RtRepoTest {
     public void identifiesItself() throws Exception {
         final Coordinates coords = new Coordinates.Simple("me", "me-branch");
         final Repo repo = new RtRepo(
-            github(),
+            this.github(),
             new FakeRequest(),
             coords
         );
-
         MatcherAssert.assertThat(
             repo.coordinates(),
             Matchers.sameInstance(coords)

--- a/src/test/java/com/jcabi/github/RtReposTest.java
+++ b/src/test/java/com/jcabi/github/RtReposTest.java
@@ -83,8 +83,14 @@ public final class RtReposTest {
             ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, response))
                 .start(this.resource.port())
         ) {
+            final Github github = Mockito.mock(Github.class);
+            final Repos reposMock = Mockito.mock(Repos.class);
+            Mockito.doReturn(github).when(reposMock).github();
+            Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+            Mockito.doReturn(github).when(reposMock).github();
+
             final RtRepos repos = new RtRepos(
-                Mockito.mock(Github.class),
+                github,
                 new ApacheRequest(container.home())
             );
             final Repo repo = this.rule.repo(repos);
@@ -118,8 +124,15 @@ public final class RtReposTest {
                 )
             ).start(this.resource.port())
         ) {
+
+            final Github github = Mockito.mock(Github.class);
+            final Repos repo = Mockito.mock(Repos.class);
+            Mockito.doReturn(github).when(repo).github();
+            Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+            Mockito.doReturn(github).when(repo).github();
+
             final RtRepos repos = new RtRepos(
-                Mockito.mock(Github.class),
+                github,
                 new ApacheRequest(container.home())
             );
             MatcherAssert.assertThat(
@@ -141,10 +154,14 @@ public final class RtReposTest {
                 new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
             ).start(this.resource.port())
         ) {
-            final Repos repos = new RtRepos(
-                Mockito.mock(Github.class),
-                new ApacheRequest(container.home())
-            );
+            final Github github = Mockito.mock(Github.class);
+            final Repos repo = Mockito.mock(Repos.class);
+            Mockito.doReturn(github).when(repo).github();
+            Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+            Mockito.doReturn(github).when(repo).github();
+
+            final Repos repos = new RtRepos(github, new ApacheRequest(container.home()));
+
             repos.remove(new Coordinates.Simple("", ""));
             final MkQuery query = container.take();
             MatcherAssert.assertThat(

--- a/src/test/java/com/jcabi/github/RtReposTest.java
+++ b/src/test/java/com/jcabi/github/RtReposTest.java
@@ -128,7 +128,6 @@ public final class RtReposTest {
             Mockito.doReturn(github).when(repo).github();
             Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
             Mockito.doReturn(github).when(repo).github();
-
             final RtRepos repos = new RtRepos(
                 github,
                 new ApacheRequest(container.home())
@@ -154,8 +153,10 @@ public final class RtReposTest {
         ) {
             final Github github = Mockito.mock(Github.class);
             Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-            final Repos repos = new RtRepos(github,
-                new ApacheRequest(container.home()));
+            final Repos repos = new RtRepos(
+                github,
+                new ApacheRequest(container.home())
+            );
             repos.remove(new Coordinates.Simple("", ""));
             final MkQuery query = container.take();
             MatcherAssert.assertThat(

--- a/src/test/java/com/jcabi/github/RtReposTest.java
+++ b/src/test/java/com/jcabi/github/RtReposTest.java
@@ -88,7 +88,6 @@ public final class RtReposTest {
             Mockito.doReturn(github).when(reposMock).github();
             Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
             Mockito.doReturn(github).when(reposMock).github();
-
             final RtRepos repos = new RtRepos(
                 github,
                 new ApacheRequest(container.home())
@@ -124,7 +123,6 @@ public final class RtReposTest {
                 )
             ).start(this.resource.port())
         ) {
-
             final Github github = Mockito.mock(Github.class);
             final Repos repo = Mockito.mock(Repos.class);
             Mockito.doReturn(github).when(repo).github();
@@ -155,13 +153,9 @@ public final class RtReposTest {
             ).start(this.resource.port())
         ) {
             final Github github = Mockito.mock(Github.class);
-            final Repos repo = Mockito.mock(Repos.class);
-            Mockito.doReturn(github).when(repo).github();
             Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-            Mockito.doReturn(github).when(repo).github();
-
-            final Repos repos = new RtRepos(github, new ApacheRequest(container.home()));
-
+            final Repos repos = new RtRepos(github,
+                new ApacheRequest(container.home()));
             repos.remove(new Coordinates.Simple("", ""));
             final MkQuery query = container.take();
             MatcherAssert.assertThat(

--- a/src/test/java/com/jcabi/github/RtTreesTest.java
+++ b/src/test/java/com/jcabi/github/RtTreesTest.java
@@ -154,6 +154,11 @@ public final class RtTreesTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
+
+        final Github github = Mockito.mock(Github.class);
+        Mockito.doReturn(github).when(repo).github();
+        Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
+
         return repo;
     }
 

--- a/src/test/java/com/jcabi/github/RtTreesTest.java
+++ b/src/test/java/com/jcabi/github/RtTreesTest.java
@@ -154,11 +154,9 @@ public final class RtTreesTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(new Coordinates.Simple("mark", "test"))
             .when(repo).coordinates();
-
         final Github github = Mockito.mock(Github.class);
         Mockito.doReturn(github).when(repo).github();
         Mockito.doReturn(Constants.ROOT_REPO).when(github).rootRepoPath();
-
         return repo;
     }
 


### PR DESCRIPTION
Per discussion on issue below, took an effort to remove the hardcoded **/repos**

Relates to: https://github.com/jcabi/jcabi-github/issues/1517
