### PR TITLE
make RepoCreate.with immutable, #1664

### DIFF
--- a/src/main/java/com/jcabi/github/Repos.java
+++ b/src/main/java/com/jcabi/github/Repos.java
@@ -153,7 +153,6 @@ public interface Repos {
          *  authenticated user.
          * @checkstyle ParameterNumberCheck (7 lines)
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         private RepoCreate(
             final String nme,
             final boolean prvt,
@@ -161,6 +160,33 @@ public interface Repos {
             final String page,
             final Optional<Boolean> auto,
             final String org
+        ) {
+            this(nme, prvt, desc, page, auto, org, new HashMap<>(0));
+        }
+
+        /**
+         * Private ctor.
+         * @param nme Name of the new repo. Cannot be empty.
+         * @param prvt Will the new repo be private?
+         *  If not, then it will be public.
+         * @param desc Description of the new repo
+         * @param page Homepage of the new repo
+         * @param auto Auto-init the new repo?
+         * @param org Organization to which this repo belongs.
+         *  When empty or null, the repo is created under the
+         *  authenticated user.
+         * @param extra Additional JSON fields keyed by name.
+         * @checkstyle ParameterNumberCheck (8 lines)
+         */
+        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+        private RepoCreate(
+            final String nme,
+            final boolean prvt,
+            final String desc,
+            final String page,
+            final Optional<Boolean> auto,
+            final String org,
+            final Map<String, JsonValue> extra
         ) {
             if (nme.isEmpty()) {
                 throw new IllegalArgumentException("Name cannot be empty!");
@@ -171,7 +197,7 @@ public interface Repos {
             this.home = page;
             this.init = auto;
             this.organization = org;
-            this.other = new HashMap<>(0);
+            this.other = new HashMap<>(extra);
         }
 
         /**
@@ -345,19 +371,23 @@ public interface Repos {
         }
 
         /**
-         * Returns a RepoCreate with the given json fields.
+         * Returns a RepoCreate with the given json field added.
          * @param key Json key
          * @param value Json value
-         * @return The same RepoCreate.
-         * @todo #1660:30min Make 'with' method immutable.
-         *  Currently, the 'with' method mutates the 'other' field.
-         *  This is not ideal, as it makes the class mutable.
-         *  Make the 'with' method immutable and return a new
-         *  RepoCreate object with the new field.
+         * @return A new RepoCreate carrying every previous field plus the new one.
          */
         public Repos.RepoCreate with(final String key, final JsonValue value) {
-            this.other.put(key, value);
-            return this;
+            final Map<String, JsonValue> extra = new HashMap<>(this.other);
+            extra.put(key, value);
+            return new Repos.RepoCreate(
+                this.repo,
+                this.priv,
+                this.descr,
+                this.home,
+                this.init,
+                this.organization,
+                extra
+            );
         }
 
         @Override

--- a/src/test/java/com/jcabi/github/RepoCreateTest.java
+++ b/src/test/java/com/jcabi/github/RepoCreateTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2013-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.jcabi.github;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Repos.RepoCreate}.
+ * @since 1.10
+ */
+final class RepoCreateTest {
+
+    /**
+     * RepoCreate.with returns a new instance and leaves the original untouched.
+     */
+    @Test
+    void withDoesNotMutateOriginal() {
+        final Repos.RepoCreate original = new Repos.RepoCreate("name", false);
+        final JsonValue value = Json.createValue("MIT");
+        final Repos.RepoCreate updated = original.with("license_template", value);
+        MatcherAssert.assertThat(
+            "with(...) must return a different instance",
+            updated,
+            Matchers.not(Matchers.sameInstance(original))
+        );
+        final JsonObject before = original.json();
+        MatcherAssert.assertThat(
+            "original RepoCreate must not carry the new field",
+            before.containsKey("license_template"),
+            Matchers.is(false)
+        );
+        final JsonObject after = updated.json();
+        MatcherAssert.assertThat(
+            "updated RepoCreate must expose the new field in its JSON",
+            after.getString("license_template"),
+            Matchers.equalTo("MIT")
+        );
+    }
+
+    /**
+     * Successive with() calls preserve every previously added field.
+     */
+    @Test
+    void withAccumulatesAcrossCalls() {
+        final Repos.RepoCreate created = new Repos.RepoCreate("name", false)
+            .with("has_issues", JsonValue.TRUE)
+            .with("has_wiki", JsonValue.FALSE);
+        final JsonObject json = created.json();
+        MatcherAssert.assertThat(
+            "first field must survive a second with() call",
+            json.getBoolean("has_issues"),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "second field must appear in the resulting json",
+            json.getBoolean("has_wiki"),
+            Matchers.is(false)
+        );
+    }
+}


### PR DESCRIPTION
Resolves the puzzle filed as #1664. `Repos.RepoCreate.with(key, value)` was mutating the internal `other` map and returning `this`, which contradicts the class invariant that every other `with...` method on `RepoCreate` returns a new instance.

A new private constructor accepts the extra-fields map, and `with(...)` now builds a fresh `RepoCreate` from a copy of the current map plus the new entry. The PDD puzzle marker is removed in the same change.

`mvn clean install -Pqulice` and `mvn -Pqulice test` were run locally on this branch; the full unit suite (734 tests, 0 failures) and the Qulice checks pass. Two new tests in `RepoCreateTest` cover the immutability contract and accumulation across successive `with` calls.

Closes #1664
