### PR TITLE
#1145: persist commit fields in MkCommits.create

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkCommits.java
+++ b/src/main/java/com/jcabi/github/mock/MkCommits.java
@@ -12,7 +12,10 @@ import com.jcabi.github.Coordinates;
 import com.jcabi.github.Repo;
 import com.jcabi.github.Statuses;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
 import java.io.IOException;
+import java.util.Map;
 import lombok.EqualsAndHashCode;
 import org.xembly.Directives;
 
@@ -74,7 +77,28 @@ public final class MkCommits implements Commits {
     @Override
     public Commit create(
         final JsonObject params
-    ) {
+    ) throws IOException {
+        final Directives dirs = new Directives().xpath(this.xpath()).add("commit");
+        for (final Map.Entry<String, JsonValue> entry : params.entrySet()) {
+            final JsonValue value = entry.getValue();
+            if (value.getValueType() == JsonValue.ValueType.ARRAY) {
+                dirs.add(entry.getKey()).attr("array", "true");
+                for (final JsonValue item : value.asJsonArray()) {
+                    dirs.add("item").set(MkCommits.asText(item)).up();
+                }
+                dirs.up();
+            } else if (value.getValueType() == JsonValue.ValueType.OBJECT) {
+                dirs.add(entry.getKey());
+                for (final Map.Entry<String, JsonValue> sub
+                    : value.asJsonObject().entrySet()) {
+                    dirs.add(sub.getKey()).set(MkCommits.asText(sub.getValue())).up();
+                }
+                dirs.up();
+            } else {
+                dirs.add(entry.getKey()).set(MkCommits.asText(value)).up();
+            }
+        }
+        this.storage.apply(dirs);
         return this.get(params.getString("sha"));
     }
 
@@ -90,5 +114,31 @@ public final class MkCommits implements Commits {
         final String sha
     ) {
         return new MkStatuses(this.get(sha));
+    }
+
+    /**
+     * XPath of the commits element in the storage XML.
+     * @return XPath
+     */
+    private String xpath() {
+        return String.format(
+            "/github/repos/repo[@coords='%s']/git/commits",
+            this.coords
+        );
+    }
+
+    /**
+     * Render JSON value as plain text suitable for XML storage.
+     * @param value JSON value
+     * @return Plain string
+     */
+    private static String asText(final JsonValue value) {
+        final String result;
+        if (value.getValueType() == JsonValue.ValueType.STRING) {
+            result = ((JsonString) value).getString();
+        } else {
+            result = value.toString();
+        }
+        return result;
     }
 }

--- a/src/test/java/com/jcabi/github/mock/MkCommitsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCommitsTest.java
@@ -5,6 +5,7 @@
 package com.jcabi.github.mock;
 
 import com.jcabi.github.Commit;
+import com.jcabi.github.Commits;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
@@ -44,6 +45,64 @@ final class MkCommitsTest {
             "Values are not equal",
             commit.sha(),
             Matchers.equalTo("12ahscba")
+        );
+    }
+
+    /**
+     * MkCommits.create() must persist the new commit's sha in storage so
+     * that subsequent calls (e.g. json(), get()) can find the commit.
+     * @throws IOException if there is any I/O problem
+     */
+    @Test
+    void persistsCreatedCommitSha() throws IOException {
+        final String sha = "9e1f3c7b8d4a5e6f7c2d1b0a9e8f7d6c5b4a3210";
+        final Commits commits = new MkGitHub().randomRepo().git().commits();
+        commits.create(
+            Json.createObjectBuilder()
+                .add("message", "persisted commit message")
+                .add("sha", sha)
+                .add("tree", "treesha9e1f3c7b8d4a")
+                .add(
+                    "parents",
+                    Json.createArrayBuilder().add("parentsha0123456789").build()
+                )
+                .add(
+                    "author",
+                    Json.createObjectBuilder()
+                        .add("name", "Alice")
+                        .add("email", "alice@example.com")
+                        .add("date", "2024-01-15T12:30:00+00:00")
+                        .build()
+                )
+                .build()
+        );
+        MatcherAssert.assertThat(
+            "sha must be persisted in storage",
+            commits.get(sha).json().getString("sha"),
+            Matchers.equalTo(sha)
+        );
+    }
+
+    /**
+     * MkCommits.create() must persist the commit message in storage.
+     * @throws IOException if there is any I/O problem
+     */
+    @Test
+    void persistsCreatedCommitMessage() throws IOException {
+        final String sha = "abcdef0123456789abcdef0123456789abcdef01";
+        final String message = "another persisted message";
+        final Commits commits = new MkGitHub().randomRepo().git().commits();
+        commits.create(
+            Json.createObjectBuilder()
+                .add("message", message)
+                .add("sha", sha)
+                .add("tree", "treesha-abcdef-0123")
+                .build()
+        );
+        MatcherAssert.assertThat(
+            "message must be persisted in storage",
+            commits.get(sha).json().getString("message"),
+            Matchers.equalTo(message)
         );
     }
 }


### PR DESCRIPTION
Fixes #1145.

`MkCommits.create(JsonObject)` previously delegated straight to `get(sha)` without applying any `Directives`, so nothing was ever written to the mock storage XML. Any subsequent call that traverses the storage (`MkCommit.json()`, etc.) raised `NodeNotFoundException` because the XPath `/github/repos/repo[@coords=...]/git/commits/commit[sha=...]` selected zero nodes.

The fix walks the input JSON and writes each key as an element under a new `<commit>` node, mirroring how `MkBranches.create` and `MkReferences.create` persist their inputs. Arrays are stored with the `@array` attribute that `JsonNode` already understands, and nested objects (`author`, etc.) are stored as nested elements.

## Reproduction

The first commit adds two failing tests to `MkCommitsTest` that call `commits.create(...)` and then read the commit back via `commits.get(sha).json()`. On master both fail with `NodeNotFoundException`. After the fix in the second commit, all three tests in `MkCommitsTest` pass and the full `mvn test` suite is green (715 tests, 6 skipped pre-existing).

## Test plan

- [x] `mvn -B -ntp test -Dtest=MkCommitsTest` — 3 / 3 green
- [x] `mvn -B -ntp test` — 715 tests, no failures or errors
- [x] No new `qulice` violations introduced (verified via `mvn -Pqulice`; only the pre-existing PMD warnings on `createsMkCommit` remain)