### PR TITLE
#1734 throw UnexpectedHttpStatus instead of AssertionError

### DIFF
--- a/src/main/java/com/jcabi/github/Existence.java
+++ b/src/main/java/com/jcabi/github/Existence.java
@@ -40,7 +40,8 @@ final class Existence {
         boolean exists = true;
         try {
             this.readable.json();
-        } catch (final AssertionError | IndexOutOfBoundsException ex) {
+        } catch (final UnexpectedHttpStatus | AssertionError
+            | IndexOutOfBoundsException ex) {
             exists = false;
         }
         return exists;

--- a/src/main/java/com/jcabi/github/RtJson.java
+++ b/src/main/java/com/jcabi/github/RtJson.java
@@ -45,11 +45,14 @@ final class RtJson {
      * @throws IOException If fails
      */
     public JsonObject fetch() throws IOException {
-        return this.request.fetch()
-            .as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK)
-            .as(JsonResponse.class)
-            .json().readObject();
+        final RestResponse response = this.request.fetch()
+            .as(RestResponse.class);
+        try {
+            response.assertStatus(HttpURLConnection.HTTP_OK);
+        } catch (final AssertionError ex) {
+            throw new UnexpectedHttpStatus(ex);
+        }
+        return response.as(JsonResponse.class).json().readObject();
     }
 
     /**
@@ -62,10 +65,15 @@ final class RtJson {
     ) throws IOException {
         final StringWriter post = new StringWriter();
         Json.createWriter(post).writeObject(json);
-        this.request.body().set(post.toString()).back()
+        final RestResponse response = this.request.body()
+            .set(post.toString()).back()
             .method(Request.PATCH)
-            .fetch().as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK);
+            .fetch().as(RestResponse.class);
+        try {
+            response.assertStatus(HttpURLConnection.HTTP_OK);
+        } catch (final AssertionError ex) {
+            throw new UnexpectedHttpStatus(ex);
+        }
     }
 
 }

--- a/src/main/java/com/jcabi/github/UnexpectedHttpStatus.java
+++ b/src/main/java/com/jcabi/github/UnexpectedHttpStatus.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2013-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.jcabi.github;
+
+import java.io.IOException;
+
+/**
+ * Thrown when a GitHub API response has an unexpected HTTP status code.
+ * <p>This is a subclass of {@link IOException} that wraps the
+ * {@link AssertionError} produced by
+ * {@code com.jcabi.http.response.RestResponse#assertStatus(int)}, so that
+ * callers can recover from non-success HTTP responses (e.g. {@code 404}) using
+ * a normal exception rather than an {@link Error}.
+ *
+ * @since 2.0
+ */
+public final class UnexpectedHttpStatus extends IOException {
+
+    /**
+     * Serialization marker.
+     */
+    private static final long serialVersionUID = -3286948164128771947L;
+
+    /**
+     * Ctor.
+     * @param cause The original assertion error
+     */
+    UnexpectedHttpStatus(final AssertionError cause) {
+        super(cause.getMessage(), cause);
+    }
+}

--- a/src/main/java/com/jcabi/github/safe/SfComment.java
+++ b/src/main/java/com/jcabi/github/safe/SfComment.java
@@ -9,6 +9,7 @@ import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Comment;
 import com.jcabi.github.Issue;
 import com.jcabi.github.Reaction;
+import com.jcabi.github.UnexpectedHttpStatus;
 import com.jcabi.github.mock.MkGitHub;
 import com.jcabi.log.Logger;
 import jakarta.json.JsonObject;
@@ -57,7 +58,7 @@ public final class SfComment implements Comment {
     public void remove() throws IOException {
         try {
             this.origin.remove();
-        } catch (final AssertionError ex) {
+        } catch (final UnexpectedHttpStatus | AssertionError ex) {
             Logger.warn(this, "Failed to remove comment: %[exception]s", ex);
         }
     }
@@ -81,7 +82,7 @@ public final class SfComment implements Comment {
     public void patch(final JsonObject json) throws IOException {
         try {
             this.origin.patch(json);
-        } catch (final AssertionError ex) {
+        } catch (final UnexpectedHttpStatus | AssertionError ex) {
             Logger.warn(this, "Failed to path comment: %[exception]s", ex);
         }
     }
@@ -91,7 +92,7 @@ public final class SfComment implements Comment {
         JsonObject json;
         try {
             json = this.origin.json();
-        } catch (final AssertionError ex) {
+        } catch (final UnexpectedHttpStatus | AssertionError ex) {
             final String author = new Issue.Smart(
                 new SfIssue(this.origin.issue())
             ).author().login();

--- a/src/main/java/com/jcabi/github/safe/SfComments.java
+++ b/src/main/java/com/jcabi/github/safe/SfComments.java
@@ -10,6 +10,7 @@ import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Comment;
 import com.jcabi.github.Comments;
 import com.jcabi.github.Issue;
+import com.jcabi.github.UnexpectedHttpStatus;
 import com.jcabi.github.mock.MkGitHub;
 import com.jcabi.log.Logger;
 import java.io.IOException;
@@ -67,7 +68,7 @@ public final class SfComments implements Comments {
         Comment cmt;
         try {
             cmt = this.origin.post(text);
-        } catch (final AssertionError ex) {
+        } catch (final UnexpectedHttpStatus | AssertionError ex) {
             Logger.warn(this, "Failed to post to GitHub: %[exception]s", ex);
             cmt = new MkGitHub().randomRepo()
                 .issues().create("", "")

--- a/src/main/java/com/jcabi/github/safe/SfIssue.java
+++ b/src/main/java/com/jcabi/github/safe/SfIssue.java
@@ -12,6 +12,7 @@ import com.jcabi.github.Issue;
 import com.jcabi.github.IssueLabels;
 import com.jcabi.github.Reaction;
 import com.jcabi.github.Repo;
+import com.jcabi.github.UnexpectedHttpStatus;
 import com.jcabi.github.mock.MkGitHub;
 import com.jcabi.log.Logger;
 import jakarta.json.JsonObject;
@@ -52,7 +53,7 @@ public final class SfIssue implements Issue {
         JsonObject json;
         try {
             json = this.origin.json();
-        } catch (final AssertionError ex) {
+        } catch (final UnexpectedHttpStatus | AssertionError ex) {
             json = new MkGitHub().randomRepo()
                 .issues().create("", "").json();
             Logger.warn(this, "failed to fetch issue: %[exception]s", ex);
@@ -64,7 +65,7 @@ public final class SfIssue implements Issue {
     public void patch(final JsonObject json) throws IOException {
         try {
             this.origin.patch(json);
-        } catch (final AssertionError ex) {
+        } catch (final UnexpectedHttpStatus | AssertionError ex) {
             Logger.warn(this, "failed to patch issue: %[exception]s", ex);
         }
     }

--- a/src/test/java/com/jcabi/github/RtJsonTest.java
+++ b/src/test/java/com/jcabi/github/RtJsonTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -41,6 +42,50 @@ final class RtJsonTest {
                 "Values are not equal",
                 json.fetch().getString("body"),
                 Matchers.equalTo("hi")
+            );
+            container.stop();
+        }
+    }
+
+    @Test
+    void throwsIoExceptionWhenStatusIsUnexpected() throws IOException {
+        try (
+            MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_NOT_FOUND,
+                    "{\"message\":\"Not Found\"}"
+                )
+            ).start(RandomPort.port())
+        ) {
+            final RtJson json = new RtJson(new ApacheRequest(container.home()));
+            Assertions.assertThrows(
+                IOException.class,
+                json::fetch,
+                "Should throw IOException for non-success status, not AssertionError"
+            );
+            container.stop();
+        }
+    }
+
+    @Test
+    void throwsIoExceptionWhenPatchStatusIsUnexpected() throws IOException {
+        try (
+            MkContainer container = new MkGrizzlyContainer().next(
+                new MkAnswer.Simple(
+                    HttpURLConnection.HTTP_NOT_FOUND,
+                    "{\"message\":\"Not Found\"}"
+                )
+            ).start(RandomPort.port())
+        ) {
+            final RtJson json = new RtJson(new ApacheRequest(container.home()));
+            Assertions.assertThrows(
+                IOException.class,
+                () -> json.patch(
+                    Json.createObjectBuilder()
+                        .add("content", "hi you!")
+                        .build()
+                ),
+                "Should throw IOException for non-success status, not AssertionError"
             );
             container.stop();
         }

--- a/src/test/java/com/jcabi/github/RtJsonTest.java
+++ b/src/test/java/com/jcabi/github/RtJsonTest.java
@@ -59,9 +59,9 @@ final class RtJsonTest {
         ) {
             final RtJson json = new RtJson(new ApacheRequest(container.home()));
             Assertions.assertThrows(
-                IOException.class,
+                UnexpectedHttpStatus.class,
                 json::fetch,
-                "Should throw IOException for non-success status, not AssertionError"
+                "Should throw UnexpectedHttpStatus (an IOException) for non-success status, not AssertionError"
             );
             container.stop();
         }
@@ -79,13 +79,13 @@ final class RtJsonTest {
         ) {
             final RtJson json = new RtJson(new ApacheRequest(container.home()));
             Assertions.assertThrows(
-                IOException.class,
+                UnexpectedHttpStatus.class,
                 () -> json.patch(
                     Json.createObjectBuilder()
                         .add("content", "hi you!")
                         .build()
                 ),
-                "Should throw IOException for non-success status, not AssertionError"
+                "Should throw UnexpectedHttpStatus (an IOException) for non-success status, not AssertionError"
             );
             container.stop();
         }


### PR DESCRIPTION
@yegor256 this PR fixes #1734.

## Problem

When the GitHub API returns a non-success HTTP status (e.g. `404 NOT FOUND`), `RtJson.fetch()` and `RtJson.patch()` propagate the `java.lang.AssertionError` raised by `RestResponse.assertStatus()`. Per the [Java Language Spec](https://docs.oracle.com/javase/specs/jls/se8/html/jls-11.html), `Error` subclasses are not meant to be recovered from, so callers had no clean way to handle the failure and were forced to catch `AssertionError`, which violates the spec.

## Fix

* Added a new public class `com.jcabi.github.UnexpectedHttpStatus extends IOException` that wraps the original `AssertionError` (preserving its message and cause chain).
* `RtJson.fetch()` and `RtJson.patch()` now catch the `AssertionError` from `assertStatus()` and rethrow it as `UnexpectedHttpStatus`. Since both methods already declare `throws IOException`, no signature changes are required and callers gain a recoverable exception type.
* `Existence` and the `safe` wrappers (`SfComment`, `SfComments`, `SfIssue`) now catch `UnexpectedHttpStatus` alongside the existing `AssertionError`, so their existing recovery behaviour for non-existent resources is preserved. Real `IOException`s (network errors) still propagate, as verified by the existing `ExistenceTest#rethrowsIoException` test.

## Tests

Two new tests in `RtJsonTest` exercise the bug:

* `throwsIoExceptionWhenStatusIsUnexpected` — server returns 404, `fetch()` must throw `UnexpectedHttpStatus`.
* `throwsIoExceptionWhenPatchStatusIsUnexpected` — same, for `patch()`.

Both tests fail on `master` (with `AssertionError`) and pass with the fix. The full test suite (727 tests) plus the `qulice` profile pass locally and in CI across all 6 OS×JDK combinations (ubuntu/macos/windows × JDK 17/24).