### PR TITLE
Make `RtChecks` more safe

### DIFF
--- a/src/main/java/com/jcabi/github/Checks.java
+++ b/src/main/java/com/jcabi/github/Checks.java
@@ -47,6 +47,6 @@ public interface Checks {
      * @return Checks.
      * @throws IOException If there is any I/O problem.
      */
-    Collection<Check> all() throws IOException;
+    Collection<? extends Check> all() throws IOException;
 
 }

--- a/src/main/java/com/jcabi/github/RtChecks.java
+++ b/src/main/java/com/jcabi/github/RtChecks.java
@@ -97,15 +97,21 @@ class RtChecks implements Checks {
             .path(coords.user())
             .path(coords.repo())
             .path("/commits")
-            .path(this.pull.head().ref())
+            .path(this.pull.head().sha())
             .path("/check-runs")
             .back()
             .method(Request.GET).fetch()
             .as(RestResponse.class)
             .assertStatus(HttpURLConnection.HTTP_OK);
-        final JsonObject object = rest.as(JsonResponse.class).json().readObject();
+        final JsonObject object = rest.as(JsonResponse.class)
+            .json()
+            .readObject();
         return Optional.ofNullable(object.getJsonArray("check_runs"))
-            .map(obj -> obj.stream().map(RtChecks::check).collect(Collectors.toList()))
+            .map(
+                obj -> obj.stream()
+                    .map(RtChecks::check)
+                    .collect(Collectors.toList())
+            )
             .orElseGet(Collections::emptyList);
     }
 

--- a/src/main/java/com/jcabi/github/RtChecks.java
+++ b/src/main/java/com/jcabi/github/RtChecks.java
@@ -35,6 +35,8 @@ import com.jcabi.http.response.RestResponse;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.json.JsonObject;
 import javax.json.JsonValue;
@@ -88,9 +90,9 @@ class RtChecks implements Checks {
      * @throws IOException If there is any I/O problem.
      */
     @Override
-    public Collection<Check> all() throws IOException {
+    public Collection<? extends Check> all() throws IOException {
         final Coordinates coords = this.pull.repo().coordinates();
-        return this.request.uri()
+        final RestResponse rest = this.request.uri()
             .path("/repos")
             .path(coords.user())
             .path(coords.repo())
@@ -100,14 +102,11 @@ class RtChecks implements Checks {
             .back()
             .method(Request.GET).fetch()
             .as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK)
-            .as(JsonResponse.class)
-            .json()
-            .readObject()
-            .getJsonArray("check_runs")
-            .stream()
-            .map(RtChecks::check)
-            .collect(Collectors.toList());
+            .assertStatus(HttpURLConnection.HTTP_OK);
+        final JsonObject object = rest.as(JsonResponse.class).json().readObject();
+        return Optional.ofNullable(object.getJsonArray("check_runs"))
+            .map(obj -> obj.stream().map(RtChecks::check).collect(Collectors.toList()))
+            .orElseGet(Collections::emptyList);
     }
 
     /**

--- a/src/main/java/com/jcabi/github/RtChecks.java
+++ b/src/main/java/com/jcabi/github/RtChecks.java
@@ -31,7 +31,9 @@ package com.jcabi.github;
 
 import com.jcabi.http.Request;
 import com.jcabi.http.response.JsonResponse;
+import com.jcabi.http.response.RestResponse;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import javax.json.JsonObject;
@@ -96,7 +98,10 @@ class RtChecks implements Checks {
             .path(this.pull.head().ref())
             .path("/check-runs")
             .back()
-            .method(Request.GET).fetch().as(JsonResponse.class)
+            .method(Request.GET).fetch()
+            .as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .as(JsonResponse.class)
             .json()
             .readObject()
             .getJsonArray("check_runs")

--- a/src/test/java/com/jcabi/github/RtChecksTest.java
+++ b/src/test/java/com/jcabi/github/RtChecksTest.java
@@ -86,13 +86,18 @@ public final class RtChecksTest {
         }
     }
 
+    /**
+     * Checks whether RtChecks can return empty checks if they are absent.
+     *
+     * @throws IOException If some I/O problem happens.
+     */
     @Test
     public void returnsEmptyChecksIfTheyAreAbsent() throws IOException {
         try (final MkContainer container = new MkGrizzlyContainer()
             .next(
                 new MkAnswer.Simple(
                     HttpURLConnection.HTTP_OK,
-                    RtChecksTest.jsonWithoutCheckRuns()
+                    RtChecksTest.empty()
                 )
             )
             .start(this.resource.port())) {
@@ -106,6 +111,12 @@ public final class RtChecksTest {
         }
     }
 
+    /**
+     * Checks whether RtChecks can throw an exception
+     * if response code is not 200.
+     *
+     * @throws IOException If some I/O problem happens.
+     */
     @Test
     public void assertsOkResponse() throws IOException {
         try (final MkContainer container = new MkGrizzlyContainer()
@@ -150,9 +161,12 @@ public final class RtChecksTest {
             .toString();
     }
 
-    private static String jsonWithoutCheckRuns() {
+    /**
+     * Creates json response body without check runs.
+     * @return Json response body.
+     */
+    private static String empty() {
         return Json.createObjectBuilder()
-            .add("total_count", Json.createValue(1))
             .build()
             .toString();
     }
@@ -175,7 +189,7 @@ public final class RtChecksTest {
         Mockito.doReturn(pull).when(pulls).get(0);
         Mockito.doReturn(repo).when(pull).repo();
         Mockito.doReturn(ref).when(pull).head();
-        Mockito.doReturn("abcdef1").when(ref).ref();
+        Mockito.doReturn("abcdef1").when(ref).sha();
         return repo;
     }
 }

--- a/src/test/java/com/jcabi/github/RtChecksTest.java
+++ b/src/test/java/com/jcabi/github/RtChecksTest.java
@@ -96,13 +96,12 @@ public final class RtChecksTest {
                 )
             )
             .start(this.resource.port())) {
-            final Checks checks = new RtChecks(
-                new JdkRequest(container.home()),
-                this.repo().pulls().get(0)
-            );
             MatcherAssert.assertThat(
-                checks.all(),
-                Matchers.iterableWithSize(1)
+                ((Checks) new RtChecks(
+                    new JdkRequest(container.home()),
+                    this.repo().pulls().get(0)
+                )).all(),
+                Matchers.iterableWithSize(0)
             );
         }
     }

--- a/src/test/java/com/jcabi/github/RtPullTest.java
+++ b/src/test/java/com/jcabi/github/RtPullTest.java
@@ -266,7 +266,7 @@ public final class RtPullTest {
                     ))
                 .start(this.resource.port())
         ) {
-            final Collection<Check> all = new RtPull(
+            final Collection<? extends Check> all = new RtPull(
                 new ApacheRequest(container.home()),
                 this.repo(),
                 new Random().nextInt()


### PR DESCRIPTION
In that PR:
1. Added check for `check_runs` json field - if it's empty (or absent) we just return empty list of checks.
2. Added check for `200 OK` response in order to print full error massage from HTTP response in case of error. 
3. Use `sha` instead of named `ref` - more secure.