### PR TITLE
feat: MkRepo returns default branch correctly

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkRepo.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepo.java
@@ -298,7 +298,13 @@ final class MkRepo implements Repo {
 
     @Override
     public Branch defaultBranch() {
-        return this.branches().find("master");
+        return new MkBranch(
+            this.storage,
+            this.self,
+            this.coords,
+            "master",
+            ""
+        );
     }
 
     @Override

--- a/src/test/java/com/jcabi/github/mock/MkRepoTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkRepoTest.java
@@ -177,4 +177,22 @@ public final class MkRepoTest {
             Matchers.hasSize(Tv.THREE)
         );
     }
+
+    /**
+     * MkRepo can return its default branch.
+     * @throws IOException if some problem inside.
+     */
+    @Test
+    public void retrievesDefaultBranch() throws IOException {
+        final String user = "testuser5";
+        final Repo repo = new MkRepo(
+            new MkStorage.InFile(),
+            user,
+            new Coordinates.Simple(user, "testrepo5")
+        );
+        MatcherAssert.assertThat(
+            repo.defaultBranch().name(),
+            Matchers.equalTo("master")
+        );
+    }
 }


### PR DESCRIPTION
The `MkRepo` tool now throws an `UnsupportedException` due to the unsupported `find()` method. Despite this, it remains useful to call `defaultBranch` from `MkRepo`, especially for testing purposes.