### PR TITLE
#1235: include owner.login in MkRepo.json()

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkRepos.java
+++ b/src/main/java/com/jcabi/github/mock/MkRepos.java
@@ -78,6 +78,7 @@ final class MkRepos implements Repos {
                 .add("name").set(settings.name()).up()
                 .add("description").set("test repository").up()
                 .add("private").set(settings.isPrivate()).up()
+                .add("owner").add("login").set(this.self).up().up()
         );
         final Repo repo = this.get(coords);
         repo.patch(settings.json());

--- a/src/test/java/com/jcabi/github/mock/MkReposTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkReposTest.java
@@ -6,6 +6,7 @@ package com.jcabi.github.mock;
 
 import com.jcabi.github.Repo;
 import com.jcabi.github.Repos;
+import jakarta.json.JsonObject;
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -106,6 +107,28 @@ final class MkReposTest {
                 )
             ).isPrivate(),
             Matchers.is(priv)
+        );
+    }
+
+    /**
+     * MkRepo's JSON contains an "owner" object with the login,
+     * matching the format of the real GitHub API.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    void jsonContainsOwnerWithLogin() throws Exception {
+        final Repos repos = new MkRepos(new MkStorage.InFile(), "amihaiemil");
+        final Repo repo = MkReposTest.repo(repos, "test", "owner test");
+        final JsonObject json = repo.json();
+        MatcherAssert.assertThat(
+            "Repo JSON should contain an 'owner' object",
+            json.containsKey("owner"),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "owner.login should match the user that created the repo",
+            json.getJsonObject("owner").getString("login"),
+            Matchers.is("amihaiemil")
         );
     }
 


### PR DESCRIPTION
@yegor256 — this fixes #1235.

The mock `MkRepo.json()` was returning a payload missing the `owner` object that the real GitHub API always includes. As reported by @amihaiemil in the issue, code like `new MkGithub("amihaiemil").randomRepo().json()` produced:

```json
{"name":"...","description":"...","private":"false","homepage":""}
```

with no `owner.login`, so any test code that exercised `Repo.json().getJsonObject("owner")` against the mock failed even though it works against the real API.

## Changes

- **`src/test/java/com/jcabi/github/mock/MkReposTest.java`** — adds `jsonContainsOwnerWithLogin`, asserting that `MkRepo.json()` contains an `owner` object whose `login` matches the user that created the repo. Committed first as a failing test (commit `d7c08b056`).
- **`src/main/java/com/jcabi/github/mock/MkRepos.java`** — in `create(...)`, the stored repo XML now includes `<owner><login>{self}</login></owner>`. `JsonNode` already maps a nested element with children into a nested JSON object, so this surfaces as `"owner": {"login": "..."}` in `MkRepo.json()`. Single-line code change (commit `59a7fb412`).

## Test plan

- [x] New test `MkReposTest#jsonContainsOwnerWithLogin` fails before the fix and passes after.
- [x] Full unit-test suite green locally: `mvn -DskipITs test` — 728 tests, 0 failures.
- [x] Full build with quality checks green locally: `mvn -DskipITs clean install -Pqulice`.
- [x] All 14 CI checks green on this PR (mvn × {ubuntu, macos, windows} × {Java 17, Java 24}, plus actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint).
