### PR TITLE
Add "Cheks" classes

### DIFF
--- a/src/main/java/com/jcabi/github/Check.java
+++ b/src/main/java/com/jcabi/github/Check.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2013-2022, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+/**
+ * Github check.
+ *
+ * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
+ * @see <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28">Check Runs API</a>
+ * @since 1.5.0
+ */
+public interface Check {
+}

--- a/src/main/java/com/jcabi/github/Check.java
+++ b/src/main/java/com/jcabi/github/Check.java
@@ -34,7 +34,15 @@ package com.jcabi.github;
  *
  * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
  * @see <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28">Check Runs API</a>
+ * @version $Id$
  * @since 1.5.0
  */
 public interface Check {
+
+    /**
+     * Checks whether Check was successful.
+     * @return True if Check was successful.
+     */
+    boolean successful();
+
 }

--- a/src/main/java/com/jcabi/github/Checks.java
+++ b/src/main/java/com/jcabi/github/Checks.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2013-2022, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import java.util.Collection;
+
+/**
+ * Github checks.
+ *
+ * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
+ * @see <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28">Check Runs API</a>
+ * @since 1.5.0
+ */
+public interface Checks {
+
+    Collection<Check> all();
+
+}

--- a/src/main/java/com/jcabi/github/Checks.java
+++ b/src/main/java/com/jcabi/github/Checks.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github;
 
+import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -40,6 +41,6 @@ import java.util.Collection;
  */
 public interface Checks {
 
-    Collection<Check> all();
+    Collection<Check> all() throws IOException;
 
 }

--- a/src/main/java/com/jcabi/github/Checks.java
+++ b/src/main/java/com/jcabi/github/Checks.java
@@ -37,10 +37,16 @@ import java.util.Collection;
  *
  * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
  * @see <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28">Check Runs API</a>
+ * @version $Id$
  * @since 1.5.0
  */
 public interface Checks {
 
+    /**
+     * Get all checks.
+     * @return Checks.
+     * @throws IOException If there is any I/O problem.
+     */
     Collection<Check> all() throws IOException;
 
 }

