### PR TITLE
#1558: validate lock reason against documented domain

### DIFF
--- a/src/main/java/com/jcabi/github/Issue.java
+++ b/src/main/java/com/jcabi/github/Issue.java
@@ -33,11 +33,6 @@ import lombok.ToString;
  *
  * @see <a href="https://developer.github.com/v3/issues/">Issues API</a>
  * @since 0.1
- * @todo #1462:30min Implement lock reason validation. According to
- *  documentation lock reason must belong to a specific value domain. This
- *  validation must be performed in lock method and tests must be added to
- *  ensure that the class is accepting the correct values and rejecting the
- *  wrong ones.
  * @checkstyle MultipleStringLiterals (500 lines)
  */
 @Immutable

--- a/src/main/java/com/jcabi/github/RtIssue.java
+++ b/src/main/java/com/jcabi/github/RtIssue.java
@@ -13,6 +13,10 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonStructure;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -32,6 +36,14 @@ final class RtIssue implements Issue {
      * Content constant.
      */
     private static final String CONTENT = "content";
+
+    /**
+     * Allowed lock reasons, per GitHub Issues API.
+     * @see <a href="https://docs.github.com/en/rest/issues/issues#lock-an-issue">Lock an issue</a>
+     */
+    private static final Set<String> LOCK_REASONS = Collections.unmodifiableSet(
+        new HashSet<>(Arrays.asList("off-topic", "too heated", "resolved", "spam"))
+    );
 
     /**
      * API entry point.
@@ -137,6 +149,14 @@ final class RtIssue implements Issue {
 
     @Override
     public void lock(final String reason) {
+        if (!RtIssue.LOCK_REASONS.contains(reason)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Invalid lock reason '%s', must be one of %s",
+                    reason, RtIssue.LOCK_REASONS
+                )
+            );
+        }
         final JsonStructure json = Json.createObjectBuilder()
             .add("lock_reason", reason)
             .build();

--- a/src/test/java/com/jcabi/github/RtIssueTest.java
+++ b/src/test/java/com/jcabi/github/RtIssueTest.java
@@ -18,6 +18,7 @@ import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -119,6 +120,47 @@ final class RtIssueTest {
         MatcherAssert.assertThat(
             "Value is not greater than expected",
             greater.compareTo(less), Matchers.greaterThan(0)
+        );
+    }
+
+    @Test
+    void locksWithValidReason() throws IOException {
+        try (
+            MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(HttpURLConnection.HTTP_NO_CONTENT, "")
+            ).start(RandomPort.port())
+        ) {
+            final RtIssue issue = new RtIssue(
+                new ApacheRequest(container.home()),
+                RtIssueTest.repo(),
+                1
+            );
+            issue.lock("off-topic");
+            final MkQuery query = container.take();
+            MatcherAssert.assertThat(
+                "Lock request was not sent with PUT method",
+                query.method(),
+                Matchers.equalTo(Request.PUT)
+            );
+            MatcherAssert.assertThat(
+                "Lock request body did not contain the expected reason",
+                query.body(),
+                Matchers.equalTo("{\"lock_reason\":\"off-topic\"}")
+            );
+            container.stop();
+        }
+    }
+
+    @Test
+    void rejectsInvalidLockReason() {
+        final RtIssue issue = new RtIssue(
+            new FakeRequest(),
+            RtIssueTest.repo(),
+            1
+        );
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> issue.lock("not-a-valid-reason")
         );
     }
 


### PR DESCRIPTION
Closes #1558.

This PR resolves the PDD puzzle in `Issue.java` lines 36-40 by adding lock-reason validation to `RtIssue.lock(String)`.

### Changes

1. **`#1558: add failing test demonstrating absent lock reason validation`** — adds two tests to `RtIssueTest`:
   - `locksWithValidReason` — verifies that `lock("off-topic")` issues `PUT /lock` with body `{"lock_reason":"off-topic"}` against a `MkGrizzlyContainer` and accepts the `204 No Content` response.
   - `rejectsInvalidLockReason` — expects `IllegalArgumentException` for an unknown reason, which fails on master because `RtIssue.lock` performs no validation and lets the request go through to the server.

2. **`#1558: validate lock reason against documented domain`** — `RtIssue.lock(String)` now checks the supplied reason against the four values documented for the GitHub Lock-an-issue endpoint (`off-topic`, `too heated`, `resolved`, `spam`) before issuing the HTTP request, throwing `IllegalArgumentException` otherwise. The puzzle text in `Issue.java` is removed.

Reference: https://docs.github.com/en/rest/issues/issues#lock-an-issue

### Local verification

`mvn -B -DskipITs test` reports 715 tests, 0 failures, 0 errors, 6 skipped.

### CI note

The `mvn (ubuntu-24.04, 17)` job currently fails on `master` (run [25203863689](https://github.com/jcabi/jcabi-github/actions/runs/25203863689)) and on every recent renovate PR (e.g. [#1848](https://github.com/jcabi/jcabi-github/pull/1848)) due to ~837 pre-existing Qulice/PMD violations across the codebase that are unrelated to this change. Fixing those is out of scope here. The other CI checks (codecov, actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint) are expected to pass.