### PR TITLE
#1036: fix path for listing public repositories

### DIFF
--- a/src/main/java/com/jcabi/github/RtRepos.java
+++ b/src/main/java/com/jcabi/github/RtRepos.java
@@ -96,7 +96,8 @@ final class RtRepos implements Repos {
     public Iterable<Repo> iterate(
         final String identifier) {
         return new RtPagination<>(
-            this.entry.uri().queryParam("since", identifier).back(),
+            this.entry.uri().path("/repositories")
+                .queryParam("since", identifier).back(),
             object -> this.get(
                 new Coordinates.Simple(object.getString("full_name"))
             )

--- a/src/test/java/com/jcabi/github/RtReposTest.java
+++ b/src/test/java/com/jcabi/github/RtReposTest.java
@@ -93,6 +93,34 @@ final class RtReposTest {
     }
 
     @Test
+    void iterateReposUsesPublicRepositoriesPath() throws IOException {
+        final String identifier = "364";
+        try (
+            MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_OK,
+                    Json.createArrayBuilder()
+                        .add(RtReposTest.response("octocat", identifier))
+                        .build().toString()
+                )
+            ).start(RandomPort.port())
+        ) {
+            new RtRepos(
+                Mockito.mock(GitHub.class),
+                new ApacheRequest(container.home())
+            ).iterate(identifier).iterator().next();
+            MatcherAssert.assertThat(
+                "iterate(...) must request /repositories?since=<id>",
+                container.take().uri().toString(),
+                Matchers.endsWith(
+                    "/repositories?since=".concat(identifier)
+                )
+            );
+            container.stop();
+        }
+    }
+
+    @Test
     void removeRepo() throws IOException {
         try (
             MkContainer container = new MkGrizzlyContainer().next(


### PR DESCRIPTION
@yegor256 this PR fixes #1036.

## Bug
`Repos#iterate(String)` (implemented by `RtRepos`) is documented to call the GitHub "List all public repositories" endpoint (`/repositories?since=...`), but it was issuing the request against the API root: `/?since=...`. As a result, GitHub returned the JSON object describing the API root rather than the expected JSON array, and `RtPagination` failed with `javax.json.JsonException: Cannot read JSON array, found JSON object`.

## Fix
Add the missing `/repositories` path segment in `RtRepos#iterate`:

```java
this.entry.uri().path("/repositories").queryParam("since", identifier).back()
```

## Commits
1. `#1036: regression test asserting /repositories path` adds `RtReposTest#iterateReposUsesPublicRepositoriesPath`, which intercepts the outgoing request and asserts the URI ends with `/repositories?since=<id>`. Verified to fail on master and pass with the fix applied.
2. `#1036: prepend /repositories path in RtRepos#iterate` is the one-line fix.

## Build status
- `mvn -DskipITs test` passes locally (717 tests, 0 failures).
- `mvn -Pqulice install` reports the same 837 PMD violations that already exist on `master` (e.g. PR #1851 was merged with the identical `mvn (ubuntu-24.04, 24)` failure). I confirmed locally that this branch produces exactly the same 837 violations as `master` — i.e. this PR does not introduce any new qulice violations.
