### PR TITLE
Add created_at and updated_at to MkCommit #1147

### DIFF
--- a/src/main/java/com/jcabi/github/mock/MkCommits.java
+++ b/src/main/java/com/jcabi/github/mock/MkCommits.java
@@ -9,6 +9,7 @@ import com.jcabi.aspects.Loggable;
 import com.jcabi.github.Commit;
 import com.jcabi.github.Commits;
 import com.jcabi.github.Coordinates;
+import com.jcabi.github.GitHub;
 import com.jcabi.github.Repo;
 import com.jcabi.github.Statuses;
 import jakarta.json.JsonObject;
@@ -90,6 +91,13 @@ public final class MkCommits implements Commits {
             } else {
                 dirs.add(entry.getKey()).set(MkCommits.asText(value)).up();
             }
+        }
+        final String timestamp = new GitHub.Time().toString();
+        if (!params.containsKey("created_at")) {
+            dirs.add("created_at").set(timestamp).up();
+        }
+        if (!params.containsKey("updated_at")) {
+            dirs.add("updated_at").set(timestamp).up();
         }
         this.storage.apply(dirs);
         return this.get(params.getString("sha"));

--- a/src/test/java/com/jcabi/github/mock/MkCommitsTest.java
+++ b/src/test/java/com/jcabi/github/mock/MkCommitsTest.java
@@ -36,6 +36,24 @@ final class MkCommitsTest {
         );
     }
 
+    @Test
+    void createdCommitHasCreatedAt() throws IOException {
+        MatcherAssert.assertThat(
+            "created_at is missing",
+            MkCommitsTest.created().json().getString("created_at"),
+            Matchers.notNullValue()
+        );
+    }
+
+    @Test
+    void createdCommitHasUpdatedAt() throws IOException {
+        MatcherAssert.assertThat(
+            "updated_at is missing",
+            MkCommitsTest.created().json().getString("updated_at"),
+            Matchers.notNullValue()
+        );
+    }
+
     /**
      * MkCommits.create() must persist the new commit's sha in storage so
      * that subsequent calls (e.g. json(), get()) can find the commit.


### PR DESCRIPTION
MkCommit.json() did not include created_at or updated_at. create() now writes both timestamps, same as the other mock resources.

Fixes #1147