### PR TITLE
feat(#1660): Add support of stargazers. Allows to retrieve list of stargazers from a repo

### DIFF
--- a/src/main/java/com/jcabi/github/Repo.java
+++ b/src/main/java/com/jcabi/github/Repo.java
@@ -197,6 +197,12 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
     Branch defaultBranch() throws IOException;
 
     /**
+     * Lists the people that have starred the repository.
+     * @return Lists the people that have starred the repository.
+     */
+    Stargazers stargazers();
+
+    /**
      * Smart Repo with extra features.
      */
     @Immutable
@@ -357,6 +363,13 @@ public interface Repo extends JsonReadable, JsonPatchable, Comparable<Repo> {
         @Override
         public Branch defaultBranch() throws IOException {
             return this.repo.defaultBranch();
+        }
+
+        @Override
+        public Stargazers stargazers() {
+            throw new UnsupportedOperationException(
+                "stargazers() not yet implemented"
+            );
         }
 
         @Override

--- a/src/main/java/com/jcabi/github/RtRepo.java
+++ b/src/main/java/com/jcabi/github/RtRepo.java
@@ -223,6 +223,11 @@ final class RtRepo implements Repo {
     }
 
     @Override
+    public Stargazers stargazers() {
+        return new RtStargazers(this.request);
+    }
+
+    @Override
     public void patch(
         final JsonObject json
     )

--- a/src/main/java/com/jcabi/github/RtStargazers.java
+++ b/src/main/java/com/jcabi/github/RtStargazers.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2013-2023, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import com.jcabi.http.Request;
+import com.jcabi.http.response.JsonResponse;
+import java.io.IOException;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+
+/**
+ * GitHub stargazers.
+ *
+ * @version $Id $
+ * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
+ * @since 1.7.1
+ */
+public final class RtStargazers implements Stargazers {
+
+    /**
+     * RESTful request.
+     */
+    private final transient Request request;
+
+    /**
+     * Public ctor.
+     * @param entry Entry request.
+     */
+    RtStargazers(final Request entry) {
+        this.request = entry.uri()
+            .path("stargazers")
+            .back();
+    }
+
+    @Override
+    public Iterable<JsonValue> iterable() throws IOException {
+        final Iterable<JsonValue> res;
+        try (
+            JsonReader json = new JsonResponse(
+                this.request.method(Request.GET).fetch()
+            ).json()
+        ) {
+            res = json.readArray();
+        }
+        return res;
+    }
+}

--- a/src/main/java/com/jcabi/github/RtStars.java
+++ b/src/main/java/com/jcabi/github/RtStars.java
@@ -48,7 +48,7 @@ import org.hamcrest.Matchers;
  */
 @Immutable
 @Loggable(Loggable.DEBUG)
-@EqualsAndHashCode(of = { "owner", "request" })
+@EqualsAndHashCode(of = {"owner", "request"})
 final class RtStars implements Stars {
 
     /**
@@ -91,8 +91,8 @@ final class RtStars implements Stars {
                         HttpURLConnection.HTTP_NO_CONTENT,
                         HttpURLConnection.HTTP_NOT_FOUND
                     )
-            )
-        ).status() == HttpURLConnection.HTTP_NO_CONTENT;
+                )
+            ).status() == HttpURLConnection.HTTP_NO_CONTENT;
     }
 
     @Override

--- a/src/main/java/com/jcabi/github/Stargazers.java
+++ b/src/main/java/com/jcabi/github/Stargazers.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2013-2023, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.github;
+
+import java.io.IOException;
+import javax.json.JsonValue;
+
+/**
+ * List of stargazers.
+ *
+ * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
+ * @version $Id$
+ * @since 1.7.1
+ * @see <a href="https://docs.github.com/en/rest/activity/starring?apiVersion=2022-11-28#list-stargazers">List Stargazers</a>
+ */
+public interface Stargazers {
+
+    /**
+     * Iterate over stargazers.
+     *
+     * @return Iterator of stargazers
+     * @throws IOException If there is any I/O problem
+     */
+    Iterable<JsonValue> iterable() throws IOException;
+}

--- a/src/main/java/com/jcabi/github/mock/MkRepo.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepo.java
@@ -53,6 +53,7 @@ import com.jcabi.github.Releases;
 import com.jcabi.github.Repo;
 import com.jcabi.github.RepoCommits;
 import com.jcabi.github.RtLanguage;
+import com.jcabi.github.Stargazers;
 import com.jcabi.github.Stars;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -304,6 +305,16 @@ final class MkRepo implements Repo {
             this.coords,
             "master",
             ""
+        );
+    }
+
+    @Override
+    public Stargazers stargazers() {
+        throw new UnsupportedOperationException(
+            String.format(
+                "%s.stargazers() not yet implemented",
+                this.getClass().getSimpleName()
+            )
         );
     }
 

--- a/src/main/java/com/jcabi/github/mock/MkStars.java
+++ b/src/main/java/com/jcabi/github/mock/MkStars.java
@@ -50,7 +50,7 @@ import org.xembly.Directives;
 @Immutable
 @Loggable(Loggable.DEBUG)
 @ToString
-@EqualsAndHashCode(of = { "storage", "self", "coords" })
+@EqualsAndHashCode(of = {"storage", "self", "coords"})
 final class MkStars implements Stars {
 
     /**

--- a/src/test/java/com/jcabi/github/RtStarsTest.java
+++ b/src/test/java/com/jcabi/github/RtStarsTest.java
@@ -68,8 +68,8 @@ public final class RtStarsTest {
     public void checkIfRepoStarred() throws Exception {
         try (
             final MkContainer container = new MkGrizzlyContainer().next(
-                new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT)
-            ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_NOT_FOUND))
+                    new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT)
+                ).next(new MkAnswer.Simple(HttpURLConnection.HTTP_NOT_FOUND))
                 .start(this.resource.port())
         ) {
             final Stars starred = new RtStars(


### PR DESCRIPTION
Add Stargazers support:
https://docs.github.com/en/rest/activity/starring?apiVersion=2022-11-28#list-stargazers
This PR allows to fetch a list of stargazers (people who starred a repo).

Actually I had been working for #1660 issue and tried to count number of stargazes, but then I have found more elegant way to retrieve repository statistics. Hence, I hope the changes I made during my search could help somebody in the future.
Related to #1660
