### PR TITLE
Handle unfinished checks

### DIFF
--- a/src/main/java/com/jcabi/github/Check.java
+++ b/src/main/java/com/jcabi/github/Check.java
@@ -44,6 +44,11 @@ import java.util.Locale;
 public interface Check {
 
     /**
+     * Undefined status or conclusion.
+     */
+    String UNDEFINED_VALUE = "undefined";
+
+    /**
      * Checks whether Check was successful.
      * @return True if Check was successful.
      * @throws IOException If there is any I/O problem.
@@ -70,7 +75,12 @@ public interface Check {
         /**
          * Completed.
          */
-        COMPLETED("completed");
+        COMPLETED("completed"),
+
+        /**
+         * Undefined. If GitHub response doesn't contain the Status value.
+         */
+        UNDEFINED(Check.UNDEFINED_VALUE);
 
         /**
          * Status.
@@ -173,7 +183,12 @@ public interface Check {
         /**
          * Timed out.
          */
-        TIMED_OUT("timed_out");
+        TIMED_OUT("timed_out"),
+
+        /**
+         * Undefined. If GitHub response doesn't contain the Conclusion value.
+         */
+        UNDEFINED(Check.UNDEFINED_VALUE);
 
         /**
          * Conclusion.

--- a/src/main/java/com/jcabi/github/RtChecks.java
+++ b/src/main/java/com/jcabi/github/RtChecks.java
@@ -123,8 +123,27 @@ class RtChecks implements Checks {
     private static RtCheck check(final JsonValue value) {
         final JsonObject check = value.asJsonObject();
         return new RtCheck(
-            check.getString("status"),
-            check.getString("conclusion")
+            RtChecks.getOrUndefined("status", check),
+            RtChecks.getOrUndefined("conclusion", check)
         );
+    }
+
+    /**
+     * Retrieves String value from JsonObject by key or return "undefined".
+     * @param key Json key.
+     * @param check Retrieve from
+     * @return Json String value or "undefined".
+     */
+    private static String getOrUndefined(
+        final String key,
+        final JsonObject check
+    ) {
+        final String res;
+        if (check.containsKey(key)) {
+            res = check.getString(key);
+        } else {
+            res = Check.UNDEFINED_VALUE;
+        }
+        return res;
     }
 }

--- a/src/main/java/com/jcabi/github/RtChecks.java
+++ b/src/main/java/com/jcabi/github/RtChecks.java
@@ -139,7 +139,7 @@ class RtChecks implements Checks {
         final JsonObject check
     ) {
         final String res;
-        if (check.containsKey(key)) {
+        if (check.containsKey(key) && !check.isNull(key)) {
             res = check.getString(key);
         } else {
             res = Check.UNDEFINED_VALUE;

--- a/src/test/java/com/jcabi/github/RtChecksTest.java
+++ b/src/test/java/com/jcabi/github/RtChecksTest.java
@@ -138,6 +138,71 @@ public final class RtChecksTest {
         }
     }
 
+    @Test
+    public void retrievesUnfinishedChecksWithoutConclusion() throws IOException {
+        try (final MkContainer container = new MkGrizzlyContainer()
+            .next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createObjectBuilder()
+                        .add("total_count", Json.createValue(1))
+                        .add("check_runs",
+                            Json.createArrayBuilder()
+                                .add(
+                                    Json.createObjectBuilder()
+                                        .add("id", Json.createValue(new Random().nextInt()))
+                                        .add("status", "completed")
+                                        .build()
+                                )
+                        )
+                        .build()
+                        .toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final Checks checks = new RtChecks(
+                new JdkRequest(container.home()),
+                this.repo().pulls().get(0)
+            );
+            MatcherAssert.assertThat(checks.all(), Matchers.hasSize(1));
+            for (final Check check : checks.all()) {
+                MatcherAssert.assertThat(check.successful(), Matchers.is(false));
+            }
+        }
+    }
+
+    @Test
+    public void retrievesUnfinishedChecksWithoutStatusAndConclusion() throws IOException {
+        try (final MkContainer container = new MkGrizzlyContainer()
+            .next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createObjectBuilder()
+                        .add("total_count", Json.createValue(1))
+                        .add("check_runs",
+                            Json.createArrayBuilder()
+                                .add(
+                                    Json.createObjectBuilder()
+                                        .add("id", Json.createValue(new Random().nextInt()))
+                                        .build()
+                                )
+                        )
+                        .build()
+                        .toString()
+                )
+            ).start(this.resource.port())
+        ) {
+            final Checks checks = new RtChecks(
+                new JdkRequest(container.home()),
+                this.repo().pulls().get(0)
+            );
+            MatcherAssert.assertThat(checks.all(), Matchers.hasSize(1));
+            for (final Check check : checks.all()) {
+                MatcherAssert.assertThat(check.successful(), Matchers.is(false));
+            }
+        }
+    }
+
     /**
      * Creates json response body.
      *


### PR DESCRIPTION
If check isn't finished GitHub returns the JSON with `"conclusion":null` which causes some errors like that [issue](https://github.com/yegor256/rultor/issues/1678#issue-1655780653).
I've added the logic that handle that situation. 