### PR TITLE
feat(#1868): add `skipped()` method to `Check` interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .classpath
+.factorypath
 .claude/
 .DS_Store
 .idea/
@@ -10,3 +11,4 @@
 /bin
 node_modules/
 target/
+.aidy/

--- a/src/main/java/com/jcabi/github/Check.java
+++ b/src/main/java/com/jcabi/github/Check.java
@@ -28,6 +28,13 @@ public interface Check {
     boolean successful() throws IOException;
 
     /**
+     * Checks whether Check was skipped.
+     * @return True if Check was skipped.
+     * @throws IOException If there is any I/O problem.
+     */
+    boolean skipped() throws IOException;
+
+    /**
      * Check status.
      * You can read more about it
      * @checkstyle LineLengthCheck (1 lines)
@@ -207,6 +214,14 @@ public interface Check {
          */
         boolean successful() {
             return this == Check.Conclusion.SUCCESS;
+        }
+
+        /**
+         * Check if check is skipped.
+         * @return True if check is skipped.
+         */
+        boolean skipped() {
+            return this == Check.Conclusion.SKIPPED;
         }
 
         /**

--- a/src/main/java/com/jcabi/github/RtCheck.java
+++ b/src/main/java/com/jcabi/github/RtCheck.java
@@ -47,4 +47,9 @@ class RtCheck implements Check {
     public boolean successful() {
         return this.status.finished() && this.conclusion.successful();
     }
+
+    @Override
+    public boolean skipped() {
+        return this.status.finished() && this.conclusion.skipped();
+    }
 }

--- a/src/main/java/com/jcabi/github/mock/MkCheck.java
+++ b/src/main/java/com/jcabi/github/mock/MkCheck.java
@@ -9,7 +9,6 @@ import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Check;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Pull;
-import com.jcabi.xml.XML;
 import java.io.IOException;
 import lombok.ToString;
 
@@ -65,15 +64,14 @@ public final class MkCheck implements Check {
 
     @Override
     public boolean successful() throws IOException {
-        final XML node = this.storage.xml().nodes(this.xpath()).get(0);
-        final Check.Status status = Check.Status.fromString(
-            node.xpath("@status").get(0)
-        );
-        final Check.Conclusion conclusion = Check.Conclusion.fromString(
-            node.xpath("@conclusion").get(0)
-        );
-        return status == Check.Status.COMPLETED
-            && conclusion == Check.Conclusion.SUCCESS;
+        return this.status() == Check.Status.COMPLETED
+            && this.conclusion() == Check.Conclusion.SUCCESS;
+    }
+
+    @Override
+    public boolean skipped() throws IOException {
+        return this.status() == Check.Status.COMPLETED
+            && this.conclusion() == Check.Conclusion.SKIPPED;
     }
 
     @Override
@@ -100,6 +98,28 @@ public final class MkCheck implements Check {
         result = 31 * result + this.pull.hashCode();
         result = 31 * result + this.identifier;
         return result;
+    }
+
+    /**
+     * Returns the status of this check from storage.
+     * @return Check status.
+     * @throws IOException If there is any I/O problem.
+     */
+    private Check.Status status() throws IOException {
+        return Check.Status.fromString(
+            this.storage.xml().nodes(this.xpath()).get(0).xpath("@status").get(0)
+        );
+    }
+
+    /**
+     * Returns the conclusion of this check from storage.
+     * @return Check conclusion.
+     * @throws IOException If there is any I/O problem.
+     */
+    private Check.Conclusion conclusion() throws IOException {
+        return Check.Conclusion.fromString(
+            this.storage.xml().nodes(this.xpath()).get(0).xpath("@conclusion").get(0)
+        );
     }
 
     /**

--- a/src/test/java/com/jcabi/github/RtCheckTest.java
+++ b/src/test/java/com/jcabi/github/RtCheckTest.java
@@ -18,7 +18,7 @@ final class RtCheckTest {
     @Test
     void checksSuccessfulState() {
         MatcherAssert.assertThat(
-            "Values are not equal",
+            "Completed+success check must be successful",
             new RtCheck(
                 Check.Status.COMPLETED,
                 Check.Conclusion.SUCCESS
@@ -30,7 +30,7 @@ final class RtCheckTest {
     @Test
     void checksNotSuccessfulStateIfInProgress() {
         MatcherAssert.assertThat(
-            "Values are not equal",
+            "In-progress check must not be successful",
             new RtCheck(
                 Check.Status.IN_PROGRESS,
                 Check.Conclusion.SUCCESS
@@ -42,11 +42,47 @@ final class RtCheckTest {
     @Test
     void checksNotSuccessfulState() {
         MatcherAssert.assertThat(
-            "Values are not equal",
+            "Cancelled check must not be successful",
             new RtCheck(
                 Check.Status.COMPLETED,
                 Check.Conclusion.CANCELLED
             ).successful(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void checksSkippedState() {
+        MatcherAssert.assertThat(
+            "Completed+skipped check must be skipped",
+            new RtCheck(
+                Check.Status.COMPLETED,
+                Check.Conclusion.SKIPPED
+            ).skipped(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void checksNotSkippedStateIfInProgress() {
+        MatcherAssert.assertThat(
+            "In-progress check must not be skipped",
+            new RtCheck(
+                Check.Status.IN_PROGRESS,
+                Check.Conclusion.SKIPPED
+            ).skipped(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void checksNotSkippedStateIfSuccess() {
+        MatcherAssert.assertThat(
+            "Successful check must not be skipped",
+            new RtCheck(
+                Check.Status.COMPLETED,
+                Check.Conclusion.SUCCESS
+            ).skipped(),
             Matchers.is(false)
         );
     }

--- a/src/test/java/com/jcabi/github/mock/MkCheckTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCheckTest.java
@@ -66,4 +66,19 @@ final class MkCheckTest {
             Matchers.is(false)
         );
     }
+
+    /**
+     * MkChecks can create skipped check.
+     * @throws IOException If some problem with I/O.
+     */
+    @Test
+    void createsSkippedCheck() throws IOException {
+        MatcherAssert.assertThat(
+            "Values are not equal",
+            ((MkChecks) this.pull.checks())
+                .create(Check.Status.COMPLETED, Check.Conclusion.SKIPPED)
+                .skipped(),
+            Matchers.is(true)
+        );
+    }
 }


### PR DESCRIPTION
Adds `skipped()` method to the `Check` interface, with implementations in `RtCheck` and `MkCheck`, so callers can distinguish skipped checks from failed ones.

Fixes #1868