### PR TITLE
feat(#1613): Replace hardcoded 'master' with default branch

### DIFF
--- a/src/main/java/com/jcabi/github/RtContents.java
+++ b/src/main/java/com/jcabi/github/RtContents.java
@@ -51,7 +51,7 @@ import lombok.EqualsAndHashCode;
  */
 @Immutable
 @Loggable(Loggable.DEBUG)
-@EqualsAndHashCode(of = { "entry", "request", "owner" })
+@EqualsAndHashCode(of = {"entry", "request", "owner"})
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class RtContents implements Contents {
 
@@ -171,7 +171,7 @@ final class RtContents implements Contents {
     public Content get(
         final String path
     ) throws IOException {
-        return this.content(path, "master");
+        return this.content(path, this.repo().defaultBranch().name());
     }
 
     @Override
@@ -215,7 +215,8 @@ final class RtContents implements Contents {
     @Override
     public RepoCommit update(
         final String path,
-        final JsonObject json)
+        final JsonObject json
+    )
         throws IOException {
         return new RtRepoCommit(
             this.entry,
@@ -254,16 +255,16 @@ final class RtContents implements Contents {
         final String name = "ref";
         RtContent content = null;
         final JsonStructure structure = this.request.method(Request.GET)
-                .uri().path(path).queryParam(name, ref).back()
-                .fetch()
-                .as(RestResponse.class)
-                .assertStatus(HttpURLConnection.HTTP_OK)
-                .as(JsonResponse.class)
-                .json().read();
+            .uri().path(path).queryParam(name, ref).back()
+            .fetch()
+            .as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .as(JsonResponse.class)
+            .json().read();
         if (JsonValue.ValueType.OBJECT.equals(structure.getValueType())) {
             content = new RtContent(
-                    this.entry.uri().queryParam(name, ref).back(), this.owner,
-                    ((JsonObject) structure).getString("path")
+                this.entry.uri().queryParam(name, ref).back(), this.owner,
+                ((JsonObject) structure).getString("path")
             );
         }
         return content;

--- a/src/main/java/com/jcabi/github/mock/MkContents.java
+++ b/src/main/java/com/jcabi/github/mock/MkContents.java
@@ -56,8 +56,8 @@ import org.xembly.Directives;
 @Immutable
 @Loggable(Loggable.DEBUG)
 @ToString
-@EqualsAndHashCode(of = { "storage", "self", "coords" })
-@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods" })
+@EqualsAndHashCode(of = {"storage", "self", "coords"})
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 final class MkContents implements Contents {
 
     /**
@@ -104,8 +104,7 @@ final class MkContents implements Contents {
 
     @Override
     public Content readme() throws IOException {
-        // @checkstyle MultipleStringLiterals (1 line)
-        return this.readme("master");
+        return this.readme(this.repo().defaultBranch().name());
     }
 
     @Override
@@ -128,7 +127,7 @@ final class MkContents implements Contents {
             if (json.containsKey("ref")) {
                 branch = json.getString("ref");
             } else {
-                branch = "master";
+                branch = this.repo().defaultBranch().name();
             }
             this.storage.apply(
                 new Directives().xpath(this.xpath()).add("content")
@@ -163,9 +162,13 @@ final class MkContents implements Contents {
     @Override
     public Content get(
         final String path
-    ) {
+    ) throws IOException {
         return new MkContent(
-            this.storage, this.self, this.coords, path, "master"
+            this.storage,
+            this.self,
+            this.coords,
+            path,
+            this.repo().defaultBranch().name()
         );
     }
 
@@ -201,7 +204,7 @@ final class MkContents implements Contents {
             if (content.containsKey("ref")) {
                 branch = content.getString("ref");
             } else {
-                branch = "master";
+                branch = this.repo().defaultBranch().name();
             }
             this.storage.apply(
                 new Directives()
@@ -235,7 +238,7 @@ final class MkContents implements Contents {
             if (json.containsKey(ref)) {
                 branch = json.getString(ref);
             } else {
-                branch = "master";
+                branch = this.repo().defaultBranch().name();
             }
             final String xpath = String.format(
                 // @checkstyle LineLengthCheck (1 line)

--- a/src/main/java/com/jcabi/github/mock/MkReleases.java
+++ b/src/main/java/com/jcabi/github/mock/MkReleases.java
@@ -50,7 +50,7 @@ import org.xembly.Directives;
 @Immutable
 @Loggable(Loggable.DEBUG)
 @ToString
-@EqualsAndHashCode(of = { "storage", "self", "coords" })
+@EqualsAndHashCode(of = {"storage", "self", "coords"})
 final class MkReleases implements Releases {
 
     /**
@@ -128,7 +128,8 @@ final class MkReleases implements Releases {
                 new Directives().xpath(this.xpath()).add("release")
                     .add("id").set(Integer.toString(number)).up()
                     .add("tag_name").set(tag).up()
-                    .add("target_commitish").set("master").up()
+                    .add("target_commitish")
+                    .set(this.repo().defaultBranch().name()).up()
                     .add("name").set("").up()
                     .add("body").set("").up()
                     .add("draft").set("true").up()

--- a/src/main/java/com/jcabi/github/mock/MkSearch.java
+++ b/src/main/java/com/jcabi/github/mock/MkSearch.java
@@ -52,7 +52,7 @@ import lombok.ToString;
 @Immutable
 @Loggable(Loggable.DEBUG)
 @ToString
-@EqualsAndHashCode(of = { "storage", "self" })
+@EqualsAndHashCode(of = {"storage", "self"})
 final class MkSearch implements Search {
 
     /**

--- a/src/test/java/com/jcabi/github/mock/MkSearchTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkSearchTest.java
@@ -114,7 +114,11 @@ public final class MkSearchTest {
             new Repos.RepoCreate("TestCode", false)
         );
         MatcherAssert.assertThat(
-            github.search().codes("jeff", "repositories", Search.Order.DESC),
+            github.search().codes(
+                "jeff",
+                "repositories",
+                Search.Order.DESC
+            ),
             Matchers.not(Matchers.emptyIterable())
         );
     }


### PR DESCRIPTION
Replace hardcoded "master" branch with `repo().defaultBranch().name()`

Closes: #1613 