### PR TITLE
`MkChecks` implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,11 +117,6 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <version>31.1-jre</version>
     </dependency>
     <dependency>
-      <groupId>org.cactoos</groupId>
-      <artifactId>cactoos</artifactId>
-      <version>0.55.0</version>
-    </dependency>
-    <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
       <version>20040616</version>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <version>31.1-jre</version>
     </dependency>
     <dependency>
+      <groupId>org.cactoos</groupId>
+      <artifactId>cactoos</artifactId>
+      <version>0.55.0</version>
+    </dependency>
+    <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
       <version>20040616</version>

--- a/src/main/java/com/jcabi/github/Check.java
+++ b/src/main/java/com/jcabi/github/Check.java
@@ -30,6 +30,8 @@
 package com.jcabi.github;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * Github check.
@@ -48,4 +50,183 @@ public interface Check {
      */
     boolean successful() throws IOException;
 
+    /**
+     * Check status.
+     * You can read more about it
+     * @checkstyle LineLengthCheck (1 lines)
+     * <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference"> here </a>
+     */
+    enum Status {
+        /**
+         * Queued.
+         */
+        QUEUED("queued"),
+
+        /**
+         * In progress.
+         */
+        IN_PROGRESS("in_progress"),
+
+        /**
+         * Completed.
+         */
+        COMPLETED("completed");
+
+        /**
+         * Status.
+         */
+        private final String status;
+
+        /**
+         * Ctor.
+         * @param stat Status.
+         */
+        Status(final String stat) {
+            this.status = stat;
+        }
+
+        /**
+         * Status.
+         * @return Status.
+         */
+        public String value() {
+            return this.status;
+        }
+
+        /**
+         * Get status from string.
+         * @param value String value.
+         * @return Status.
+         */
+        public static Status fromString(final String value) {
+            return Arrays.stream(Status.values())
+                .filter(stat -> stat.same(value))
+                .findFirst()
+                .orElseThrow(
+                    () -> new IllegalArgumentException(
+                        String.format("Invalid value %s for status", value)
+                    )
+                );
+        }
+
+        /**
+         * Check if check is finished.
+         * @return True if check is finished.
+         */
+        boolean finished() {
+            return this == Status.COMPLETED;
+        }
+
+        /**
+         * Check if status is the same as value.
+         * @param value Value.
+         * @return True if status is the same as value.
+         */
+        boolean same(final String value) {
+            return this.status.equals(value.toLowerCase(Locale.ROOT));
+        }
+    }
+
+    /**
+     * Check conclusion.
+     * You can read more about it
+     * @checkstyle LineLengthCheck (1 lines)
+     * <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference"> here </a>
+     */
+    enum Conclusion {
+
+        /**
+         * Action required.
+         */
+        ACTION_REQUIRED("action_required"),
+
+        /**
+         * Cancelled.
+         */
+        CANCELLED("cancelled"),
+
+        /**
+         * Failure.
+         */
+        FAILURE("failure"),
+
+        /**
+         * Neutral.
+         */
+        NEUTRAL("neutral"),
+
+        /**
+         * Success.
+         */
+        SUCCESS("success"),
+
+        /**
+         * Skipped.
+         */
+        SKIPPED("skipped"),
+
+        /**
+         * Stale.
+         */
+        STALE("stale"),
+
+        /**
+         * Timed out.
+         */
+        TIMED_OUT("timed_out");
+
+        /**
+         * Conclusion.
+         */
+        private final String conclusion;
+
+        /**
+         * Ctor.
+         * @param con Conclusion.
+         */
+        Conclusion(final String con) {
+            this.conclusion = con;
+        }
+
+        /**
+         * Get conclusion from string.
+         * @param value String value.
+         * @return Conclusion.
+         */
+        public static Conclusion fromString(final String value) {
+            return Arrays.stream(Conclusion.values())
+                .filter(stat -> stat.same(value))
+                .findFirst()
+                .orElseThrow(
+                    () -> new IllegalArgumentException(
+                        String.format("Invalid value %s for conclusion", value)
+                    )
+                );
+        }
+
+        /**
+         * Conclusion.
+         * @return Conclusion.
+         */
+        public String value() {
+            return this.conclusion;
+        }
+
+        /**
+         * Check if check is successful.
+         * @return True if check is successful.
+         */
+        boolean successful() {
+            return this == Conclusion.SUCCESS;
+        }
+
+        /**
+         * Check if conclusion is the same as value.
+         * @param value Value to compare.
+         * @return True if conclusion is the same as value.
+         */
+        boolean same(final String value) {
+            return this.conclusion.equals(value.toLowerCase(Locale.ROOT));
+        }
+    }
 }

