### PR TITLE
feat(#1626): use default branch instead of hardcoded value

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -28,4 +28,4 @@ jobs:
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
       - run: java -version
       - run: mvn -version
-      - run: mvn --errors --batch-mode -Dinvoker.skip -DskipITs clean install -Pqulice
+      - run: mvn --errors --batch-mode -"Dinvoker.skip" -"DskipITs" clean install -Pqulice

--- a/src/main/java/com/jcabi/github/RtContents.java
+++ b/src/main/java/com/jcabi/github/RtContents.java
@@ -171,7 +171,7 @@ final class RtContents implements Contents {
     public Content get(
         final String path
     ) throws IOException {
-        return this.content(path, "master");
+        return this.content(path, this.repo().defaultBranch().name());
     }
 
     @Override


### PR DESCRIPTION
Use default branch instead of hardcoded `master` value inside `RtContents`.

Closes: #1626 