--- a/src/main/java/com/jcabi/github/RtCheck.java
+++ b/src/main/java/com/jcabi/github/RtCheck.java
@@ -1,12 +1,248 @@
+/**
+ * Copyright (c) 2013-2022, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jcabi.github;
 
-public class RtCheck implements Check {
+import java.util.Arrays;
+import java.util.Locale;
 
-    private final int id;
-    private final String status;
+/**
+ * Github check.
+ *
+ * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
+ * @see <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28">Check Runs API</a>
+ * @version $Id$
+ * @since 1.5.0
+ */
+class RtCheck implements Check {
 
-    RtCheck(final int identifier, final String stat) {
-        this.id = identifier;
+    /**
+     * Status.
+     */
+    private final transient Status status;
+
+    /**
+     * Conclusion.
+     */
+    private final transient Conclusion conclusion;
+
+    /**
+     * Ctor.
+     * @param stat Status.
+     * @param conc Conclusion.
+     */
+    RtCheck(
+        final String stat,
+        final String conc
+    ) {
+        this(Status.fromString(stat), Conclusion.fromString(conc));
+    }
+
+    /**
+     * Ctor.
+     * @param stat Status.
+     * @param conc Conclusion.
+     */
+    RtCheck(
+        final Status stat,
+        final Conclusion conc
+    ) {
         this.status = stat;
+        this.conclusion = conc;
+    }
+
+    @Override
+    public boolean successful() {
+        return this.status.finished() && this.conclusion.successful();
+    }
+
+    /**
+     * Check status.
+     * You can read more about it
+     * @checkstyle LineLengthCheck (1 lines)
+     * <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference"> here </a>
+     */
+    enum Status {
+        /**
+         * Queued.
+         */
+        QUEUED("queued"),
+
+        /**
+         * In progress.
+         */
+        IN_PROGRESS("in_progress"),
+
+        /**
+         * Completed.
+         */
+        COMPLETED("completed");
+
+        /**
+         * Status.
+         */
+        private final String status;
+
+        /**
+         * Ctor.
+         * @param stat Status.
+         */
+        Status(final String stat) {
+            this.status = stat;
+        }
+
+        /**
+         * Check if check is finished.
+         * @return True if check is finished.
+         */
+        boolean finished() {
+            return this == Status.COMPLETED;
+        }
+
+        /**
+         * Get status from string.
+         * @param value String value.
+         * @return Status.
+         */
+        static Status fromString(final String value) {
+            return Arrays.stream(Status.values())
+                .filter(stat -> stat.same(value))
+                .findFirst()
+                .orElseThrow(
+                    () -> new IllegalArgumentException(
+                        String.format("Invalid value %s for status", value)
+                    )
+                );
+        }
+
+        /**
+         * Check if status is the same as value.
+         * @param value Value.
+         * @return True if status is the same as value.
+         */
+        boolean same(final String value) {
+            return this.status.equals(value.toLowerCase(Locale.ROOT));
+        }
+    }
+
+    /**
+     * Check conclusion.
+     * You can read more about it
+     * @checkstyle LineLengthCheck (1 lines)
+     * <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference"> here </a>
+     */
+    enum Conclusion {
+
+        /**
+         * Action required.
+         */
+        ACTION_REQUIRED("action_required"),
+
+        /**
+         * Cancelled.
+         */
+        CANCELLED("cancelled"),
+
+        /**
+         * Failure.
+         */
+        FAILURE("failure"),
+
+        /**
+         * Neutral.
+         */
+        NEUTRAL("neutral"),
+
+        /**
+         * Success.
+         */
+        SUCCESS("success"),
+
+        /**
+         * Skipped.
+         */
+        SKIPPED("skipped"),
+
+        /**
+         * Stale.
+         */
+        STALE("stale"),
+
+        /**
+         * Timed out.
+         */
+        TIMED_OUT("timed_out");
+
+        /**
+         * Conclusion.
+         */
+        private final String conclusion;
+
+        /**
+         * Ctor.
+         * @param con Conclusion.
+         */
+        Conclusion(final String con) {
+            this.conclusion = con;
+        }
+
+        /**
+         * Check if check is successful.
+         * @return True if check is successful.
+         */
+        boolean successful() {
+            return this == Conclusion.SUCCESS;
+        }
+
+        /**
+         * Get conclusion from string.
+         * @param value String value.
+         * @return Conclusion.
+         */
+        static Conclusion fromString(final String value) {
+            return Arrays.stream(Conclusion.values())
+                .filter(stat -> stat.same(value))
+                .findFirst()
+                .orElseThrow(
+                    () -> new IllegalArgumentException(
+                        String.format("Invalid value %s for conclusion", value)
+                    )
+                );
+        }
+
+        /**
+         * Check if conclusion is the same as value.
+         * @param value Value to compare.
+         * @return True if conclusion is the same as value.
+         */
+        boolean same(final String value) {
+            return this.conclusion.equals(value.toLowerCase(Locale.ROOT));
+        }
     }
 }

--- a/src/main/java/com/jcabi/github/RtCheck.java
+++ b/src/main/java/com/jcabi/github/RtCheck.java
@@ -1,0 +1,12 @@
+package com.jcabi.github;
+
+public class RtCheck implements Check {
+
+    private final int id;
+    private final String status;
+
+    RtCheck(final int identifier, final String stat) {
+        this.id = identifier;
+        this.status = stat;
+    }
+}

--- a/src/main/java/com/jcabi/github/RtChecks.java
+++ b/src/main/java/com/jcabi/github/RtChecks.java
@@ -1,3 +1,32 @@
+/**
+ * Copyright (c) 2013-2022, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jcabi.github;
 
 import com.jcabi.http.Request;
@@ -8,13 +37,33 @@ import java.util.stream.Collectors;
 import javax.json.JsonObject;
 import javax.json.JsonValue;
 
-public class RtChecks implements Checks {
+/**
+ * Github Checks.
+ *
+ * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
+ * @see <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28">Check Runs API</a>
+ * @version $Id$
+ * @since 1.5.0
+ */
+class RtChecks implements Checks {
 
-    private final Pull pull;
-    private final Request request;
+    /**
+     * Pull request.
+     */
+    private final transient Pull pull;
 
-    RtChecks(final Request req, final Pull pr) {
-        this.pull = pr;
+    /**
+     * Http Request.
+     */
+    private final transient Request request;
+
+    /**
+     * Ctor.
+     * @param req Request
+     * @param prequest Pull request
+     */
+    RtChecks(final Request req, final Pull prequest) {
+        this.pull = prequest;
         this.request = req;
     }
 
@@ -56,8 +105,16 @@ public class RtChecks implements Checks {
             .collect(Collectors.toList());
     }
 
+    /**
+     * Get check by id.
+     * @param value Json value.
+     * @return Check.
+     */
     private static RtCheck check(final JsonValue value) {
         final JsonObject check = value.asJsonObject();
-        return new RtCheck(check.getInt("id"), check.getString("status"));
+        return new RtCheck(
+            check.getString("status"),
+            check.getString("conclusion")
+        );
     }
 }

--- a/src/main/java/com/jcabi/github/RtChecks.java
+++ b/src/main/java/com/jcabi/github/RtChecks.java
@@ -1,0 +1,63 @@
+package com.jcabi.github;
+
+import com.jcabi.http.Request;
+import com.jcabi.http.response.JsonResponse;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+
+public class RtChecks implements Checks {
+
+    private final Pull pull;
+    private final Request request;
+
+    RtChecks(final Request req, final Pull pr) {
+        this.pull = pr;
+        this.request = req;
+    }
+
+    /**
+     * Get all checks.
+     * JSON schema:
+     * <p>{@code
+     * {
+     *   "total_count": 1,
+     *   "check_runs": [
+     *     {
+     *       "id": 4,
+     *       "status": "completed",
+     *       ...
+     *     }
+     *   ]
+     * }
+     * }</p>
+     * @return Checks.
+     * @throws IOException If there is any I/O problem.
+     */
+    @Override
+    public Collection<Check> all() throws IOException {
+        final Coordinates coords = this.pull.repo().coordinates();
+        return this.request.uri()
+            .path("/repos")
+            .path(coords.user())
+            .path(coords.repo())
+            .path("/commits")
+            .path(this.pull.head().ref())
+            .path("/check-runs")
+            .back()
+            .method(Request.GET).fetch().as(JsonResponse.class)
+            .json()
+            .readObject()
+            .getJsonArray("check_runs")
+            .stream()
+            .map(RtChecks::check)
+            .collect(Collectors.toList());
+    }
+
+    private static RtCheck check(final JsonValue value) {
+        final JsonObject check = value.asJsonObject();
+        return new RtCheck(check.getInt("id"), check.getString("status"));
+    }
+}

--- a/src/test/java/com/jcabi/github/RtCheckTest.java
+++ b/src/test/java/com/jcabi/github/RtCheckTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2013-2022, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RtCheck}.
+ *
+ * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
+ * @version $Id$
+ * @since 1.5.0
+ */
+public final class RtCheckTest {
+
+    /**
+     * RtCheck can check successful state.
+     */
+    @Test
+    public void checksSuccessfulState() {
+        MatcherAssert.assertThat(
+            new RtCheck(
+                RtCheck.Status.COMPLETED,
+                RtCheck.Conclusion.SUCCESS
+            ).successful(),
+            Matchers.is(true)
+        );
+    }
+
+    /**
+     * RtCheck can check not successful state if in progress.
+     */
+    @Test
+    public void checksNotSuccessfulStateIfInProgress() {
+        MatcherAssert.assertThat(
+            new RtCheck(
+                RtCheck.Status.IN_PROGRESS,
+                RtCheck.Conclusion.SUCCESS
+            ).successful(),
+            Matchers.is(false)
+        );
+    }
+
+    /**
+     * RtCheck can check not successful state if cancelled.
+     */
+    @Test
+    public void checksNotSuccessfulState() {
+        MatcherAssert.assertThat(
+            new RtCheck(
+                RtCheck.Status.COMPLETED,
+                RtCheck.Conclusion.CANCELLED
+            ).successful(),
+            Matchers.is(false)
+        );
+    }
+
+    /**
+     * Can not create RtCheck with unexisting status.
+     */
+    @Test
+    public void createsWithUnexistingStatus() {
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> new RtCheck(
+                "unexisting",
+                "success"
+            ).successful()
+        );
+    }
+
+    /**
+     * Can not create RtCheck with unexisting conclusion.
+     */
+    @Test
+    public void createsWithUnexistingConclusion() {
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> new RtCheck(
+                "completed",
+                "unexist"
+            ).successful()
+        );
+    }
+}

