### PR TITLE
feat: get default branch from repo

### DIFF
--- a/src/main/java/com/jcabi/github/Repo.java
+++ b/src/main/java/com/jcabi/github/Repo.java
@@ -45,7 +45,7 @@ import lombok.ToString;
  * @checkstyle MultipleStringLiterals (500 lines)
  */
 @Immutable
-@SuppressWarnings({ "PMD.TooManyMethods", "PMD.ExcessivePublicCount" })
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessivePublicCount"})
 public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
 
     /**
@@ -189,12 +189,20 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
     Iterable<Language> languages() throws IOException;
 
     /**
+     * Get default branch.
+     *
+     * @return Default branch.
+     * @throws IOException If there is any I/O problem.
+     */
+    Branch defaultBranch() throws IOException;
+
+    /**
      * Smart Repo with extra features.
      */
     @Immutable
     @ToString
     @Loggable(Loggable.DEBUG)
-    @EqualsAndHashCode(of = { "repo", "jsn" })
+    @EqualsAndHashCode(of = {"repo", "jsn"})
     final class Smart implements Repo {
         /**
          * Encapsulated Repo.
@@ -204,6 +212,7 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
          * SmartJson object for convenient JSON parsing.
          */
         private final transient SmartJson jsn;
+
         /**
          * Public ctor.
          * @param rep Repo
@@ -232,6 +241,7 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
         public boolean hasDescription() throws IOException {
             return this.jsn.hasNotNull("description");
         }
+
         /**
          * Get its description.
          * @return Description
@@ -240,6 +250,7 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
         public String description() throws IOException {
             return this.jsn.text("description");
         }
+
         /**
          * Is it private?.
          * @return TRUE if it's private
@@ -252,22 +263,27 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
                     .toString().replace("\"", "")
             );
         }
+
         @Override
         public Github github() {
             return this.repo.github();
         }
+
         @Override
         public Coordinates coordinates() {
             return this.repo.coordinates();
         }
+
         @Override
         public Issues issues() {
             return this.repo.issues();
         }
+
         @Override
         public Milestones milestones() {
             return this.repo.milestones();
         }
+
         @Override
         public Pulls pulls() {
             return this.repo.pulls();
@@ -277,68 +293,89 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
         public Hooks hooks() {
             return this.repo.hooks();
         }
+
         @Override
         public IssueEvents issueEvents() {
             return this.repo.issueEvents();
         }
+
         @Override
         public Labels labels() {
             return this.repo.labels();
         }
+
         @Override
         public Assignees assignees() {
             return this.repo.assignees();
         }
+
         @Override
         public Releases releases() {
             return this.repo.releases();
         }
+
         @Override
         public DeployKeys keys() {
             return this.repo.keys();
         }
+
         @Override
         public Forks forks() {
             return this.repo.forks();
         }
+
         @Override
         public Contents contents() {
             return this.repo.contents();
         }
+
         @Override
         public Collaborators collaborators() {
             return this.repo.collaborators();
         }
+
         @Override
         public Git git() {
             return this.repo.git();
         }
+
         @Override
         public Stars stars() {
             return this.repo.stars();
         }
+
         @Override
         public Notifications notifications() {
             return this.repo.notifications();
         }
+
         @Override
         public Iterable<Language> languages() throws IOException {
             return this.repo.languages();
         }
+
+        @Override
+        public Branch defaultBranch() throws IOException {
+            return this.repo.defaultBranch();
+        }
+
         @Override
         public void patch(
             final JsonObject json
         ) throws IOException {
             this.repo.patch(json);
         }
+
         @Override
         public RepoCommits commits() {
             return this.repo.commits();
         }
+
         @Override
         public Branches branches() {
             return this.repo.branches();
         }
+
         @Override
         public JsonObject json() throws IOException {
             return this.repo.json();

--- a/src/main/java/com/jcabi/github/RtRepo.java
+++ b/src/main/java/com/jcabi/github/RtRepo.java
@@ -50,12 +50,12 @@ import lombok.EqualsAndHashCode;
  */
 @Immutable
 @Loggable(Loggable.DEBUG)
-@EqualsAndHashCode(of = { "ghub", "entry", "coords" })
+@EqualsAndHashCode(of = {"ghub", "entry", "coords"})
 @SuppressWarnings
     (
         {
             "PMD.TooManyMethods",
-        "PMD.CouplingBetweenObjects"
+            "PMD.CouplingBetweenObjects"
         }
     )
 final class RtRepo implements Repo {
@@ -213,8 +213,19 @@ final class RtRepo implements Repo {
     }
 
     @Override
+    public Branch defaultBranch() throws IOException {
+        return new RtBranch(
+            this.request,
+            this,
+            this.json().getString("default_branch"),
+            ""
+        );
+    }
+
+    @Override
     public void patch(
-        final JsonObject json)
+        final JsonObject json
+    )
         throws IOException {
         new RtJson(this.request).patch(json);
     }

--- a/src/main/java/com/jcabi/github/mock/MkRepo.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepo.java
@@ -32,6 +32,7 @@ package com.jcabi.github.mock;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Assignees;
+import com.jcabi.github.Branch;
 import com.jcabi.github.Branches;
 import com.jcabi.github.Collaborators;
 import com.jcabi.github.Contents;
@@ -72,7 +73,7 @@ import lombok.ToString;
 @Immutable
 @Loggable(Loggable.DEBUG)
 @ToString
-@EqualsAndHashCode(of = {"storage", "self", "coords" })
+@EqualsAndHashCode(of = {"storage", "self", "coords"})
 @SuppressWarnings
     (
         {
@@ -293,6 +294,11 @@ final class MkRepo implements Repo {
         final int ruby = 777;
         languages.add(new RtLanguage("Ruby", ruby));
         return languages;
+    }
+
+    @Override
+    public Branch defaultBranch() {
+        return this.branches().find("master");
     }
 
     @Override

--- a/src/test/java/com/jcabi/github/RtRepoTest.java
+++ b/src/test/java/com/jcabi/github/RtRepoTest.java
@@ -35,6 +35,7 @@ import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.request.ApacheRequest;
 import com.jcabi.http.request.FakeRequest;
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Iterator;
 import javax.json.Json;
@@ -310,6 +311,34 @@ public final class RtRepoTest {
             new FakeRequest()
         );
         MatcherAssert.assertThat(repo.stars(), Matchers.notNullValue());
+    }
+
+    /**
+     * RtRepo can fetch its default branch.
+     *
+     * @throws IOException If some problem occurs.
+     */
+    @Test
+    public void fetchDefaultBranch() throws IOException {
+        final String expected = "main";
+        try (
+            final MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createObjectBuilder()
+                        .add("default_branch", expected)
+                        .build().toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            MatcherAssert.assertThat(
+                RtRepoTest.repo(
+                    new ApacheRequest(container.home())
+                ).defaultBranch().name(),
+                Matchers.equalTo(expected)
+            );
+            container.stop();
+        }
     }
 
     /**


### PR DESCRIPTION
According with [that doc](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository) we can get `default_branch` from any repo:
```json
{
//..
"forks_count": 9,
"stargazers_count": 80,
"watchers_count": 80,
"size": 108,
"default_branch": "master",
//...
}
```

It could be useful for some cases (like [that](https://github.com/yegor256/rultor/issues/1302)) to get a default repo branch.