--- a/src/main/java/com/jcabi/github/RtCheck.java
+++ b/src/main/java/com/jcabi/github/RtCheck.java
@@ -29,9 +29,6 @@
  */
 package com.jcabi.github;
 
-import java.util.Arrays;
-import java.util.Locale;
-
 /**
  * Github check.
  *
@@ -57,10 +54,7 @@ class RtCheck implements Check {
      * @param stat Status.
      * @param conc Conclusion.
      */
-    RtCheck(
-        final String stat,
-        final String conc
-    ) {
+    RtCheck(final String stat, final String conc) {
         this(Status.fromString(stat), Conclusion.fromString(conc));
     }
 
@@ -80,169 +74,5 @@ class RtCheck implements Check {
     @Override
     public boolean successful() {
         return this.status.finished() && this.conclusion.successful();
-    }
-
-    /**
-     * Check status.
-     * You can read more about it
-     * @checkstyle LineLengthCheck (1 lines)
-     * <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference"> here </a>
-     */
-    enum Status {
-        /**
-         * Queued.
-         */
-        QUEUED("queued"),
-
-        /**
-         * In progress.
-         */
-        IN_PROGRESS("in_progress"),
-
-        /**
-         * Completed.
-         */
-        COMPLETED("completed");
-
-        /**
-         * Status.
-         */
-        private final String status;
-
-        /**
-         * Ctor.
-         * @param stat Status.
-         */
-        Status(final String stat) {
-            this.status = stat;
-        }
-
-        /**
-         * Check if check is finished.
-         * @return True if check is finished.
-         */
-        boolean finished() {
-            return this == Status.COMPLETED;
-        }
-
-        /**
-         * Get status from string.
-         * @param value String value.
-         * @return Status.
-         */
-        static Status fromString(final String value) {
-            return Arrays.stream(Status.values())
-                .filter(stat -> stat.same(value))
-                .findFirst()
-                .orElseThrow(
-                    () -> new IllegalArgumentException(
-                        String.format("Invalid value %s for status", value)
-                    )
-                );
-        }
-
-        /**
-         * Check if status is the same as value.
-         * @param value Value.
-         * @return True if status is the same as value.
-         */
-        boolean same(final String value) {
-            return this.status.equals(value.toLowerCase(Locale.ROOT));
-        }
-    }
-
-    /**
-     * Check conclusion.
-     * You can read more about it
-     * @checkstyle LineLengthCheck (1 lines)
-     * <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference"> here </a>
-     */
-    enum Conclusion {
-
-        /**
-         * Action required.
-         */
-        ACTION_REQUIRED("action_required"),
-
-        /**
-         * Cancelled.
-         */
-        CANCELLED("cancelled"),
-
-        /**
-         * Failure.
-         */
-        FAILURE("failure"),
-
-        /**
-         * Neutral.
-         */
-        NEUTRAL("neutral"),
-
-        /**
-         * Success.
-         */
-        SUCCESS("success"),
-
-        /**
-         * Skipped.
-         */
-        SKIPPED("skipped"),
-
-        /**
-         * Stale.
-         */
-        STALE("stale"),
-
-        /**
-         * Timed out.
-         */
-        TIMED_OUT("timed_out");
-
-        /**
-         * Conclusion.
-         */
-        private final String conclusion;
-
-        /**
-         * Ctor.
-         * @param con Conclusion.
-         */
-        Conclusion(final String con) {
-            this.conclusion = con;
-        }
-
-        /**
-         * Check if check is successful.
-         * @return True if check is successful.
-         */
-        boolean successful() {
-            return this == Conclusion.SUCCESS;
-        }
-
-        /**
-         * Get conclusion from string.
-         * @param value String value.
-         * @return Conclusion.
-         */
-        static Conclusion fromString(final String value) {
-            return Arrays.stream(Conclusion.values())
-                .filter(stat -> stat.same(value))
-                .findFirst()
-                .orElseThrow(
-                    () -> new IllegalArgumentException(
-                        String.format("Invalid value %s for conclusion", value)
-                    )
-                );
-        }
-
-        /**
-         * Check if conclusion is the same as value.
-         * @param value Value to compare.
-         * @return True if conclusion is the same as value.
-         */
-        boolean same(final String value) {
-            return this.conclusion.equals(value.toLowerCase(Locale.ROOT));
-        }
     }
 }

--- a/src/main/java/com/jcabi/github/mock/MkCheck.java
+++ b/src/main/java/com/jcabi/github/mock/MkCheck.java
@@ -34,10 +34,10 @@ import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Check;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Pull;
+import com.jcabi.xml.XML;
 import java.io.IOException;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.xembly.Directives;
 
 /**
  * Mock Github check.
@@ -94,8 +94,15 @@ public final class MkCheck implements Check {
 
     @Override
     public boolean successful() throws IOException {
-        this.storage.apply(new Directives(this.xpath()));
-        return false;
+        final XML node = this.storage.xml().nodes(this.xpath()).get(0);
+        final Status status = Status.fromString(
+            node.xpath("@status").get(0)
+        );
+        final Conclusion conclusion = Conclusion.fromString(
+            node.xpath("@conclusion").get(0)
+        );
+        return status == Status.COMPLETED
+            && conclusion == Conclusion.SUCCESS;
     }
 
     /**
@@ -105,7 +112,7 @@ public final class MkCheck implements Check {
     private String xpath() {
         return String.format(
             // @checkstyle LineLength (1 line)
-            "/github/repos/repo[@coords='%s']/pulls/pull[number='%d']/checks/check[id='%d']",
+            "/github/repos/repo[@coords='%s']/pulls/pull[number='%d']/checks/check[@id='%d']",
             this.coordinates, this.pull.number(), this.identifier
         );
     }

--- a/src/main/java/com/jcabi/github/mock/MkChecks.java
+++ b/src/main/java/com/jcabi/github/mock/MkChecks.java
@@ -97,17 +97,22 @@ public final class MkChecks implements Checks {
 
     /**
      * Create check.
+     * @param status Status.
+     * @param conclusion Conclusion.
      * @return Check.
      * @throws IOException If fails.
      */
-    public Check create() throws IOException {
+    public Check create(
+        final Check.Status status,
+        final Check.Conclusion conclusion
+    ) throws IOException {
         final int identifier = new SecureRandom().nextInt();
         final Directives directives = new Directives()
             .xpath(this.xpath())
             .add("check")
             .attr("id", identifier)
-            .attr("status", "queued")
-            .attr("conclusion", "cancelled")
+            .attr("status", status.value())
+            .attr("conclusion", conclusion.value())
             .up();
         this.storage.apply(directives);
         return new MkCheck(

--- a/src/main/java/com/jcabi/github/mock/MkChecks.java
+++ b/src/main/java/com/jcabi/github/mock/MkChecks.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.github.mock;
 
+import com.google.common.collect.ImmutableList;
 import com.jcabi.github.Check;
 import com.jcabi.github.Checks;
 import com.jcabi.github.Coordinates;
@@ -36,7 +37,6 @@ import com.jcabi.github.Pull;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Collection;
-import org.cactoos.list.ListOf;
 import org.xembly.Directives;
 
 /**
@@ -81,7 +81,7 @@ public final class MkChecks implements Checks {
 
     @Override
     public Collection<Check> all() throws IOException {
-        return new ListOf<>(
+        return ImmutableList.copyOf(
             new MkIterable<>(
                 this.storage,
                 String.format("%s/check", this.xpath()),

--- a/src/main/java/com/jcabi/github/mock/MkPull.java
+++ b/src/main/java/com/jcabi/github/mock/MkPull.java
@@ -220,7 +220,7 @@ final class MkPull implements Pull {
      */
     @Override
     public Checks checks() {
-        return new MkChecks();
+        return new MkChecks(this.storage, this.coords, this);
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/mock/MkPulls.java
+++ b/src/main/java/com/jcabi/github/mock/MkPulls.java
@@ -144,6 +144,7 @@ final class MkPulls implements Pulls {
                     .add("number").set(Integer.toString(number)).up()
                     .add("head").set(canonical).up()
                     .add("base").set(base).up()
+                    .add("checks").up()
                     .add("user")
                     .add("login").set(this.self)
                     .up()

--- a/src/test/java/com/jcabi/github/RtCheckTest.java
+++ b/src/test/java/com/jcabi/github/RtCheckTest.java
@@ -50,8 +50,8 @@ public final class RtCheckTest {
     public void checksSuccessfulState() {
         MatcherAssert.assertThat(
             new RtCheck(
-                RtCheck.Status.COMPLETED,
-                RtCheck.Conclusion.SUCCESS
+                Check.Status.COMPLETED,
+                Check.Conclusion.SUCCESS
             ).successful(),
             Matchers.is(true)
         );
@@ -64,8 +64,8 @@ public final class RtCheckTest {
     public void checksNotSuccessfulStateIfInProgress() {
         MatcherAssert.assertThat(
             new RtCheck(
-                RtCheck.Status.IN_PROGRESS,
-                RtCheck.Conclusion.SUCCESS
+                Check.Status.IN_PROGRESS,
+                Check.Conclusion.SUCCESS
             ).successful(),
             Matchers.is(false)
         );
@@ -78,8 +78,8 @@ public final class RtCheckTest {
     public void checksNotSuccessfulState() {
         MatcherAssert.assertThat(
             new RtCheck(
-                RtCheck.Status.COMPLETED,
-                RtCheck.Conclusion.CANCELLED
+                Check.Status.COMPLETED,
+                Check.Conclusion.CANCELLED
             ).successful(),
             Matchers.is(false)
         );

--- a/src/test/java/com/jcabi/github/mock/MkCheckTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCheckTest.java
@@ -38,13 +38,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test case for {@link MkChecks}.
+ * Test case for {@link MkCheck}.
  *
  * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
  * @version $Id$
  * @since 1.6.1
  */
-public final class MkChecksTest {
+public final class MkCheckTest {
 
     /**
      * Pull request.
@@ -53,51 +53,43 @@ public final class MkChecksTest {
 
     /**
      * Set up.
-     * @throws IOException If some problem with I/O.
+     * @throws java.io.IOException If some problem with I/O.
      */
     @Before
     public void setUp() throws IOException {
         this.pull = new MkGithub()
             .randomRepo()
             .pulls()
-            .create("Test PR", "abcdef8", "abcdef9");
+            .create("Test PR", "abcdea8", "abcdea9");
     }
 
     /**
-     * MkChecks can return empty checks by default.
+     * MkChecks can create successful check.
      * @throws IOException If some problem with I/O.
      */
     @Test
-    public void returnsEmptyChecksByDefault() throws IOException {
+    public void createsSuccessfulCheck() throws IOException {
         MatcherAssert.assertThat(
-            ((MkChecks) this.pull.checks()).all(),
-            Matchers.empty()
-        );
-    }
-
-    /**
-     * MkChecks can create a check.
-     * @throws IOException If some problem with I/O.
-     */
-    @Test
-    public void createsCheck() throws IOException {
-        final MkChecks checks = (MkChecks) this.pull.checks();
-        final Check check = checks.create(
-            Check.Status.COMPLETED,
-            Check.Conclusion.SUCCESS
-        );
-        MatcherAssert.assertThat(
-            checks.all(),
-            Matchers.hasSize(1)
-        );
-        final Check next = checks.all().iterator().next();
-        MatcherAssert.assertThat(
-            check,
-            Matchers.equalTo(next)
-        );
-        MatcherAssert.assertThat(
-            next.successful(),
+            ((MkChecks) this.pull.checks())
+                .create(Check.Status.COMPLETED, Check.Conclusion.SUCCESS)
+                .successful(),
             Matchers.is(true)
+        );
+    }
+
+    /**
+     * MkChecks can create failed check.
+     * @throws IOException If some problem with I/O.
+     */
+    @Test
+    public void createsFailedCheck() throws IOException {
+        MatcherAssert.assertThat(
+            ((MkChecks) this.pull.checks())
+                .create(
+                    Check.Status.COMPLETED,
+                    Check.Conclusion.FAILURE
+                ).successful(),
+            Matchers.is(false)
         );
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkChecksTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkChecksTest.java
@@ -27,25 +27,69 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.jcabi.github;
+package com.jcabi.github.mock;
 
+import com.jcabi.github.Check;
+import com.jcabi.github.Pull;
 import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
- * Github check.
+ * Test case for {@link MkChecks}.
  *
  * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
- * @see <a href="https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28">Check Runs API</a>
  * @version $Id$
- * @since 1.5.0
+ * @since 1.6.1
  */
-public interface Check {
+public final class MkChecksTest {
 
     /**
-     * Checks whether Check was successful.
-     * @return True if Check was successful.
-     * @throws IOException If there is any I/O problem.
+     * Pull request.
      */
-    boolean successful() throws IOException;
+    private transient Pull pull;
 
+    /**
+     * Set up.
+     * @throws IOException If some problem with I/O.
+     */
+    @Before
+    public void setUp() throws IOException {
+        this.pull = new MkGithub()
+            .randomRepo()
+            .pulls()
+            .create("Test PR", "abcdef8", "abcdef9");
+    }
+
+    /**
+     * MkChecks can return empty checks by default.
+     * @throws IOException If some problem with I/O.
+     */
+    @Test
+    public void returnsEmptyChecksByDefault() throws IOException {
+        MatcherAssert.assertThat(
+            ((MkChecks) this.pull.checks()).all(),
+            Matchers.empty()
+        );
+    }
+
+    /**
+     * MkChecks can create a check.
+     * @throws IOException If some problem with I/O.
+     */
+    @Test
+    public void createsCheck() throws IOException {
+        final MkChecks checks = (MkChecks) this.pull.checks();
+        final Check check = checks.create();
+        MatcherAssert.assertThat(
+            checks.all(),
+            Matchers.hasSize(1)
+        );
+        MatcherAssert.assertThat(
+            check,
+            Matchers.equalTo(checks.all().iterator().next())
+        );
+    }
 }


### PR DESCRIPTION
I started implementing a feature related to `Checks`, but I quickly realized that I lacked testing capabilities. Therefore, I decided to improve my implementation by adding correct implementations of `MkChecks` and `MkCheck`. In my pull request, I added the following changes:

1. Implemented `MkChecks` and `MkCheck`.
2. Added tests for `MkChecks` and `MkCheck`.
3. Moved the Status and Conclusion enums into the Check interface.
___
Please, let me know if that PR too big, I'll try to split it.