--- a/src/test/java/com/jcabi/github/RtChecksTest.java
+++ b/src/test/java/com/jcabi/github/RtChecksTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2013-2022, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.http.mock.MkAnswer;
+import com.jcabi.http.mock.MkContainer;
+import com.jcabi.http.mock.MkGrizzlyContainer;
+import com.jcabi.http.request.JdkRequest;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import javax.json.Json;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test case for {@link RtChecks}.
+ *
+ * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
+ * @since 1.5.0
+ */
+public final class RtChecksTest {
+
+    /**
+     * The rule for skipping test if there's BindException.
+     * @checkstyle VisibilityModifierCheck (3 lines)
+     */
+    @Rule
+    public final transient RandomPort resource = new RandomPort();
+
+    @Test
+    public void getsAllChecks() throws IOException {
+        try (final MkContainer container = new MkGrizzlyContainer()
+            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, this.json()))
+            .start(this.resource.port())) {
+            final Checks checks = new RtChecks(
+                new JdkRequest(container.home()),
+                this.repo().pulls().get(0)
+            );
+            MatcherAssert.assertThat(
+                checks.all(),
+                Matchers.iterableWithSize(1)
+            );
+        }
+    }
+
+    private String json() {
+        return Json.createObjectBuilder()
+            .add("total_count", Json.createValue(1))
+            .add("check_runs",
+                Json.createArrayBuilder()
+                    .add(
+                        Json.createObjectBuilder()
+                            .add("id", Json.createValue(100))
+                            .add("status", "completed")
+                            .build()
+                    )
+            )
+            .build()
+            .toString();
+    }
+
+    /**
+     * Create and return repo for testing.
+     * @return Repo
+     */
+    private Repo repo() throws IOException {
+        final Repo repo = Mockito.mock(Repo.class);
+        final Pulls pulls = Mockito.mock(Pulls.class);
+        final Pull pull = Mockito.mock(Pull.class);
+        final PullRef ref = Mockito.mock(PullRef.class);
+        Mockito.doReturn(new Coordinates.Simple("volodya-lombrozo", "jtcop"))
+            .when(repo)
+            .coordinates();
+        Mockito.doReturn(pulls).when(repo).pulls();
+        Mockito.doReturn(pull).when(pulls).get(0);
+        Mockito.doReturn(repo).when(pull).repo();
+        Mockito.doReturn(ref).when(pull).head();
+        Mockito.doReturn("abcdef1").when(ref).ref();
+        return repo;
+    }
+
+
+}

