### PR TITLE
#1168: handle JSON null in User.Smart#name() and #hasName()

### DIFF
--- a/src/main/java/com/jcabi/github/User.java
+++ b/src/main/java/com/jcabi/github/User.java
@@ -162,7 +162,8 @@ public interface User extends JsonReadable, JsonPatchable {
          */
         public String name() throws IOException {
             final JsonObject json = this.json();
-            if (!json.containsKey("name")) {
+            final String key = "name";
+            if (!json.containsKey(key) || json.isNull(key)) {
                 throw new IllegalStateException(
                     String.format(
                         // @checkstyle LineLength (1 line)
@@ -171,7 +172,7 @@ public interface User extends JsonReadable, JsonPatchable {
                     )
                 );
             }
-            return json.getString("name");
+            return json.getString(key);
         }
 
         /**
@@ -180,7 +181,9 @@ public interface User extends JsonReadable, JsonPatchable {
          * @throws IOException If it fails
          */
         public boolean hasName() throws IOException {
-            return this.json().containsKey("name");
+            final JsonObject json = this.json();
+            final String key = "name";
+            return json.containsKey(key) && !json.isNull(key);
         }
 
         /**

--- a/src/test/java/com/jcabi/github/RtUserTest.java
+++ b/src/test/java/com/jcabi/github/RtUserTest.java
@@ -100,6 +100,24 @@ final class RtUserTest {
     }
 
     @Test
+    void hasNameReturnsFalseWhenNameIsNull() throws IOException {
+        MatcherAssert.assertThat(
+            "hasName() must return false when 'name' JSON value is null",
+            RtUserTest.userWithNullName().hasName(),
+            Matchers.equalTo(false)
+        );
+    }
+
+    @Test
+    void nameThrowsIllegalStateWhenNameIsNull() throws IOException {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            RtUserTest.userWithNullName()::name,
+            "name() must throw IllegalStateException when 'name' JSON value is null"
+        );
+    }
+
+    @Test
     void describeAsJson() throws IOException {
         final RtUser user = new RtUser(
             Mockito.mock(GitHub.class),
@@ -420,6 +438,25 @@ final class RtUserTest {
         } finally {
             container.close();
         }
+    }
+
+    /**
+     * Return User.Smart with a JSON null "name" property.
+     * @return User.Smart whose JSON has "name":null.
+     */
+    private static User.Smart userWithNullName() {
+        return new User.Smart(
+            new RtUser(
+                Mockito.mock(GitHub.class),
+                new FakeRequest().withBody(
+                    Json.createObjectBuilder()
+                        .addNull("name")
+                        .build()
+                        .toString()
+                ),
+                "octoc"
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
@yegor256, this PR closes #1168.

### The bug

When a GitHub user account has no name set, the API returns `"name": null` in the user JSON instead of omitting the key. In that case, `User.Smart#hasName()` returned `true` (because the key is present) and `User.Smart#name()` then failed with `java.lang.ClassCastException` from `JsonObject#getString` while trying to cast `JsonValue.NULL` to `JsonString`. Calling `hasName()` first did not protect callers from the CCE.

### The fix

Both `name()` and `hasName()` now treat a JSON `null` value the same as an absent key:

- `hasName()` returns `false` when the value is JSON `null`.
- `name()` throws the same `IllegalStateException` it already threw when the key was absent.

The behavioral contract `if (smart.hasName()) smart.name();` is once again safe.

### Tests

`RtUserTest` gets two regression tests (`hasNameReturnsFalseWhenNameIsNull`, `nameThrowsIllegalStateWhenNameIsNull`) that fail on `master` with the original `ClassCastException` and pass after the fix. They are committed before the fix so the regression is reproducible from the test commit alone.

### Commits

1. `#1168: regression tests for User.Smart with null name JSON value`
2. `#1168: skip JSON null when checking User.Smart#name() and #hasName()`

### CI note

The `mvn` workflow currently fails on `master` due to ~837 pre-existing `qulice` (PMD/Checkstyle) violations that this PR does not introduce. With my changes the violation count is unchanged at 837. All other 8 CI jobs pass.