--- a/src/test/java/com/jcabi/github/RtChecksTest.java
+++ b/src/test/java/com/jcabi/github/RtChecksTest.java
@@ -35,6 +35,7 @@ import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.request.JdkRequest;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Random;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -46,6 +47,7 @@ import org.mockito.Mockito;
  * Test case for {@link RtChecks}.
  *
  * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
+ * @version $Id$
  * @since 1.5.0
  */
 public final class RtChecksTest {
@@ -57,10 +59,20 @@ public final class RtChecksTest {
     @Rule
     public final transient RandomPort resource = new RandomPort();
 
+    /**
+     * Checks whether RtChecks can get all checks.
+     *
+     * @throws IOException If some problem happens.
+     */
     @Test
     public void getsAllChecks() throws IOException {
         try (final MkContainer container = new MkGrizzlyContainer()
-            .next(new MkAnswer.Simple(HttpURLConnection.HTTP_OK, this.json()))
+            .next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    RtChecksTest.json()
+                )
+            )
             .start(this.resource.port())) {
             final Checks checks = new RtChecks(
                 new JdkRequest(container.home()),
@@ -73,15 +85,22 @@ public final class RtChecksTest {
         }
     }
 
-    private String json() {
+    /**
+     * Creates json response body.
+     *
+     * @return Json response body.
+     */
+    private static String json() {
         return Json.createObjectBuilder()
             .add("total_count", Json.createValue(1))
-            .add("check_runs",
+            .add(
+                "check_runs",
                 Json.createArrayBuilder()
                     .add(
                         Json.createObjectBuilder()
-                            .add("id", Json.createValue(100))
+                            .add("id", Json.createValue(new Random().nextInt()))
                             .add("status", "completed")
+                            .add("conclusion", "success")
                             .build()
                     )
             )
@@ -92,14 +111,16 @@ public final class RtChecksTest {
     /**
      * Create and return repo for testing.
      * @return Repo
+     * @throws IOException If some problem happens.
      */
     private Repo repo() throws IOException {
         final Repo repo = Mockito.mock(Repo.class);
         final Pulls pulls = Mockito.mock(Pulls.class);
         final Pull pull = Mockito.mock(Pull.class);
         final PullRef ref = Mockito.mock(PullRef.class);
-        Mockito.doReturn(new Coordinates.Simple("volodya-lombrozo", "jtcop"))
-            .when(repo)
+        Mockito.doReturn(
+                new Coordinates.Simple("volodya-lombrozo", "jtcop")
+            ).when(repo)
             .coordinates();
         Mockito.doReturn(pulls).when(repo).pulls();
         Mockito.doReturn(pull).when(pulls).get(0);
@@ -108,6 +129,4 @@ public final class RtChecksTest {
         Mockito.doReturn("abcdef1").when(ref).ref();
         return repo;
     }
-
-
 }

--- a/src/test/java/com/jcabi/github/RtCollaboratorsTest.java
+++ b/src/test/java/com/jcabi/github/RtCollaboratorsTest.java
@@ -185,7 +185,7 @@ public final class RtCollaboratorsTest {
      * @param login Username to login
      * @return JsonObject
      */
-    static JsonValue json(final String login) {
+    private static JsonValue json(final String login) {
         return Json.createObjectBuilder()
             .add("login", login)
             .build();

--- a/src/test/java/com/jcabi/github/RtCollaboratorsTest.java
+++ b/src/test/java/com/jcabi/github/RtCollaboratorsTest.java
@@ -185,7 +185,7 @@ public final class RtCollaboratorsTest {
      * @param login Username to login
      * @return JsonObject
      */
-    private static JsonValue json(final String login) {
+    static JsonValue json(final String login) {
         return Json.createObjectBuilder()
             .add("login", login)
             .build();


### PR DESCRIPTION
I have added several classes to the codebase, including:
- `Checks` interface
- `Check` interface
- `RtChecks` class, which implements the `Checks` interface
- `RtCheck` class, which implements the `Check` interface
The PR may seem large due to the addition of excessive JavaDocs. Additionally, I am unsure about the overall design of the added classes.